### PR TITLE
chore(release): lockstep version bumper + publish workflow guards

### DIFF
--- a/.github/workflows/npm-publish-js-sdk-nuxt.yml
+++ b/.github/workflows/npm-publish-js-sdk-nuxt.yml
@@ -12,9 +12,47 @@ permissions:
 jobs:
   process:
     runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Verify version lockstep across workspaces
+        shell: bash
+        run: |
+          ROOT=$(jq -r .version package.json)
+          SDK=$(jq -r .version packages/jssdk/package.json)
+          NUXT=$(jq -r .version packages/jssdk-nuxt/package.json)
+          if [ "$ROOT" != "$SDK" ] || [ "$ROOT" != "$NUXT" ]; then
+            echo "::error::Version mismatch: root=$ROOT jssdk=$SDK nuxt=$NUXT"
+            exit 1
+          fi
+          echo "All packages at version $ROOT"
+
+      - name: Verify package version matches release tag
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          EXPECTED="${TAG#v}"
+          ACTUAL=$(jq -r .version packages/jssdk-nuxt/package.json)
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::Release tag $TAG (expected version $EXPECTED) does not match package.json version $ACTUAL"
+            exit 1
+          fi
+
+      - name: Verify version is not already published
+        shell: bash
+        run: |
+          PKG=$(jq -r .name packages/jssdk-nuxt/package.json)
+          VER=$(jq -r .version packages/jssdk-nuxt/package.json)
+          if npm view "$PKG@$VER" version >/dev/null 2>&1; then
+            echo "::error::$PKG@$VER is already published on npm"
+            exit 1
+          fi
+          echo "$PKG@$VER is not yet published — OK to proceed"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5

--- a/.github/workflows/npm-publish-js-sdk.yml
+++ b/.github/workflows/npm-publish-js-sdk.yml
@@ -12,9 +12,47 @@ permissions:
 jobs:
   process:
     runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Verify version lockstep across workspaces
+        shell: bash
+        run: |
+          ROOT=$(jq -r .version package.json)
+          SDK=$(jq -r .version packages/jssdk/package.json)
+          NUXT=$(jq -r .version packages/jssdk-nuxt/package.json)
+          if [ "$ROOT" != "$SDK" ] || [ "$ROOT" != "$NUXT" ]; then
+            echo "::error::Version mismatch: root=$ROOT jssdk=$SDK nuxt=$NUXT"
+            exit 1
+          fi
+          echo "All packages at version $ROOT"
+
+      - name: Verify package version matches release tag
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          EXPECTED="${TAG#v}"
+          ACTUAL=$(jq -r .version packages/jssdk/package.json)
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::Release tag $TAG (expected version $EXPECTED) does not match package.json version $ACTUAL"
+            exit 1
+          fi
+
+      - name: Verify version is not already published
+        shell: bash
+        run: |
+          PKG=$(jq -r .name packages/jssdk/package.json)
+          VER=$(jq -r .version packages/jssdk/package.json)
+          if npm view "$PKG@$VER" version >/dev/null 2>&1; then
+            echo "::error::$PKG@$VER is already published on npm"
+            exit 1
+          fi
+          echo "$PKG@$VER is not yet published — OK to proceed"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "package-jssdk:test:run-underLoad-v2-batchByChunk": "vitest run -t \"crmItemListAsCompany batchByChunk @apiV2\" --project jsSdk:underLoad",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "typecheck": "pnpm run package-jssdk:typecheck && pnpm run package-jssdk-nuxt:typecheck && pnpm run docs:typecheck && pnpm run playground-nuxt:typecheck && pnpm run playground-cli:typecheck"
+    "typecheck": "pnpm run package-jssdk:typecheck && pnpm run package-jssdk-nuxt:typecheck && pnpm run docs:typecheck && pnpm run playground-nuxt:typecheck && pnpm run playground-cli:typecheck",
+    "release:bump": "node scripts/bump-version.mjs"
   },
   "devDependencies": {
     "@nuxt/eslint-config": "^1.15.2",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+const TARGETS = [
+  'package.json',
+  'packages/jssdk/package.json',
+  'packages/jssdk-nuxt/package.json'
+]
+
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[\w.-]+)?$/
+
+const newVersion = process.argv[2]
+
+if (!newVersion || !SEMVER_RE.test(newVersion)) {
+  process.stderr.write([
+    'Usage: pnpm run release:bump <version>',
+    '       version must match <major>.<minor>.<patch>[-prerelease]',
+    '       e.g. 1.1.1, 1.2.0, 2.0.0-rc.1'
+  ].join('\n') + '\n')
+  process.exit(1)
+}
+
+const targets = TARGETS.map((rel) => {
+  const abs = join(repoRoot, rel)
+  const raw = readFileSync(abs, 'utf8')
+  const pkg = JSON.parse(raw)
+  return { rel, abs, raw, current: pkg.version }
+})
+
+const distinct = new Set(targets.map(t => t.current))
+if (distinct.size !== 1) {
+  process.stderr.write('Refusing to bump: package versions are out of sync:\n')
+  for (const { rel, current } of targets) {
+    process.stderr.write(`  ${rel}: ${current}\n`)
+  }
+  process.stderr.write('Resolve the drift manually, then retry.\n')
+  process.exit(1)
+}
+
+const [currentVersion] = distinct
+if (currentVersion === newVersion) {
+  process.stderr.write(`Refusing to bump: new version ${newVersion} matches the current one.\n`)
+  process.exit(1)
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+for (const target of targets) {
+  const pattern = new RegExp(`("version"\\s*:\\s*")${escapeRegExp(target.current)}(")`)
+  if (!pattern.test(target.raw)) {
+    process.stderr.write(`Failed to locate version field in ${target.rel}\n`)
+    process.exit(1)
+  }
+  const updated = target.raw.replace(pattern, `$1${newVersion}$2`)
+  writeFileSync(target.abs, updated)
+  process.stdout.write(`Updated ${target.rel}: ${currentVersion} → ${newVersion}\n`)
+}
+
+process.stdout.write('\nRefreshing pnpm lockfile…\n')
+const install = spawnSync('pnpm', ['install', '--lockfile-only'], {
+  cwd: repoRoot,
+  stdio: 'inherit'
+})
+if (install.status !== 0) {
+  process.stderr.write('\npnpm install --lockfile-only failed. Fix the issue and re-run.\n')
+  process.exit(install.status ?? 1)
+}
+
+process.stdout.write([
+  '',
+  `Bumped to ${newVersion}. Review the diff and commit:`,
+  '',
+  '  git add -A',
+  `  git commit -m "chore(release): v${newVersion}"`,
+  ''
+].join('\n'))


### PR DESCRIPTION
## Summary

Two pain points around versioning are addressed; the third one (`workspace:*` → exact pin in the published Nuxt module) is left alone because it is by design.

**1. Tройной ручной bump → одна команда**

`scripts/bump-version.mjs` is a tiny dependency-free Node script wired up as `pnpm run release:bump <version>`. It updates `package.json`, `packages/jssdk/package.json` and `packages/jssdk-nuxt/package.json` in lockstep via a surgical regex replace (only the `version` field is touched — no JSON reformatting of neighbouring fields), then runs `pnpm install --lockfile-only` so `workspace:*` references are re-resolved.

Guards in the script:
- refuses on invalid semver shape;
- refuses on no-op bumps (new version equals current);
- refuses on out-of-sync versions and prints the drift across all three files.

**2. Publish-workflow guard-rails**

Both `.github/workflows/npm-publish-js-sdk.yml` and `npm-publish-js-sdk-nuxt.yml` now run three guards **before** install / lint / build, so a misconfigured release fails in seconds instead of 5+ minutes in:

1. **Lockstep** — three `package.json` versions must agree;
2. **Tag ↔ version** (only on `release` event) — `tag_name` (`v1.1.0`) must match `package.json` version (`1.1.0`);
3. **Not yet on npm** — `npm view pkg@ver` must return nothing.

`workflow_dispatch` is also restricted to `main` so a stray feature branch cannot overwrite the `latest` dist-tag. `release` events are unaffected — they always check out the tag commit.

### Files

| Action | File |
|---|---|
| new | `scripts/bump-version.mjs` |
| edit | `package.json` (adds `release:bump` script entry) |
| edit | `.github/workflows/npm-publish-js-sdk.yml` |
| edit | `.github/workflows/npm-publish-js-sdk-nuxt.yml` |

### Out of scope

- `workspace:*` in `packages/jssdk-nuxt/package.json` — kept (by design)
- CHANGELOG inside published packages — not changed
- Prerelease dist-tag (`next` / `beta` / `rc`) — not added; only `latest` remains

## Test plan

Bump script (verified locally end-to-end):

- [x] `pnpm run release:bump` (no args) → exit 1, usage hint
- [x] `pnpm run release:bump 1.1` → exit 1, usage hint (invalid semver)
- [x] `pnpm run release:bump 1.1.0` (current) → exit 1, no-op refusal
- [x] `pnpm run release:bump 1.1.1` → three files bumped (+1 / -1 diff each), `pnpm-lock.yaml` refreshed, no formatting drift in neighbouring JSON fields
- [x] Manually corrupt one `package.json` version → drift detected, all three current values printed, exit 1

Workflow guards (to verify by triggering on the branch):

- [ ] `workflow_dispatch` on `claude/fix-package-versioning-k6rPd` should be **rejected** by the job-level `if` (only `main` allowed)
- [ ] After merge to `main`: `workflow_dispatch` reaches the guards and shows `All packages at version 1.1.0` + `... is not yet published — OK to proceed`, then proceeds (or stops at the not-yet-published guard if `1.1.0` is already on npm, which it is — useful smoke test)
- [ ] When the next real release is published, the tag-version guard validates `v<X.Y.Z>` ↔ `package.json` and the publish proceeds as before

---
_Generated by [Claude Code](https://claude.ai/code/session_018YsKecMqZ3fySLFLcGpR6A)_