### PR TITLE
fix(frame)!: normalize selectCRM result buckets to real arrays

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-dialog.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-dialog.md
@@ -1,75 +1,223 @@
 ---
 title: Dialog Manager Class
-description: 'Used for displaying standard dialogs.'
+description: 'Wraps the BX24 system dialogs (user picker, access permission picker, CRM entity picker) so they can be opened from inside a Bitrix24 application iframe.'
 category: 'B24Frame'
 navigation.title: Dialog
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/dialog.ts
+    target: _blank
 ---
 
-::warning
-We are still updating this page. Some data may be missing here — we will complete it shortly.
-::
+`DialogManager` is exposed via [`$b24.dialog`](/docs/working-with-the-rest-api/frame/#dialog) on a `B24Frame` instance and is only available when your application is rendered inside a Bitrix24 iframe (it relies on `postMessage` to talk to the parent window).
+
+It mirrors the legacy [`BX24.selectUser`](https://apidocs.bitrix24.com/sdk/bx24-js-sdk/system-dialogues/bx24-select-user.html), [`BX24.selectUsers`](https://apidocs.bitrix24.com/sdk/bx24-js-sdk/system-dialogues/bx24-select-users.html), [`BX24.selectAccess`](https://apidocs.bitrix24.com/sdk/bx24-js-sdk/system-dialogues/bx24-select-access.html) and [`BX24.selectCRM`](https://apidocs.bitrix24.com/sdk/bx24-js-sdk/system-dialogues/bx24-select-crm.html) helpers, but returns strongly-typed `Promise`s instead of taking callbacks.
 
 ## Methods
 
 ### selectUser
+
 ```ts
 async selectUser(): Promise<null|SelectedUser>
 ```
 
-Displays a standard dialog for selecting a single user.
+Displays the standard dialog for selecting a single company employee.
 
-Shows only company employees.
-
-Returns a `Promise` that resolves to `null` or a [`SelectedUser`](#selectusers) object.
+The promise resolves to a [`SelectedUser`](#selecteduser) object, or `null` if the user closed the dialog without making a selection.
 
 ```ts
 // ... /////
 $b24 = await initializeB24Frame()
 // ... /////
-const makeSelectUsers = async() => {
-	const selectedUser = await $b24.dialog.selectUser()
-	$logger.info(selectedUser)
+const makeSelectUser = async() => {
+  const selectedUser = await $b24.dialog.selectUser()
+  if (!selectedUser) {
+    return
+  }
+  $logger.info(selectedUser)
 }
 ```
 
 ### selectUsers
+
 ```ts
 async selectUsers(): Promise<SelectedUser[]>
 ```
 
-Displays a standard dialog for selecting multiple users.
+Displays the standard dialog for selecting multiple company employees.
 
-Shows only company employees.
-
-Returns a `Promise` that resolves to an array of [`SelectedUser`](#selecteduser) objects.
+The promise resolves to an array of [`SelectedUser`](#selecteduser) objects. The array is empty when the user confirms the dialog without picking anyone.
 
 ```ts
 // ... /////
 $b24 = await initializeB24Frame()
 // ... /////
 const makeSelectUsers = async() => {
-	const selectedUsers = await $b24.dialog.selectUsers()
-	
-	const list = selectedUsers.map((row: SelectedUser): string => {
-		return [ `[id: ${row.id}]`, row.name ].join(' ')
-	})
-	
-	$logger.info(selectedUsers, list)
+  const selectedUsers = await $b24.dialog.selectUsers()
+
+  const list = selectedUsers.map((row: SelectedUser): string => {
+    return [`[id: ${row.id}]`, row.name].join(' ')
+  })
+
+  $logger.info(selectedUsers, list)
 }
 ```
+
+### selectAccess
+
+```ts
+async selectAccess(blockedAccessPermissions?: string[]): Promise<SelectedAccess[]>
+```
+
+Displays the standard access permission selection dialog (departments, groups, individual users, and predefined permission codes such as `AU` or `CR`).
+
+| Parameter                   | Type       | Description                                                                                                                                |
+|-----------------------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `blockedAccessPermissions`  | `string[]` | Optional list of permission codes to disable in the dialog. Defaults to `[]`. Useful when some permissions are already granted elsewhere. |
+
+The promise resolves to an array of [`SelectedAccess`](#selectedaccess) entries.
+
+```ts
+// ... /////
+$b24 = await initializeB24Frame()
+// ... /////
+const makeSelectAccess = async() => {
+  const selected = await $b24.dialog.selectAccess(['AU'])
+
+  $logger.info(
+    selected.map(row => `${row.id} → ${row.name}`)
+  )
+}
+```
+
+### selectCRM
+
+```ts
+async selectCRM(params?: SelectCRMParams): Promise<SelectedCRM>
+```
+
+Displays the standard dialog for selecting CRM entities (leads, contacts, companies, deals, quotes).
+
+| Parameter                  | Type                            | Description                                                                                                                                                                  |
+|----------------------------|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `params.entityType`        | `SelectCRMParamsEntityType[]`   | Which entity types to show as tabs in the picker. Allowed values: `lead`, `contact`, `company`, `deal`, `quote`.                                                             |
+| `params.multiple`          | `boolean`                       | Allow multiple selection. Defaults to `false`.                                                                                                                                |
+| `params.value`             | `SelectCRMParamsValue`          | Optional map of entity IDs to mark as initially selected. Applied **only when `multiple` is `true`** — single-select mode ignores it.                                          |
+
+The promise resolves to a [`SelectedCRM`](#selectedcrm) object whose properties (`lead`, `contact`, `company`, `deal`, `quote`) are real JavaScript arrays of [`SelectedCRMEntity`](#selectedcrmentity). Buckets for entity types the user did not pick (or did not request) are left `undefined` rather than set to an empty array.
+
+::note
+Since v1.0.7, `selectCRM` always returns real arrays. Earlier versions forwarded the parent window's payload as-is, so each bucket was actually a `Record<string, SelectedCRMEntity>` (e.g. `{ 0: {...}, 1: {...} }`) — calling `.length` or `.map()` on it returned `undefined`. Code written against the documented types continues to work; the only behavioural difference is that the runtime shape now matches the types.
+::
+
+```ts
+// ... /////
+$b24 = await initializeB24Frame()
+// ... /////
+const makeSelectCRM = async() => {
+  const selected = await $b24.dialog.selectCRM({
+    entityType: ['contact', 'company'],
+    multiple: true,
+    value: {
+      contact: [42],
+      company: [7]
+    }
+  })
+
+  selected.contact?.forEach((row) => {
+    $logger.info(`[${row.id}] ${row.title} — ${row.url}`)
+  })
+
+  selected.company?.forEach((row) => {
+    $logger.info(`[${row.id}] ${row.title}`)
+  })
+}
+```
+
+::note
+Single-select mode (`multiple: false`) still resolves to the same `SelectedCRM` shape — buckets just contain at most one element. To grab that element use `selected.contact?.[0]`.
+::
 
 ## Data Types
 
 ### SelectedUser
 
-Used to represent information about a selected user in the Bitrix24 application. It contains several fields that describe the user's ID, name, photo, position, and other characteristics.
+Represents a single company employee picked through `selectUser` / `selectUsers`. The `sub` and `sup` flags describe the hierarchical relationship with the current user.
 
-> The `sub` and `sup` fields help determine hierarchical relationships between the current user and the selected user.
+| Field      | Type           | Description                                                                                |
+|------------|----------------|--------------------------------------------------------------------------------------------|
+| `id`       | `NumberString` | User identifier — a string containing a numeric value (e.g. `"42"`).                       |
+| `name`     | `string`       | Formatted display name.                                                                    |
+| `photo`    | `string`       | URL of the user's avatar.                                                                  |
+| `position` | `string`       | User's job title.                                                                          |
+| `url`      | `string`       | URL of the user's profile inside the portal.                                               |
+| `sub`      | `boolean`      | `true` when the selected user is a subordinate of the current user.                        |
+| `sup`      | `boolean`      | `true` when the selected user is a supervisor of the current user.                         |
 
-- **`id: NumberString`**: User identifier. Represented as a string containing a numeric value.
-- **`name: string`**: Formatted name of the user.
-- **`photo: string`**: URL of the user's photo.
-- **`position: string`**: User's position in the company.
-- **`url: string`**: URL of the user's profile.
-- **`sub: boolean`**: Flag indicating that the selected user is a subordinate of the current user. A value of `true` means the user is a subordinate.
-- **`sup: boolean`**: Flag indicating that the selected user is a supervisor of the current user. A value of `true` means the user is a supervisor.
+### SelectedAccess
+
+Represents one entry returned by `selectAccess`.
+
+| Field  | Type     | Description                                                                                              |
+|--------|----------|----------------------------------------------------------------------------------------------------------|
+| `id`   | `string` | Permission code (see the table below).                                                                   |
+| `name` | `string` | Human-readable name of the permission, localized to the portal language.                                 |
+
+The `id` field uses Bitrix24's permission-code grammar:
+
+| Pattern        | Meaning                                                       |
+|----------------|---------------------------------------------------------------|
+| `AU`           | All authorized portal users.                                  |
+| `CR`           | Current user.                                                 |
+| `U${number}`   | A specific user by ID.                                        |
+| `IU${number}`  | An employee by ID (extranet-aware).                           |
+| `D${number}`   | All employees of a department.                                |
+| `DR${number}`  | All employees of a department, including subdepartments.      |
+| `G${number}`   | A user group (e.g. `G2` — all visitors).                      |
+| `SG${number}`  | A social network / workgroup.                                 |
+
+### SelectCRMParamsEntityType
+
+```ts
+type SelectCRMParamsEntityType = 'lead' | 'contact' | 'company' | 'deal' | 'quote'
+```
+
+The set of CRM entity kinds that `selectCRM` understands. Passed in as `params.entityType` and used as the keys of both `SelectCRMParamsValue` and `SelectedCRM`.
+
+### SelectCRMParamsValue
+
+Map of entity IDs to pre-select when `multiple: true`. Only the requested entity types are read; extra keys are ignored.
+
+| Field      | Type       | Description                                            |
+|------------|------------|--------------------------------------------------------|
+| `lead`     | `number[]` | Lead IDs to mark as already selected.                  |
+| `contact`  | `number[]` | Contact IDs to mark as already selected.               |
+| `company`  | `number[]` | Company IDs to mark as already selected.               |
+| `deal`     | `number[]` | Deal IDs to mark as already selected.                  |
+| `quote`    | `number[]` | Quote IDs to mark as already selected.                 |
+
+### SelectedCRMEntity
+
+Represents one row inside a `SelectedCRM` bucket.
+
+| Field   | Type                          | Description                                                                                                |
+|---------|-------------------------------|------------------------------------------------------------------------------------------------------------|
+| `id`    | `string`                      | Prefixed entity identifier — see the table in [`SelectedCRM`](#selectedcrm).                               |
+| `type`  | `SelectCRMParamsEntityType`   | Entity kind (`lead` / `contact` / `company` / `deal` / `quote`).                                           |
+| `place` | `string`                      | UI placement label used by Bitrix24 (rarely needed; informational).                                        |
+| `title` | `string`                      | Display title of the entity (e.g. company name, deal title, contact full name).                            |
+| `desc`  | `string`                      | Short description shown next to the title in the picker.                                                   |
+| `url`   | `string`                      | URL to open the entity inside the portal.                                                                  |
+
+### SelectedCRM
+
+Result of `selectCRM`. Each property is either an array of [`SelectedCRMEntity`](#selectedcrmentity) refined with a literal `id` pattern, or `undefined` when the user picked nothing of that type.
+
+| Field      | Type                                                                  | Description                                                                                              |
+|------------|-----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| `lead`     | `(SelectedCRMEntity & { id: ``L_${number}`` })[]`                     | Picked leads. Each `id` looks like `L_42`.                                                               |
+| `contact`  | `(SelectedCRMEntity & { id: ``C_${number}``, image: string })[]`      | Picked contacts. The extra `image` field holds the contact's avatar URL.                                 |
+| `company`  | `(SelectedCRMEntity & { id: ``CO_${number}``, image: string })[]`     | Picked companies. The extra `image` field holds the company logo URL.                                    |
+| `deal`     | `(SelectedCRMEntity & { id: ``D_${number}`` })[]`                     | Picked deals. Each `id` looks like `D_17`.                                                               |
+| `quote`    | `(SelectedCRMEntity & { id: ``Q_${number}`` })[]`                     | Picked quotes. Each `id` looks like `Q_3`.                                                               |

--- a/packages/jssdk/src/frame/dialog.ts
+++ b/packages/jssdk/src/frame/dialog.ts
@@ -169,18 +169,69 @@ export class DialogManager {
   }
 
   /**
-   * Method invokes the system dialog for selecting a CRM entity
+   * Invokes the system dialog for selecting CRM entities
+   * (leads, contacts, companies, deals, quotes).
    *
-   * @param {SelectCRMParams} params
-   * @return {Promise<SelectedCRM>}
+   * The resolved `SelectedCRM` object contains a separate bucket per
+   * entity type. Each present bucket is a real `Array`, so consumers can
+   * use `.length`, `.map()`, `for..of`, etc. directly. Buckets for entity
+   * types that were not selected (or not requested via `entityType`) are
+   * left `undefined` rather than being set to an empty array.
+   *
+   * Note: the parent window historically returned each bucket as a
+   * `Record<string, SelectedCRMEntity>` (e.g. `{ 0: {...}, 1: {...} }`).
+   * The SDK normalizes that response to a real array before returning it.
+   *
+   * @param {SelectCRMParams} [params] - Filter and behavior options.
+   *   - `entityType`: which entity types are shown in the dialog.
+   *   - `multiple`: allow multiple selection (default `false`).
+   *   - `value`: pre-selected entities (only applied when `multiple` is `true`).
+   * @return {Promise<SelectedCRM>} Resolves to an object whose properties
+   *   (`lead`, `contact`, `company`, `deal`, `quote`) are arrays of
+   *   {@link SelectedCRMEntity} objects.
    *
    * @link https://apidocs.bitrix24.com/sdk/bx24-js-sdk/system-dialogues/bx24-select-crm.html
    */
   async selectCRM(params?: SelectCRMParams): Promise<SelectedCRM> {
-    return this.#messageManager.send(MessageCommands.selectCRM, {
+    const response = await this.#messageManager.send(MessageCommands.selectCRM, {
       entityType: params?.entityType,
       multiple: params?.multiple,
       value: params?.value
-    })
+    }) as Partial<Record<SelectCRMParamsEntityType, unknown>> | null | undefined
+
+    // The parent window returns each entity bucket as a Record<string, SelectedCRMEntity>
+    // (e.g. { 0: {...}, 1: {...} }) rather than a real array. Normalize to arrays so
+    // the runtime shape matches the documented `SelectedCRM` types.
+    const result: SelectedCRM = {}
+    if (!response) {
+      return result
+    }
+
+    const toArray = <T>(bucket: unknown): T[] | undefined => {
+      if (bucket === undefined || bucket === null) {
+        return undefined
+      }
+      if (Array.isArray(bucket)) {
+        return bucket as T[]
+      }
+      return Object.values(bucket as Record<string, T>)
+    }
+
+    const lead = toArray<SelectedCRMEntity & { id: `L_${number}` }>(response.lead)
+    if (lead) result.lead = lead
+
+    const contact = toArray<SelectedCRMEntity & { id: `C_${number}`, image: string }>(response.contact)
+    if (contact) result.contact = contact
+
+    const company = toArray<SelectedCRMEntity & { id: `CO_${number}`, image: string }>(response.company)
+    if (company) result.company = company
+
+    const deal = toArray<SelectedCRMEntity & { id: `D_${number}` }>(response.deal)
+    if (deal) result.deal = deal
+
+    const quote = toArray<SelectedCRMEntity & { id: `Q_${number}` }>(response.quote)
+    if (quote) result.quote = quote
+
+    return result
   }
 }


### PR DESCRIPTION
## Summary

Fixes #21.

`b24.dialog.selectCRM()` advertised each entity bucket (`lead`, `contact`, `company`, `deal`, `quote`) as an array of `SelectedCRMEntity`, but at runtime the parent window returned a `Record<string, SelectedCRMEntity>` (e.g. `{ 0: {...}, 1: {...} }`). Calling `selected.contact.length` or `.map()` therefore returned `undefined`, and TypeScript could not catch it because the static types disagreed with reality.

This PR normalizes each bucket via `Object.values` before resolving, so the runtime shape matches the documented `SelectedCRM` type. Pre-existing arrays are passed through untouched (forward-compatible).

### Changes

- `packages/jssdk/src/frame/dialog.ts`
  - Convert each CRM entity bucket to a real `Array` in `selectCRM()`.
  - Expand the JSDoc to describe the bucket shape, the normalization, and the params.
- `docs/content/docs/2.working-with-the-rest-api/31.frame-dialog.md`
  - Add the previously missing `selectAccess` and `selectCRM` sections.
  - Reformat all methods with parameter tables and runnable examples.
  - Add `Data Types` entries for `SelectedAccess`, `SelectCRMParamsEntityType`, `SelectCRMParamsValue`, `SelectedCRMEntity`, `SelectedCRM`, including the access-permission and CRM ID-prefix grammars.
  - Add a note flagging the runtime behaviour change.

### Breaking change

`selectCRM()` previously resolved to an object whose buckets were `Record<string, SelectedCRMEntity>`. They are now real arrays, matching the documented `SelectedCRM` types.

- Code that already used array operations (or accessed indices like `selected.contact[0]`) keeps working unchanged.
- Code that iterated the record with `Object.keys` / `Object.values` or read length-less object properties needs to switch to array access.

## Test plan

- [x] `pnpm run package-jssdk:typecheck`
- [x] `pnpm run lint`
- [x] Manual smoke inside a Bitrix24 iframe: open a CRM picker with `multiple: true`, confirm `selected.contact` is an `Array`, `.length` and `.map()` work as expected.
- [x] Manual smoke with `multiple: false`: confirm `selected.contact?.[0]` returns the chosen entity.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2YwKSFgmUN8CATJ7j8UFD)_