### PR TITLE
chore(release): v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [1.1.1](https://github.com/bitrix24/b24jssdk/compare/v1.1.0...v1.1.1) (2026-05-15)
+
+### Features
+
+* **limiters\RestrictionParams:** add `retryOnNetworkError` flag — set to `false` to throw immediately on `NETWORK_ERROR` / `REQUEST_TIMEOUT` instead of retrying. Important for non-idempotent calls (e.g. `crm.documentgenerator.document.add`) where retries can create duplicates
+* **limiters\RestrictionParams:** add `hardErrorCodes` and `softErrorCodes` — merge custom REST error codes into the built-in hard/soft lists so business-specific codes can opt out of automatic retry or be returned as soft errors via `AjaxResult` (#24)
+* **limiters\RestrictionManager:** expose `BUILT_IN_HARD_ERROR_CODES` / `BUILT_IN_SOFT_ERROR_CODES` as readonly static fields so callers can introspect the defaults
+* **limiters\ParamsFactory:** `realtime` preset now ships with `retryOnNetworkError: false` so realtime callers don't accidentally retry non-idempotent writes
+
+### Bug Fixes
+
+* **batch:** preserve `null` results in batch responses — previously coerced to `{}` via `resultData ?? {}`, which broke nullable interfaces (e.g. `im.chat.get` with non-matching params) and hid the difference between "no data" and "empty object"
+* **batch-v3:** tighten response parsing — drop the misleading `result_error`/`result_time` split (a v2-only envelope shape), guard against missing entries in the all-or-nothing v3 model, and stop polluting per-method stats with cross-method failures (#23)
+
+### Chore
+
+* **release:** add `pnpm run release:bump <version>` ([scripts/bump-version.mjs](scripts/bump-version.mjs)) — updates root + both package workspaces in lockstep, refreshes the pnpm lockfile, refuses on out-of-sync versions / invalid semver / no-op bumps
+* **ci:** unify CI into `.github/workflows/ci.yml`; both npm publish workflows now gate on green CI, matching versions across all three `package.json` files, the GitHub release tag matching the version, and the `package@version` not already being on npm. `workflow_dispatch` is restricted to `main`
+
+### Docs
+
+* **limiters:** expand long-running request guidance and cross-link the new retry / error-code knobs
+* **batch:** document `null` result passthrough and the v3 all-or-nothing model
+* **test:** document required webhook scopes for the integration suite (`main` scope for webhook tests)
+
 ## [1.1.0](https://github.com/bitrix24/b24jssdk/compare/v1.0.6...v1.1.0) (2026-05-08)
 
 ### ⚠ BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitrix24/b24jssdk-main",
   "description": "Bitrix24 REST API JS SDK",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Bitrix",
   "packageManager": "pnpm@10.33.2",
   "repository": {

--- a/packages/jssdk-nuxt/package.json
+++ b/packages/jssdk-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitrix24/b24jssdk-nuxt",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "packageManager": "pnpm@10.33.2",
   "author": "Bitrix",
   "license": "MIT",

--- a/packages/jssdk-nuxt/src/module.ts
+++ b/packages/jssdk-nuxt/src/module.ts
@@ -5,7 +5,7 @@ export type ModuleOptions = object
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: '@bitrix24/b24jssdk-nuxt',
-    version: '1.1.0',
+    version: '1.1.1',
     configKey: 'B24JsSdkNuxt',
     compatibility: {
       nuxt: '>=4.2.2'

--- a/packages/jssdk/package.json
+++ b/packages/jssdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitrix24/b24jssdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Bitrix",
   "license": "MIT",
   "description": "Bitrix24 REST API JavaScript SDK",


### PR DESCRIPTION
## Summary

Patch release bundling everything merged into `main` since v1.1.0. No breaking changes.

- Bump root, `packages/jssdk`, `packages/jssdk-nuxt` and `packages/jssdk-nuxt/src/module.ts` from `1.1.0` to `1.1.1` (via `pnpm run release:bump 1.1.1`; the module.ts update is manual because the bumper does not touch it yet).
- Append a `1.1.1` entry to `CHANGELOG.md` covering all user-facing changes since v1.1.0.

### What's in v1.1.1

**Features**
- `limiters\RestrictionParams.retryOnNetworkError` — opt out of automatic retries on `NETWORK_ERROR` / `REQUEST_TIMEOUT` for non-idempotent calls. The `realtime` preset now ships with `retryOnNetworkError: false`.
- `limiters\RestrictionParams.hardErrorCodes` / `softErrorCodes` — merge custom REST error codes into the built-in hard/soft lists for business-specific endpoints (closes #24).
- `RestrictionManager.BUILT_IN_HARD_ERROR_CODES` / `BUILT_IN_SOFT_ERROR_CODES` exposed as readonly static fields for introspection.

**Bug Fixes**
- `batch`: preserve `null` results in batch responses instead of coercing to `{}` (e.g. `im.chat.get` with non-matching params).
- `batch-v3`: tighten response parsing, drop the v2-only `result_error`/`result_time` cast, guard against missing entries, and stop polluting per-method stats with cross-method failures (closes #23).

**Chore / Tooling**
- `pnpm run release:bump <version>` — lockstep version bumper for all three `package.json` files + lockfile refresh, with semver / no-op / drift guards.
- Unified `.github/workflows/ci.yml`; publish workflows now gate on green CI, matching versions across all `package.json` files, the GitHub release tag matching the version, and the `package@version` not already being on npm. `workflow_dispatch` restricted to `main`.

**Docs**
- Expanded `limiters` page (long-running request guidance, cross-links to the new retry / error-code knobs).
- Documented `null` result passthrough and the v3 all-or-nothing batch model.
- Documented required webhook scopes for the integration test suite.

## Test plan

- [x] `pnpm install`
- [x] `pnpm run dev:prepare`
- [x] `pnpm run lint:fix` — clean
- [x] `pnpm run typecheck` — clean
- [ ] Wait for CI on this PR to go green before merging
- [ ] After merge: tag `v1.1.1` on `main` and cut the GitHub Release so the npm publish workflows fire

## Follow-up

`scripts/bump-version.mjs` currently only touches the three `package.json` files; the `version: '...'` literal in `packages/jssdk-nuxt/src/module.ts` had to be bumped manually. Worth a small follow-up PR to add that path to the bumper's `TARGETS`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J4PhSocKnbi8XcSVjJUoHc)_