### PR TITLE
ci: add unified ci.yml workflow and gate releases on green CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,19 @@
-name: NPM build 👷‍♂️
+name: ci
 
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_call:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
     env:
       NUXT_PUBLIC_USE_AI: false
@@ -25,12 +32,11 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Prepare
         run: pnpm run dev:prepare
@@ -41,11 +47,8 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
-      - name: Build
+      - name: Build (jssdk)
         run: pnpm --filter ./packages/jssdk build
 
-      - name: Build NUXT
+      - name: Build (jssdk-nuxt)
         run: pnpm --filter ./packages/jssdk-nuxt build
-
-      - name: Generate Docs
-        run: pnpm run docs:generate

--- a/.github/workflows/npm-publish-js-sdk-nuxt.yml
+++ b/.github/workflows/npm-publish-js-sdk-nuxt.yml
@@ -10,7 +10,11 @@ permissions:
   id-token: write
 
 jobs:
-  process:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  publish:
+    needs: ci
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,16 +31,10 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Prepare
         run: pnpm run dev:prepare
-
-      - name: Lint
-        run: pnpm run lint
-
-      - name: Typecheck
-        run: pnpm run typecheck
 
       - name: Build
         run: pnpm --filter ./packages/jssdk-nuxt build

--- a/.github/workflows/npm-publish-js-sdk.yml
+++ b/.github/workflows/npm-publish-js-sdk.yml
@@ -10,7 +10,11 @@ permissions:
   id-token: write
 
 jobs:
-  process:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  publish:
+    needs: ci
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,16 +31,10 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Prepare
         run: pnpm run dev:prepare
-
-      - name: Lint
-        run: pnpm run lint
-
-      - name: Typecheck
-        run: pnpm run typecheck
 
       - name: Build
         run: pnpm --filter ./packages/jssdk build


### PR DESCRIPTION
## Summary

- New `.github/workflows/ci.yml` runs on `pull_request` and `push` to `main` (plus `workflow_dispatch` for manual reruns). Steps: checkout → install pnpm → setup Node 22 → `pnpm install --frozen-lockfile` → `pnpm run dev:prepare` → `pnpm run lint` → `pnpm run typecheck` → `pnpm --filter ./packages/jssdk build` → `pnpm --filter ./packages/jssdk-nuxt build`.
- `ci.yml` also exposes `workflow_call`, and both `npm-publish-js-sdk.yml` / `npm-publish-js-sdk-nuxt.yml` now declare a `ci` job (`uses: ./.github/workflows/ci.yml`) with `publish: needs: ci`. **Releases physically cannot publish to npm until CI is green on the same commit.**
- `npm-pre-publish.yml` deleted — its lint/typecheck/build steps are now in `ci.yml` (and additionally run on PRs); its `docs:generate` step is already handled by `deploy.yml`.

## Adaptations vs. the suggested snippet

- No root `pnpm test` / `pnpm build` scripts — split into filtered builds for `packages/jssdk` and `packages/jssdk-nuxt`.
- Added `pnpm run dev:prepare` before `typecheck` (Nuxt workspaces need `.nuxt/` generated).
- Dropped the `Test` step: all tests are integration tests requiring `B24_HOOK` against a real Bitrix24 portal (per `CLAUDE.md`, "Tests hit real Bitrix24 REST endpoints — never mock responses"). Cannot run in fork PRs.
- pnpm version is auto-detected by `pnpm/action-setup@v5` from `packageManager: pnpm@10.33.2` in `package.json`.

## Test plan

- [ ] CI workflow turns green on this PR (lint, typecheck, both builds).
- [ ] After merge, verify `ci.yml` runs on the push-to-main event (and that `npm-pre-publish.yml` is no longer triggered — it's gone).
- [ ] Manual `workflow_dispatch` on `ci.yml` from the Actions tab works.
- [ ] On the next GitHub Release, confirm both `NPM publish JS SDK 🚀` and `NPM publish JS SDK NUXT 🚀` show two sequential jobs (`ci` then `publish`), and that publishing is blocked when `ci` fails. A safe dry-run is `workflow_dispatch` on either publish workflow against a non-default branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_018RdfgADSC7kH7JyVGWoudY)_