### PR TITLE
docs(skills): add agent skills for the SDK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,18 @@ b24jssdk/
 │   ├── cli/            # CLI playground for testing
 │   └── nuxt/           # Nuxt playground
 ├── docs/               # Documentation site (Nuxt)
+├── skills/             # Agent skills: when-to-use guidance for the SDK
 ├── test/               # Integration tests
 └── vitest.config.ts    # Vitest workspace configuration
 ```
+
+## Agent skills
+
+The `skills/` directory follows the layout used by [`bitrix24/b24ui/skills`](https://github.com/bitrix24/b24ui/tree/main/skills): a top-level `index.json` manifest + per-skill folders with `SKILL.md` and `references/` (guidelines, recipes, api-surface). Skills teach **when** to use which entry point/method; detailed API references live in `packages/jssdk/README-AI.md` and the docs site.
+
+Available skills:
+
+- `skills/b24-jssdk/` — building Bitrix24 REST integrations: frame placements, server-side webhooks, OAuth apps, Pull events, Nuxt module. Read `skills/b24-jssdk/SKILL.md` first; its routing table tells you which references to load for a given task.
 
 ## Tech stack
 

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
@@ -17,6 +17,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
+  - label: Skill — conventions
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/guidelines/conventions.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
@@ -17,9 +17,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
-  - label: Skill — conventions
+  - label: Skill — rest-api-v2
     iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/guidelines/conventions.md
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/rest-api-v2.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
@@ -17,6 +17,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
+  - label: Skill — conventions
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/guidelines/conventions.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
@@ -17,9 +17,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
-  - label: Skill — conventions
+  - label: Skill — rest-api-v3
     iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/guidelines/conventions.md
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/rest-api-v3.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
@@ -15,6 +15,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
+  - label: Skill — list-pagination
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/list-pagination.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
@@ -15,9 +15,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
-  - label: Skill — list-pagination
+  - label: Skill — rest-api-v2
     iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/list-pagination.md
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/rest-api-v2.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
@@ -15,6 +15,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
+  - label: Skill — list-pagination
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/list-pagination.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
@@ -15,9 +15,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
-  - label: Skill — list-pagination
+  - label: Skill — rest-api-v3
     iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/list-pagination.md
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/rest-api-v3.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
@@ -15,6 +15,9 @@ links:
   - label: Async Generator
     iconName: MdnwebdocsIcon
     to: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator
+  - label: Skill — list-pagination
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/list-pagination.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
@@ -15,9 +15,9 @@ links:
   - label: Async Generator
     iconName: MdnwebdocsIcon
     to: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator
-  - label: Skill — list-pagination
+  - label: Skill — rest-api-v2
     iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/list-pagination.md
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/rest-api-v2.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
@@ -15,9 +15,9 @@ links:
   - label: Async Generator
     iconName: MdnwebdocsIcon
     to: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator
-  - label: Skill — list-pagination
+  - label: Skill — rest-api-v3
     iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/list-pagination.md
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/rest-api-v3.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
@@ -15,6 +15,9 @@ links:
   - label: Async Generator
     iconName: MdnwebdocsIcon
     to: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator
+  - label: Skill — list-pagination
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/list-pagination.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
@@ -17,6 +17,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
+  - label: Skill — batch-calls
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/batch-calls.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
@@ -17,9 +17,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
-  - label: Skill — batch-calls
+  - label: Skill — rest-api-v2
     iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/batch-calls.md
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/rest-api-v2.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
@@ -17,6 +17,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
+  - label: Skill — batch-calls
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/batch-calls.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
@@ -17,9 +17,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
-  - label: Skill — batch-calls
+  - label: Skill — rest-api-v3
     iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/batch-calls.md
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/rest-api-v3.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/30.frame-initialize-b24-frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame-initialize-b24-frame.md
@@ -3,6 +3,10 @@ title: B24Frame Initialization
 description: 'Function is designed to initialize a B24Frame'
 category: 'B24Frame'
 navigation.title: Initialization
+links:
+  - label: Skill — frame-apps
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/frame-apps.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/30.frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame.md
@@ -3,6 +3,10 @@ title: B24Frame Class
 description: 'Designed for managing Bitrix24 applications. It inherits functionality from AbstractB24 and provides methods for working with authentication, messages, sliders, and more.'
 category: 'B24Frame'
 navigation.title: Introduction
+links:
+  - label: Skill — frame-apps
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/frame-apps.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-dialog.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-dialog.md
@@ -8,6 +8,9 @@ links:
     icon: i-simple-icons-github
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/dialog.ts
     target: _blank
+  - label: Skill — ui-integrations
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/ui-integrations.md
 ---
 
 `DialogManager` is exposed via [`$b24.dialog`](/docs/working-with-the-rest-api/frame/#dialog) on a `B24Frame` instance and is only available when your application is rendered inside a Bitrix24 iframe (it relies on `postMessage` to talk to the parent window).

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-options.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-options.md
@@ -3,6 +3,10 @@ title: Options Manager Class
 description: 'Used for managing application and user settings in the Bitrix24 application. It allows initializing data, getting, and setting options through messages to the parent window.'
 category: 'B24Frame'
 navigation.title: Options
+links:
+  - label: Skill — ui-integrations
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/ui-integrations.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-parent.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-parent.md
@@ -3,6 +3,10 @@ title: Parent Manager Class
 description: 'Provides methods for managing the parent application window in Bitrix24, including resizing the window, managing scroll, initiating calls, and opening the messenger.'
 category: 'B24Frame'
 navigation.title: Parent
+links:
+  - label: Skill — ui-integrations
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/ui-integrations.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
@@ -3,6 +3,10 @@ title: Placement Manager Class
 description: 'Used for managing the placement of widgets in the Bitrix24 application.'
 category: 'B24Frame'
 navigation.title: Placement
+links:
+  - label: Skill — ui-integrations
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/ui-integrations.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-slider.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-slider.md
@@ -10,6 +10,9 @@ links:
   - label: StatusClose
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/slider.ts
+  - label: Skill — ui-integrations
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/ui-integrations.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
@@ -18,9 +18,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
-  - label: Skill — batch-calls
+  - label: Skill — rest-api-v2
     iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/batch-calls.md
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/rest-api-v2.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
@@ -18,6 +18,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
+  - label: Skill — batch-calls
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/batch-calls.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
@@ -18,6 +18,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
+  - label: Skill — batch-calls
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/batch-calls.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
@@ -18,9 +18,9 @@ links:
   - label: SdkError
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts
-  - label: Skill — batch-calls
+  - label: Skill — rest-api-v3
     iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/batch-calls.md
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/recipes/rest-api-v3.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/66.logger.md
+++ b/docs/content/docs/2.working-with-the-rest-api/66.logger.md
@@ -13,6 +13,9 @@ links:
   - label: Monolog
     iconName: GitHubIcon
     to: https://github.com/Seldaek/monolog
+  - label: Skill — logger
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/guidelines/logger.md
 ---
 
 ::warning

--- a/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
+++ b/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
@@ -7,6 +7,9 @@ links:
   - label: Limiters
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/tree/main/packages/jssdk/src/core/http/limiters
+  - label: Skill — rate-limiting
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/references/guidelines/rate-limiting.md
 ---
 
 ::warning

--- a/packages/jssdk/README-AI.md
+++ b/packages/jssdk/README-AI.md
@@ -17,13 +17,24 @@ Core building blocks:
 - **UI managers (frame-only):** `parent`, `slider`, `dialog`, `placement`, `options`, `auth`
 - **Helpers:** `B24HelperManager` and `useB24Helper()` composable; Pull client
 
-> Companion documentation: [`skills/b24-jssdk/SKILL.md`](../../skills/b24-jssdk/SKILL.md) is an agent-oriented routing guide (decision matrices, recipes, anti-patterns). This README-AI is the code-pattern reference; the skill tells you **when** to reach for which pattern.
+> Companion documentation: [`skills/b24-jssdk/SKILL.md`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24-jssdk/SKILL.md) is an agent-oriented routing guide (decision matrices, recipes, anti-patterns). This README-AI is the code-pattern reference; the skill tells you **when** to reach for which pattern.
 
 Note: since v0.4.0 the package ships ESM and UMD only (no CommonJS).
 
 ## Deprecation notice — read before generating code
 
 The following surface is `@deprecated` and **scheduled for removal in `2.0.0`**. **Generate new code against `b24.actions.v{2,3}.*` only.** The legacy surface remains documented below the line where it's strictly necessary to recognise older codebases.
+
+### v2 vs v3 — which version to call
+
+`b24.actions.v2.*` and `b24.actions.v3.*` are independent endpoints, not a replacement-of-one-by-the-other. Pick by method:
+
+- **v3 currently supports a small set:** `/tasks.task.*`, `/main.eventlog.*`, `/batch`, `/scopes`, `/rest.scope.list`, `/rest.documentation.openapi`, `/documentation`. Source of truth: [`packages/jssdk/src/core/version-manager.ts`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/version-manager.ts).
+- **Everything else is v2-only** — CRM (`crm.item.*`, `crm.deal.*`, …), IM, `user.current`, `profile`, placement, options, settings.
+
+`b24.actions.v3.call.make` throws `SdkError(JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3)` immediately for a v2-only method. `b24.actions.v3.batch.make` throws the same error if any one method in the batch isn't v3-supported — you cannot mix v2-only and v3 methods inside a single v3 batch.
+
+Practical rule: **default to v2; switch the specific call to v3 only when its method is on the v3 list.** Examples below follow this rule.
 
 | Deprecated | Replacement |
 |---|---|
@@ -91,8 +102,8 @@ async function boot() {
   }))
   logger.info('items', items)
 
-  // Named batch (v3 form — works for v2 too; pick v2 when calls use v2-only methods)
-  const batch = await $b24.actions.v3.batch.make({
+  // Named batch — v2 because crm.item.* is a v2-only method
+  const batch = await $b24.actions.v2.batch.make({
     calls: {
       CompanyList: {
         method: 'crm.item.list',
@@ -219,8 +230,8 @@ const response = await $b24.actions.v2.call.make({
 })
 logger.info('companies:', response.getData().result.items)
 
-// Batch (array form)
-const batch = await $b24.actions.v3.batch.make({
+// Batch (array form) — v2 because crm.item.* is v2-only
+const batch = await $b24.actions.v2.batch.make({
   calls: [
     ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.company, select: ['id'] }],
     ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.contact, select: ['id'] }]
@@ -279,13 +290,25 @@ import {
   type B24OAuthSecret
 } from '@bitrix24/b24jssdk'
 
+// Persisted per-portal/user state — typically captured after the OAuth code exchange.
+// Authoritative shapes: packages/jssdk/src/types/auth.ts.
 const authOptions: B24OAuthParams = {
-  domain: 'your_domain.bitrix24.com'
-  // … remaining auth fields — see packages/jssdk/src/types/auth.ts
+  applicationToken: '1xxxxx1694',
+  userId: 1,
+  memberId: '3xx2030386cyy1b',
+  accessToken: '1xxxxx1694',
+  refreshToken: '0xxxx4e000011e700000001000000260dc83b47c40e9b5fd501093674c4f5',
+  expires: 1745997853,
+  expiresIn: 3600,
+  scope: 'crm,catalog,bizproc,placement,user_brief',
+  domain: 'your_domain.bitrix24.com',
+  clientEndpoint: 'https://your_domain.bitrix24.com/rest/',
+  serverEndpoint: 'https://oauth.bitrix.info/rest/',
+  status: 'L'
 }
 const oAuthSecret: B24OAuthSecret = {
-  // client_id / client_secret + token-refresh endpoint
-  // … see packages/jssdk/src/types/auth.ts
+  clientId: process.env.B24_CLIENT_ID!,
+  clientSecret: process.env.B24_CLIENT_SECRET!
 }
 
 const $b24 = new B24OAuth(authOptions, oAuthSecret, {
@@ -296,15 +319,16 @@ $b24.setLogger(LoggerBrowser.build('OAuthApp', true))
 $b24.offClientSideWarning() // server-side
 
 // Persist rotated tokens on every successful refresh
-$b24.setCallbackRefreshAuth((newAuth) => {
-  saveTokens(newAuth)
+$b24.setCallbackRefreshAuth(async ({ authData, b24OAuthParams }) => {
+  await saveTokens(b24OAuthParams)
 })
 
-// Optional: override how refresh is performed (e.g. centralised service)
-$b24.setCustomRefreshAuth(async (currentAuth) => fetchNewTokensFromYourBackend(currentAuth))
+// Optional: produce a new token pair yourself (called instead of the built-in refresh)
+$b24.setCustomRefreshAuth(async () => fetchNewTokensFromYourBackend())
 
 try {
-  const response = await $b24.actions.v3.call.make({ method: 'user.current' })
+  // user.current is v2-only
+  const response = await $b24.actions.v2.call.make({ method: 'user.current' })
   console.log(response.getData().result)
 } catch (e) {
   if (e instanceof RefreshTokenError) {
@@ -589,7 +613,8 @@ Notes:
 import { AjaxError } from '@bitrix24/b24jssdk'
 
 try {
-  const res = await $b24.actions.v3.call.make({
+  // crm.item.* is v2-only
+  const res = await $b24.actions.v2.call.make({
     method: 'crm.item.get',
     params: { entityTypeId: 1, id: 10 }
   })

--- a/packages/jssdk/README-AI.md
+++ b/packages/jssdk/README-AI.md
@@ -2,51 +2,52 @@
 
 Purpose: give AI agents a precise, code-oriented overview of the SDK to generate working Bitrix24 apps. This SDK lets you:
 
-- Call Bitrix24 REST API from apps embedded in Bitrix24 (iframe) and from backend services
+- Call Bitrix24 REST API from apps embedded in Bitrix24 (iframe), from backend services via webhook, and from OAuth local apps
 - Interact with Bitrix24 UI: open sliders, dialogs, resize frame, set page title, IM integrations, etc.
 - Manage app/user options via the parent portal
-- Use helpers (profile/app/options/currencies/licenses/payments) and Pull client
+- Use helpers (profile / app / options / currencies / licenses / payments) and the Pull (push) client
 
 Core building blocks:
 
-- Frontend in frame: B24Frame + initializeB24Frame()
-- Backend/service: B24Hook (webhook-based)
-- REST utilities: callMethod, callBatch, callListMethod, fetchListMethod
-- UI managers: parent, slider, dialog, placement, options, auth
-- Helpers: B24HelperManager and useB24Helper hook; Pull client
+- **Frontend in frame:** `B24Frame` + `initializeB24Frame()`
+- **Backend / service:** `B24Hook` (webhook-based)
+- **OAuth apps:** `B24OAuth` (token refresh + recoverable failures)
+- **REST surface (shared by all three):** `b24.actions.v{2,3}.{call, callList, fetchList, batch, batchByChunk}.make(options)`
+- **Utility checks:** `b24.tools.{healthCheck, ping}.make(options?)`
+- **UI managers (frame-only):** `parent`, `slider`, `dialog`, `placement`, `options`, `auth`
+- **Helpers:** `B24HelperManager` and `useB24Helper()` composable; Pull client
+
+> Companion documentation: [`skills/b24-jssdk/SKILL.md`](../../skills/b24-jssdk/SKILL.md) is an agent-oriented routing guide (decision matrices, recipes, anti-patterns). This README-AI is the code-pattern reference; the skill tells you **when** to reach for which pattern.
 
 Note: since v0.4.0 the package ships ESM and UMD only (no CommonJS).
 
 ## Deprecation notice — read before generating code
 
-The following surface is `@deprecated` and **scheduled for removal in `2.0.0`**.
-Many examples in this document still reference it because it remains the most
-widely-used path today, but new code should target the `actions.v{2,3}.*` API.
+The following surface is `@deprecated` and **scheduled for removal in `2.0.0`**. **Generate new code against `b24.actions.v{2,3}.*` only.** The legacy surface remains documented below the line where it's strictly necessary to recognise older codebases.
 
 | Deprecated | Replacement |
 |---|---|
-| `b24.callMethod(method, params, start?)` | `b24.actions.v2.call.make({ method, params })` / `b24.actions.v3.call.make({ method, params })` |
-| `b24.callBatch(calls, isHaltOnError?, returnAjaxResult?)` | `b24.actions.v2.batch.make({ calls, options })` / `b24.actions.v3.batch.make(...)` |
-| `b24.callBatchByChunk(calls, isHaltOnError)` | `b24.actions.v2.batchByChunk.make({ calls, options })` / `b24.actions.v3.batchByChunk.make(...)` |
-| `b24.callListMethod(method, params, progress?, customKey?)` | `b24.actions.v2.callList.make({ method, params, customKeyForResult })` / `b24.actions.v3.callList.make(...)` |
-| `b24.fetchListMethod(method, params, idKey?, customKey?)` | `b24.actions.v2.fetchList.make({ method, params, idKey, customKeyForResult })` / `b24.actions.v3.fetchList.make(...)` |
-| `AjaxResult#isMore()`, `#hasMore()`, `#getNext()`, `#fetchNext()`, `#getTotal()` | The `next`/`total` envelope fields are `restApi:v2`-only (no `restApi:v3` counterpart). Do not iterate manually — let `actions.v{2,3}.{callList,fetchList}` handle pagination. For element counts in `restApi:v3` use the `aggregate` action with `count` / `countDistinct`. |
+| `b24.callMethod(method, params, start?)` | `b24.actions.v3.call.make({ method, params, requestId })` / `b24.actions.v2.call.make(...)` |
+| `b24.callBatch(calls, isHaltOnError?, returnAjaxResult?)` | `b24.actions.v3.batch.make({ calls, options })` / `b24.actions.v2.batch.make(...)` |
+| `b24.callBatchByChunk(calls, isHaltOnError)` | `b24.actions.v3.batchByChunk.make({ calls, options })` / `b24.actions.v2.batchByChunk.make(...)` |
+| `b24.callListMethod(method, params, progress?, customKey?)` | `b24.actions.v3.callList.make({ method, params, idKey, customKeyForResult })` / `b24.actions.v2.callList.make(...)` |
+| `b24.fetchListMethod(method, params, idKey?, customKey?)` | `b24.actions.v3.fetchList.make({ method, params, idKey, customKeyForResult })` / `b24.actions.v2.fetchList.make(...)` |
+| `AjaxResult#isMore()`, `#hasMore()`, `#getNext()`, `#fetchNext()`, `#getTotal()` | These rely on the `restApi:v2`-only `next`/`total` envelope fields and have no `restApi:v3` counterpart. Don't paginate manually — use `callList.make` / `fetchList.make`. For element counts in v3 use the `aggregate` action with `count` / `countDistinct`. |
 
-`AjaxResult.getData()` returns exactly `{ result: T, time: PayloadTime }` — the
-v2-only `next` and `total` fields are no longer surfaced through the public type.
+`AjaxResult.getData()` returns exactly `{ result: T, time: PayloadTime }` — the v2-only `next` and `total` fields are no longer surfaced through the public type.
 
 
 ## Frontend in Bitrix24 (TypeScript, ESM)
 
-Use when your app runs inside Bitrix24 as an iframe placement. The SDK initializes by messaging with the parent window and supplies auth tokens automatically.
+Use when your app runs inside Bitrix24 as an iframe placement. The SDK initialises by messaging the parent window and handles auth automatically.
 
-Minimal contract
+Minimal contract:
 
 - `initializeB24Frame(): Promise<B24Frame>`
 - `B24Frame.isInit`: boolean (after init)
-- Auth auto-refresh on 401 (expired/invalid token)
+- Auth auto-refresh on `401`
 
-Example: initialize, call REST, cleanup
+Example: initialise, call REST, cleanup.
 
 ```ts
 import {
@@ -55,42 +56,61 @@ import {
   EnumCrmEntityTypeId,
   Text,
   LoggerBrowser,
-  Result,
   type ISODate
 } from '@bitrix24/b24jssdk'
 
 const logger = LoggerBrowser.build('MyApp', import.meta.env?.DEV === true)
 let $b24: B24Frame
 
+interface Company { id: number, title: string, createdTime: ISODate }
+
 async function boot() {
   $b24 = await initializeB24Frame()
+  $b24.setLogger(logger)
 
-  // Single method
-  const companies = await $b24.callMethod('crm.item.list', {
-    entityTypeId: EnumCrmEntityTypeId.company,
-    order: { id: 'desc' },
-    select: ['id', 'title', 'createdTime']
+  // Single method (v2 — crm.item.* is a v2 method)
+  const response = await $b24.actions.v2.call.make<{ items: Company[] }>({
+    method: 'crm.item.list',
+    params: {
+      entityTypeId: EnumCrmEntityTypeId.company,
+      order: { id: 'desc' },
+      select: ['id', 'title', 'createdTime']
+    },
+    requestId: 'companies-recent'
   })
-  logger.info('items:', companies.getData().result)
 
-  // Batch (object syntax, with keys)
-  const batch: Result = await $b24.callBatch({
-    CompanyList: {
-      method: 'crm.item.list',
-      params: {
-        entityTypeId: EnumCrmEntityTypeId.company,
-        order: { id: 'desc' },
-        select: ['id', 'title', 'createdTime']
-      }
-    }
-  }, true)
-  const data = batch.getData()
-  const list = (data.CompanyList.items || []).map((it: any) => ({
-    id: Number(it.id),
+  if (!response.isSuccess) {
+    logger.error('failed', response.getErrorMessages())
+    return
+  }
+
+  const items = response.getData().result.items.map((it) => ({
+    id: it.id,
     title: it.title,
-    createdTime: Text.toDateTime(it.createdTime as ISODate)
+    createdTime: Text.toDateTime(it.createdTime)
   }))
-  logger.info('batch list:', list)
+  logger.info('items', items)
+
+  // Named batch (v3 form — works for v2 too; pick v2 when calls use v2-only methods)
+  const batch = await $b24.actions.v3.batch.make({
+    calls: {
+      CompanyList: {
+        method: 'crm.item.list',
+        params: {
+          entityTypeId: EnumCrmEntityTypeId.company,
+          order: { id: 'desc' },
+          select: ['id', 'title', 'createdTime']
+        }
+      }
+    },
+    options: { isHaltOnError: true, requestId: 'companies-batch' }
+  })
+
+  if (!batch.isSuccess) {
+    logger.error('batch failed', batch.getErrorMessages())
+    return
+  }
+  logger.info('batch list:', batch.getData())
 }
 
 function teardown() {
@@ -98,29 +118,29 @@ function teardown() {
 }
 ```
 
-Useful getters and services on B24Frame
+Useful getters and services on `B24Frame`:
 
-- auth: getAuthData(), refreshAuth(), isAdmin; getAppSid()
-- parent: fitWindow(), resizeWindow(w,h), resizeWindowAuto(node?, minH?, minW?), setTitle(title), closeApplication(), reloadWindow(), scrollParentWindow(scroll)
-- slider: getUrl(path), openPath(url[, width]), openSliderAppPage(params), closeSliderAppPage()
-- dialog: selectUser(), selectUsers()  [selectAccess(), selectCRM() are deprecated]
-- placement: title, options, isSliderMode, getInterface(), bindEvent(event, cb), call(command, params), callCustomBind(command, params?, cb)
-- options: appGet/set, userGet/set
-- getLang(): portal UI language
+- `auth`: `getAuthData()`, `refreshAuth()`, `isAdmin`, `getAppSid()`, `getUniq(prefix)`
+- `parent`: `fitWindow()`, `resizeWindow(w,h)`, `resizeWindowAuto(node?, minH?, minW?)`, `setTitle(title)`, `closeApplication()`, `reloadWindow()`, `scrollParentWindow(scroll)`
+- `slider`: `getUrl(path)`, `openPath(url[, width])`, `openSliderAppPage(params)`, `closeSliderAppPage()`
+- `dialog`: `selectUser()`, `selectUsers()` (`selectAccess()` / `selectCRM()` are deprecated)
+- `placement`: `title`, `options`, `isSliderMode`, `getInterface()`, `bindEvent(event, cb)`, `call(command, params)`, `callCustomBind(command, params?, cb)`
+- `options`: `appGet/appSet`, `userGet/userSet`
+- `getLang()`: portal UI language
 
-Patterns
+Patterns:
 
-- Always await initializeB24Frame() before any call.
-- Destroy on page/component unmount with $b24.destroy().
-- For large result sets prefer callListMethod or fetchListMethod.
-- For big batches use callBatchByChunk to respect limits.
+- Always `await initializeB24Frame()` before any REST call.
+- Destroy on page/component unmount with `$b24.destroy()`.
+- For large result sets use `b24.actions.v{2,3}.fetchList.make` (async generator, constant memory).
+- For batches over 50 commands use `b24.actions.v{2,3}.batchByChunk.make` — the SDK chunks for you.
 - A per-command `result` inside a batch can be `null` when the underlying REST method legitimately returns `null` (e.g. `im.chat.get` with non-matching params). Declare the generic as `T | null` and handle the `null` branch — the SDK no longer coerces it to `{}` (see issue #23).
 - `restApi:v3` batch is all-or-nothing: per-command errors are not returned. If any call fails, the whole batch fails and `response.getErrorMessages()` carries the error.
 
 
 ## Frontend via UMD (CDN)
 
-When you can’t bundle ESM, load the global B24Js from a CDN inside your iframe app.
+When you can't bundle ESM, load the global `B24Js` from a CDN inside your iframe app.
 
 ```html
 <script src="https://unpkg.com/@bitrix24/b24jssdk@latest/dist/umd/index.min.js"></script>
@@ -129,19 +149,22 @@ When you can’t bundle ESM, load the global B24Js from a CDN inside your iframe
     try {
       const logger = B24Js.LoggerBrowser.build('MyApp', true)
       const $b24 = await B24Js.initializeB24Frame()
+      $b24.setLogger(logger)
 
-      const res = await $b24.callBatch({
-        CompanyList: {
-          method: 'crm.item.list',
-          params: {
-            entityTypeId: B24Js.EnumCrmEntityTypeId.company,
-            order: { id: 'desc' },
-            select: ['id', 'title', 'createdTime']
-          }
-        }
-      }, true)
+      const response = await $b24.actions.v2.call.make({
+        method: 'crm.item.list',
+        params: {
+          entityTypeId: B24Js.EnumCrmEntityTypeId.company,
+          select: ['id', 'title', 'createdTime']
+        },
+        requestId: 'umd-companies'
+      })
 
-      logger.info('data:', res.getData())
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages())
+        return
+      }
+      logger.info('data:', response.getData().result.items)
     } catch (e) {
       console.error(e)
     }
@@ -149,98 +172,173 @@ When you can’t bundle ESM, load the global B24Js from a CDN inside your iframe
 </script>
 ```
 
-Globals exposed by UMD
+Globals exposed by UMD:
 
-- B24Js.initializeB24Frame
-- B24Js.B24Frame and managers via properties (auth, parent, slider, dialog, placement, options)
-- Utilities: LoggerBrowser, Text, Type, enums (e.g., EnumCrmEntityTypeId), Result, AjaxError/AjaxResult, etc.
+- `B24Js.initializeB24Frame`
+- `B24Js.B24Frame` and managers via properties (`auth`, `parent`, `slider`, `dialog`, `placement`, `options`)
+- Action types (`B24Js.ApiVersion`, etc.), utilities (`LoggerBrowser`, `Text`, `Type`), enums (e.g. `EnumCrmEntityTypeId`), result classes (`Result`, `AjaxError`, `AjaxResult`)
 
 
-## Backend/Services (Node.js, ESM) with B24Hook
+## Backend / Services (Node.js, ESM) with `B24Hook`
 
-Use B24Hook when calling Bitrix24 REST from servers or scripts via incoming webhook. Auth is embedded in the webhook path and no frame is required.
+Use `B24Hook` when calling Bitrix24 REST from servers or scripts via incoming webhook. Auth is embedded in the webhook path — **never use this on the client**.
 
-Minimal contract
+Minimal contract:
 
-- new B24Hook({ b24Url, userId, secret }) or B24Hook.fromWebhookUrl(url)
-- callMethod, callBatch, callListMethod, fetchListMethod
+- `new B24Hook(b24HookParams, options?)` or `B24Hook.fromWebhookUrl(url, options?)`
+- `b24.actions.v{2,3}.{call, callList, fetchList, batch, batchByChunk}.make(options)`
 
-Example: construct from webhook URL and call API
+Construct from URL:
 
 ```ts
 import {
   B24Hook,
   EnumCrmEntityTypeId,
   LoggerBrowser,
-  Result
+  ParamsFactory
 } from '@bitrix24/b24jssdk'
 
 const logger = LoggerBrowser.build('Srv', true)
 
 const $b24 = B24Hook.fromWebhookUrl(
-  'https://your_domain.bitrix24.com/rest/1/k32t88gf3azpmwv3'
+  'https://your_domain.bitrix24.com/rest/1/k32t88gf3azpmwv3',
+  // Optional: pre-tune limiter for the workload
+  // { restrictionParams: ParamsFactory.getBatchProcessing() }
 )
+$b24.setLogger(logger)
+$b24.offClientSideWarning() // server-only — silence the client-warning
 
-// Optional: silence client-side warning (Node is server-side)
-$b24.offClientSideWarning?.()
-
-// Single method
-const res = await $b24.callMethod('crm.item.list', {
-  entityTypeId: EnumCrmEntityTypeId.company,
-  order: { id: 'desc' },
+// Single call (v2)
+const response = await $b24.actions.v2.call.make({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.company,
+    order: { id: 'desc' }
+  },
+  requestId: 'companies'
 })
-logger.info('companies:', res.getData().result)
+logger.info('companies:', response.getData().result.items)
 
-// Batch (array syntax)
-const batch: Result = await $b24.callBatch([
-  ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.company, select: ['id'] }],
-  ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.contact, select: ['id'] }]
-], true)
+// Batch (array form)
+const batch = await $b24.actions.v3.batch.make({
+  calls: [
+    ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.company, select: ['id'] }],
+    ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.contact, select: ['id'] }]
+  ],
+  options: { isHaltOnError: true, requestId: 'cross-list' }
+})
 logger.info('batch:', batch.getData())
 ```
 
-Listing helpers
+Listing helpers:
 
 ```ts
-// Pull a full list with automatic paging
-const list = await $b24.callListMethod('crm.item.list', {
-  entityTypeId: EnumCrmEntityTypeId.deal,
-  select: ['id', 'title']
+// Auto-paged list, in memory — use for known small sets (< 1000)
+const list = await $b24.actions.v2.callList.make({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.deal,
+    select: ['id', 'title']
+  },
+  idKey: 'id',                   // crm.item.list returns lowercase 'id'
+  customKeyForResult: 'items',
+  requestId: 'deals-list'
 })
-console.log(list.getData()) // array of items
+console.log(list.getData())      // T[]
 
-// Or stream chunks
-for await (const chunk of $b24.fetchListMethod('crm.item.list', { entityTypeId: EnumCrmEntityTypeId.deal }, 'id')) {
+// Streaming for large datasets — constant memory
+for await (const chunk of $b24.actions.v2.fetchList.make({
+  method: 'crm.item.list',
+  params: { entityTypeId: EnumCrmEntityTypeId.deal },
+  idKey: 'id',
+  customKeyForResult: 'items',
+  requestId: 'deals-stream'
+})) {
   console.log('chunk size', chunk.length)
 }
 ```
 
-Notes
+Notes:
 
-- Supported Node versions: ^18, ^20, or >=22.
-- B24Hook warns if used on the client; keep it server-side.
+- Supported Node versions: `^18`, `^20`, or `>=22`.
+- `B24Hook` warns if used on the client; keep it server-side.
+- One `B24Hook` per portal — limiter state is per-instance.
 
 
-## UI Integrations in Frame (sliders, dialogs, parent window)
+## OAuth local apps with `B24OAuth`
 
-These require a B24Frame (i.e., running inside Bitrix24 placement iframe).
-
-Sliders
+For local apps that authenticate via OAuth. The SDK exposes the same REST surface as `B24Frame` / `B24Hook`; what's different is auth lifecycle (access/refresh tokens, recoverable failures).
 
 ```ts
-// Open a portal path in a slider
-const url = $b24.slider.getUrl('/crm/deal/details/1')
-const result = await $b24.slider.openPath(url, 1640)
-if (result.isOpenAtNewWindow) {
-  // On mobile, falls back to window.open and returns close status after polling
+import {
+  B24OAuth,
+  ParamsFactory,
+  RefreshTokenError,
+  LoggerBrowser,
+  type B24OAuthParams,
+  type B24OAuthSecret
+} from '@bitrix24/b24jssdk'
+
+const authOptions: B24OAuthParams = {
+  domain: 'your_domain.bitrix24.com'
+  // … remaining auth fields — see packages/jssdk/src/types/auth.ts
+}
+const oAuthSecret: B24OAuthSecret = {
+  // client_id / client_secret + token-refresh endpoint
+  // … see packages/jssdk/src/types/auth.ts
 }
 
-// Open your application page as a slider and then close it
+const $b24 = new B24OAuth(authOptions, oAuthSecret, {
+  restrictionParams: ParamsFactory.getDefault()
+})
+
+$b24.setLogger(LoggerBrowser.build('OAuthApp', true))
+$b24.offClientSideWarning() // server-side
+
+// Persist rotated tokens on every successful refresh
+$b24.setCallbackRefreshAuth((newAuth) => {
+  saveTokens(newAuth)
+})
+
+// Optional: override how refresh is performed (e.g. centralised service)
+$b24.setCustomRefreshAuth(async (currentAuth) => fetchNewTokensFromYourBackend(currentAuth))
+
+try {
+  const response = await $b24.actions.v3.call.make({ method: 'user.current' })
+  console.log(response.getData().result)
+} catch (e) {
+  if (e instanceof RefreshTokenError) {
+    // Refresh token revoked or app uninstalled — redirect user to OAuth consent
+    redirectToReauth()
+    return
+  }
+  throw e
+}
+
+// Optional — initialise the admin flag once after construction
+await $b24.initIsAdmin('init-1')
+console.log($b24.auth.isAdmin)
+```
+
+
+## UI integrations in frame (sliders, dialogs, parent window)
+
+These require a `B24Frame` (running inside a Bitrix24 placement iframe).
+
+Sliders:
+
+```ts
+const url = $b24.slider.getUrl('/crm/deal/details/1/')
+const status = await $b24.slider.openPath(url, 1640)
+if (status.isOpenAtNewWindow) {
+  // Mobile: opened in a new tab; SDK polled until the tab closed
+}
+
 await $b24.slider.openSliderAppPage({ some: 'params' })
 await $b24.slider.closeSliderAppPage()
 ```
 
-Dialogs
+Dialogs:
 
 ```ts
 const user = await $b24.dialog.selectUser()         // null | { id, name, ... }
@@ -248,7 +346,7 @@ const users = await $b24.dialog.selectUsers()       // SelectedUser[]
 // selectAccess() and selectCRM() exist but are deprecated
 ```
 
-Parent window and IM integrations
+Parent window and IM integrations:
 
 ```ts
 await $b24.parent.fitWindow()
@@ -258,50 +356,44 @@ await $b24.parent.imCallTo(5, true)          // video call to user 5
 await $b24.parent.imOpenMessenger('chat12')  // open messenger
 ```
 
-Placement API
+Placement API:
 
 ```ts
-// Placement meta
 console.log($b24.placement.title, $b24.placement.options, $b24.placement.isSliderMode)
 
-// Query interface capabilities
 const iface = await $b24.placement.getInterface()
-
-// Bind placement events or custom commands
 await $b24.placement.bindEvent('onMessage', (...args) => console.log(args))
 await $b24.placement.call('someCommand', { foo: 'bar' })
 await $b24.placement.callCustomBind('someCommand', { opt: 1 }, (...args) => {})
 ```
 
-Options
+Options:
 
 ```ts
-// App-level
 await $b24.options.appSet('installComplete', true)
 const appFlag = $b24.options.appGet('installComplete')
 
-// User-level
 await $b24.options.userSet('theme', 'dark')
 const theme = $b24.options.userGet('theme')
 ```
 
-Auth and environment
+Auth and environment:
 
 ```ts
-const auth = $b24.auth.getAuthData() // { access_token, refresh_token, expires_in, domain, member_id } | false
+const auth = $b24.auth.getAuthData()  // { access_token, refresh_token, expires_in, domain, member_id } | false
 if (!auth) {
   await $b24.auth.refreshAuth()
 }
-const lang = $b24.getLang()          // portal UI language
-const sid = $b24.getAppSid()         // app SID in current session
+const lang = $b24.getLang()           // portal UI language
+const sid = $b24.getAppSid()          // app SID in current session
 ```
 
 
-## Helpers and Pull Client
+## Helpers and Pull client
 
-The SDK ships a high-level helper to preload portal and app data and to work with Pull client.
+The SDK ships a high-level helper to preload portal/app data and wire the Pull client.
 
-Initialization pattern (after B24Frame is initialized)
+Initialisation (after `B24Frame` is initialised):
 
 ```ts
 import { useB24Helper, LoadDataType, type TypePullMessage } from '@bitrix24/b24jssdk'
@@ -321,247 +413,331 @@ await initB24Helper($b24, [
   LoadDataType.App,
   LoadDataType.Currency,
   LoadDataType.AppOptions,
-  LoadDataType.UserOptions,
+  LoadDataType.UserOptions
 ])
 
 // Enable Pull
-usePullClient('prefix')      // optionally pass userId
+usePullClient('prefix')                       // optionally pass userId
 useSubscribePullClient((m: TypePullMessage) => {
   // handle Pull messages
 }, 'application')
 startPullClient()
 
-// Access helper data and extra managers
+// Access helper data and managers
 const helper = getB24Helper()
 const userId = helper.profileInfo.data.id
-const uniq = $b24.auth.getUniq('prefix') // unique per member
+const uniq = $b24.auth.getUniq('prefix')      // unique per member
 ```
 
-Notes
+Cleanup order: `destroyB24Helper()` *before* `$b24.destroy()`.
 
-- Helper managers: profile, app, payment, license, currency, options
-- Currency and options managers internally use callBatch/callBatchByChunk
+Notes:
+
+- Helper managers: `profile`, `app`, `payment`, `license`, `currency`, `options`.
+- `LicenseManager` swaps `RestrictionManager` to enterprise params automatically on enterprise portals (no code change required).
+- `CurrencyManager` and the helper-level `OptionsManager` internally use `b24.actions.v{2,3}.batch.make` / `batchByChunk.make`.
 
 
-## REST calling model and error handling
+## REST calling model
 
-Core REST utilities live in AbstractB24 and Http:
+The REST surface lives on `b24.actions` (alongside `b24.tools`):
 
-- callMethod(method, params[, start]) => `Promise<AjaxResult>`
-- callBatch(calls, isHaltOnError = true, returnAjaxResult = false) => `Promise<Result>`
-  - calls can be object { key: { method, params } } or array [ [method, params], ... ]
-  - If isHaltOnError=false, Result accumulates errors; otherwise rejects on first error
-  - If returnAjaxResult=true, you receive AjaxResult objects per command
-- callListMethod(method, params, progress?, customKey?) => `Promise<Result>` (auto-paging)
-- fetchListMethod(method, params, idKey='ID', customKey?) => `AsyncGenerator<any[]>`
+```text
+b24.actions
+├── v3 / v2
+│   ├── call          .make({ method, params?, requestId? })        → Promise<AjaxResult<T>>
+│   ├── callList      .make({ method, params?, idKey?, customKeyForResult, requestId?, limit? })
+│   │                                                                → Promise<Result<T[]>>
+│   ├── fetchList     .make({ method, params?, idKey?, customKeyForResult, requestId?, limit? })
+│   │                                                                → AsyncGenerator<T[]>
+│   ├── batch         .make({ calls, options? })                    → Promise<CallBatchResult<T>>
+│   └── batchByChunk  .make({ calls, options? })                    → Promise<Result<T[]>>
+b24.tools
+├── healthCheck       .make({ requestId? })                          → Promise<boolean>
+└── ping              .make({ requestId? })                          → Promise<number>  // ms
+```
 
-### Choosing list retrieval strategy (recommendations)
+Key option fields:
 
-- callListMethod: fetches the entire dataset into memory. Use only for small selections (< 1000 items) due to higher memory pressure.
-- fetchListMethod: streams data in chunks via async iterator. Use for large datasets to keep memory usage low.
-- callMethod (manual pagination): control paging via the `start` cursor. Use when you need precise batching and custom flow. For big data it’s typically less efficient/convenient than fetchListMethod.
+- `requestId?` — stable id for tracking / dedup / debug logs.
+- `idKey?` — id field used for cursor pagination. Default: `'id'` in v3, `'ID'` in v2. For `crm.item.list` always pass `idKey: 'id'`.
+- `customKeyForResult` — payload-array key. **Required in v3**, optional in v2 (defaults to `null`, meaning the result array is the response root). For `crm.item.list` it's `'items'`.
+- `limit?` (v3 list actions only) — page size. Default `50`, max `1000`.
+- `options.isHaltOnError` (batch) — `true` rejects on first failing command; `false` accumulates per-command errors.
+- `options.returnAjaxResult` (batch) — wrap each result in `AjaxResult` for granular inspection (incompatible with `batchByChunk`).
 
-Below are complete examples that iterate until all data are fetched.
-
-#### A) Small datasets: callListMethod (all-in-memory)
-
-Assumes `$b24` is already initialized (either B24Frame or B24Hook).
+Batch input accepts three shapes — pick whichever makes consumer code clearest:
 
 ```ts
-import { EnumCrmEntityTypeId, Result } from '@bitrix24/b24jssdk'
+// 1. Array of tuples
+await b24.actions.v3.batch.make({
+  calls: [
+    ['tasks.task.get', { id: 1, select: ['id', 'title'] }],
+    ['tasks.task.get', { id: 2, select: ['id', 'title'] }]
+  ]
+})
 
-async function loadAllCompaniesSmall($b24: any) {
-  const response: Result = await $b24.callListMethod(
-    'crm.item.list',
-    {
-      entityTypeId: EnumCrmEntityTypeId.company,
-      order: { id: 'asc' },
-      select: ['id', 'title']
-    },
-    (progress: number) => {
-      // Optional progress callback (0..100)
-      // console.log('progress', progress)
-    }
-  )
+// 2. Array of objects
+await b24.actions.v3.batch.make({
+  calls: [
+    { method: 'tasks.task.get', params: { id: 1, select: ['id', 'title'] } },
+    { method: 'tasks.task.get', params: { id: 2, select: ['id', 'title'] } }
+  ]
+})
 
-  const items = response.getData() as any[]
-  // Process all items (already fully loaded in memory)
-  for (const row of items) {
-    // ...process row
-  }
-
-  return items
-}
+// 3. Named object — results keyed by name
+await b24.actions.v3.batch.make({
+  calls: {
+    Task: { method: 'tasks.task.get', params: { id: 1, select: ['id', 'title'] } },
+    Log: ['main.eventlog.list', { select: ['id', 'userId'], pagination: { limit: 5 } }]
+  },
+  options: { returnAjaxResult: true }
+})
 ```
 
-#### B) Large datasets: fetchListMethod (streaming by chunks)
+### Choosing list retrieval strategy
 
-For `crm.item.list`, use `idKey: 'id'` so the fast-iterator strategy works reliably with v3 entities.
+- **`callList.make`** — fetches the entire dataset into memory. Only for small selections (< 1000 items).
+- **`fetchList.make`** — streams chunks via async generator. Use for any large/unknown dataset.
+- **`call.make` + manual cursor (legacy)** — only when you must control page boundaries yourself, and only in **v2** (v3 has no `next` envelope). See the "Manual pagination" subsection in the deprecation appendix below.
+
+#### A) Small datasets — `callList.make`
+
+```ts
+import { EnumCrmEntityTypeId, Text } from '@bitrix24/b24jssdk'
+
+interface Company { id: number, title: string }
+
+const sixMonthAgo = new Date()
+sixMonthAgo.setMonth(sixMonthAgo.getMonth() - 6)
+
+const response = await $b24.actions.v2.callList.make<Company>({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.company,
+    filter: {
+      '=%title': 'A%',
+      '>=createdTime': Text.toB24Format(sixMonthAgo)
+    },
+    select: ['id', 'title']
+  },
+  idKey: 'id',
+  customKeyForResult: 'items',
+  requestId: 'companies-recent'
+})
+
+if (!response.isSuccess) {
+  throw new Error(response.getErrorMessages().join('; '))
+}
+
+const items: Company[] = response.getData() ?? []
+```
+
+#### B) Large datasets — `fetchList.make`
 
 ```ts
 import { EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
 
-async function loadAllDealsStreaming($b24: any) {
-  const all: any[] = []
+interface Deal { id: number, title: string }
 
-  for await (const chunk of $b24.fetchListMethod(
-    'crm.item.list',
-    {
-      entityTypeId: EnumCrmEntityTypeId.deal,
-      select: ['id', 'title']
-    },
-    'id' // idKey for crm.item.list payloads
-  )) {
-    // Process current chunk
-    for (const row of chunk) {
-      // ...process row
-    }
-    all.push(...chunk)
+for await (const chunk of $b24.actions.v2.fetchList.make<Deal>({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.deal,
+    select: ['id', 'title']
+  },
+  idKey: 'id',
+  customKeyForResult: 'items',
+  requestId: 'deals-stream'
+})) {
+  for (const row of chunk) {
+    // process row
   }
-
-  return all
 }
 ```
 
-#### C) Manual pagination: callMethod + next pages
-
-> **`@deprecated` — slated for removal in `2.0.0`.** `callMethod`, `isMore()`,
-> and `getNext()` rely on the `restApi:v2` envelope field `next`, which
-> `restApi:v3` does not return. Prefer `b24.actions.v{2,3}.fetchList.make` for
-> custom-throttled iteration; that helper hides pagination for both API versions.
-
-Use when you need to control page sizes, pauses, or add custom throttling. Iterate until `isMore()` returns false, using `getNext($b24.getHttpClient())`.
+For a v3 method (e.g. `main.eventlog.list`):
 
 ```ts
-import { EnumCrmEntityTypeId, AjaxResult } from '@bitrix24/b24jssdk'
+interface LogItem { id: number, userId: number }
 
-async function loadAllContactsManual($b24: any) {
-  const all: any[] = []
+const generator = $b24.actions.v3.fetchList.make<LogItem>({
+  method: 'main.eventlog.list',
+  params: {
+    filter: [['timestampX', '>=', Text.toB24Format(sixMonthAgo)]],
+    select: ['id', 'userId']
+  },
+  idKey: 'id',
+  customKeyForResult: 'items',
+  requestId: 'log-stream',
+  limit: 200
+})
 
-  // First page (start defaults to 0)
-  let page: AjaxResult = await $b24.callMethod('crm.item.list', {
-    entityTypeId: EnumCrmEntityTypeId.contact,
-    order: { id: 'asc' },
-    select: ['id', 'name']
-  }, 0)
-
-  // Process first page
-  all.push(...(page.getData().result as any[]))
-
-  // Follow next cursors until done
-  while (page.isMore()) {
-    const next = await page.getNext($b24.getHttpClient())
-    if (next === false) break
-
-    // Optional: your throttling/backoff here
-    // await new Promise(r => setTimeout(r, 50))
-
-    all.push(...(next.getData().result as any[]))
-    page = next
-  }
-
-  return all
+for await (const chunk of generator) {
+  // …
 }
 ```
 
-Result and AjaxResult basics
+Notes:
+
+- `callList.make` / `fetchList.make` **ignore** a user-supplied `order` (cursor pagination orders by `idKey`). The action logs a warning. Use `filter` to narrow.
+- Errors inside `fetchList.make` throw `SdkError` (code `JSSDK_CORE_B24_FETCH_LIST_METHOD_API_V{2,3}`) on the `for await` iteration.
+
+### Result / AjaxResult basics
 
 ```ts
 import { AjaxError } from '@bitrix24/b24jssdk'
 
 try {
-  const res = await $b24.callMethod('crm.item.get', { entityTypeId: 1, id: 10 })
-  const payload = res.getData()                  // { result, time } — see Deprecation notice
-  const ok = res.isSuccess                       // boolean
-  // const total = res.getTotal()                // @deprecated, removed in 2.0.0; v3 has no `total`
+  const res = await $b24.actions.v3.call.make({
+    method: 'crm.item.get',
+    params: { entityTypeId: 1, id: 10 }
+  })
+  if (!res.isSuccess) {
+    console.error(res.getErrorMessages())
+    return
+  }
+  const payload = res.getData()           // { result: T, time: PayloadTime }
+  // res.getTotal() / res.isMore() — @deprecated, v2-only; removed in 2.0.0
 } catch (e) {
   if (e instanceof AjaxError) {
     console.error(e.code, e.description, e.status, e.requestInfo)
   } else {
-    console.error(e)
+    throw e
   }
 }
 ```
 
 
+## Rate limiting
+
+The SDK throttles automatically via `RestrictionManager`. Tune only when you have a specific workload need.
+
+```ts
+import { ParamsFactory } from '@bitrix24/b24jssdk'
+
+// At construction (B24Hook / B24OAuth)
+const $b24 = B24Hook.fromWebhookUrl(url, {
+  restrictionParams: ParamsFactory.getBatchProcessing()
+})
+
+// Or anytime after init (any entry point)
+await $b24.setRestrictionManagerParams(ParamsFactory.getEnterprise())
+
+// Partial override
+await $b24.setRestrictionManagerParams({
+  ...ParamsFactory.getDefault(),
+  rateLimit: { burstLimit: 100, drainRate: 3, adaptiveEnabled: true },
+  maxRetries: 5
+})
+```
+
+Available presets: `getDefault()`, `getEnterprise()`, `getBatchProcessing()`, `getRealtime()`, `fromTariffPlan(plan)`. `LicenseManager` (loaded via `useB24Helper()` + `LoadDataType.App`) auto-applies the enterprise preset on enterprise portals.
+
+
 ## Recommended generation patterns (for AI)
 
-- Frontend
-  - Always guard for frame context; initialize via await initializeB24Frame()
-  - On component unmount call $b24.destroy()
-  - For UI actions: prefer $b24.slider.openPath and handle mobile fallback via isOpenAtNewWindow in the returned StatusClose
-  - Use $b24.parent.fitWindow() after content changes
-  - Use $b24.options.appSet/userSet for settings persistence
-- Backend
-  - Construct B24Hook with B24Hook.fromWebhookUrl() when possible
-  - Use callListMethod/fetchListMethod for large lists
-  - Batch related calls with callBatch; chunk big arrays with callBatchByChunk
-- Logging
-  - Build once via LoggerBrowser.build(appName, isDev) and set to instances if needed
-- Types and enums
-  - Prefer exported enums (e.g., EnumCrmEntityTypeId) and types (ISODate, payload types)
+**Frontend:**
+
+- Always guard for frame context; initialise via `await initializeB24Frame()`.
+- On component unmount call `$b24.destroy()`.
+- For UI actions: prefer `$b24.slider.openPath` and handle mobile fallback via `isOpenAtNewWindow` in the returned `StatusClose`.
+- Call `$b24.parent.fitWindow()` after content changes.
+- Use `$b24.options.appSet/userSet` for settings persistence.
+- All REST calls go through `b24.actions.v{2,3}.*.make`.
+
+**Backend:**
+
+- Construct `B24Hook` with `B24Hook.fromWebhookUrl()` when possible.
+- For lists: `callList.make` (small known sets) or `fetchList.make` (large/unknown — preferred).
+- For groups of calls: `batch.make` (≤ 50 commands) or `batchByChunk.make` (any size).
+- For bulk migrations, pass `ParamsFactory.getBatchProcessing()` as `restrictionParams`.
+
+**OAuth:**
+
+- Always register `setCallbackRefreshAuth` to persist rotated tokens.
+- Catch `RefreshTokenError` specifically and redirect to re-auth.
+- Don't share a `B24OAuth` instance across users — tokens are user-scoped.
+
+**Logging:**
+
+- Build once via `LoggerBrowser.build(appName, isDev)` and attach via `$b24.setLogger(logger)`.
+
+**Types and enums:**
+
+- Prefer exported enums (e.g. `EnumCrmEntityTypeId`) and types (`ISODate`, payload types).
+- For new code prefer v3 methods; fall back to v2 only when v3 doesn't support the method (you'll get `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`).
 
 
-## UMD vs ESM quick cheat sheet
+## UMD vs ESM cheat sheet
 
-- UMD: window.B24Js global; load via unpkg CDN; use inside Bitrix24 iframe
-- ESM: import from '@bitrix24/b24jssdk'; works in browsers with bundlers and in Node (server-side) for B24Hook
+- **UMD:** `window.B24Js` global; load via unpkg CDN; use inside Bitrix24 iframe placements.
+- **ESM:** `import from '@bitrix24/b24jssdk'`; works in browsers with bundlers and in Node (server-side) for `B24Hook` / `B24OAuth`.
 
 
 ## Caveats and constraints
 
-- Frame-only APIs (dialogs, sliders, placement, parent, options, auth refresh) require running in Bitrix24 placement context
-- openPath automatically handles mobile devices by opening a new tab and polling for close status; check the returned StatusClose
-- Webhook (B24Hook) is not safe on the client; keep it on the server
-- Batch limits apply (SDK default chunk size is 50)
+- Frame-only APIs (`slider`, `dialog`, `placement`, `parent`, `options`, `auth.refreshAuth`) require Bitrix24 placement context — they don't exist on `B24Hook` / `B24OAuth`.
+- `slider.openPath` opens a new tab on mobile and polls for close — check `StatusClose.isOpenAtNewWindow`.
+- `B24Hook` is not safe on the client; keep it server-side.
+- Batch single-request limit is 50 commands — `batchByChunk.make` splits transparently.
 
 
 ## Export map (selected)
 
-- initializeB24Frame, B24Frame and its managers: auth, parent, slider, dialog, placement, options
-- B24Hook (+ B24Hook.fromWebhookUrl)
-- AbstractB24 helpers: callMethod, callBatch, callListMethod, fetchListMethod, callBatchByChunk, chunkArray
-- HTTP types and classes: AjaxResult, AjaxError, Result
-- LoggerBrowser, Text, Type, Browser, tools/use-formatters
-- Types/enums: http, b24, auth, payloads, user, slider, handler, placement, crm, catalog, bizproc, event, pull, b24-helper
+- `initializeB24Frame`, `B24Frame` and its managers: `auth`, `parent`, `slider`, `dialog`, `placement`, `options`
+- `B24Hook` (+ `B24Hook.fromWebhookUrl`)
+- `B24OAuth` (+ `RefreshTokenError`)
+- REST surface on `AbstractB24`: `actions.v{2,3}.{call,callList,fetchList,batch,batchByChunk}`, `tools.{healthCheck,ping}`, `setRestrictionManagerParams`, `getHttpClient`, `destroy`
+- Action option types: `ActionCallV{2,3}`, `ActionCallListV{2,3}`, `ActionFetchListV{2,3}`, `ActionBatchV{2,3}`, `ActionBatchByChunkV{2,3}`, `IB24BatchOptions`, `BatchCommandsArrayUniversal`, `BatchCommandsObjectUniversal`, `BatchNamedCommandsUniversal`
+- Result/error: `AjaxResult`, `AjaxError`, `Result`, `SdkError`, `RefreshTokenError`
+- Limiters: `RestrictionManager`, `RateLimiter`, `OperatingLimiter`, `AdaptiveDelayer`, `ParamsFactory`, `RestrictionParams`
+- `LoggerBrowser`, `LoggerFactory`, `Text`, `Type`, `Browser`, `useFormatters`, `pick`, `omit`, `getEnumValue`
+- Types/enums: `EnumCrmEntityTypeId`, `ApiVersion`, `ISODate`, `TypeCallParams`, plus modules `types/{http, b24, auth, payloads, user, slider, handler, placement, crm, catalog, bizproc, event, pull, b24-helper}`
+
+Deprecated re-exports (removed in 2.0.0): `AbstractB24.callMethod`, `callBatch`, `callListMethod`, `fetchListMethod`, `callBatchByChunk`, `chunkArray`; `AjaxResult.isMore`, `hasMore`, `getNext`, `fetchNext`, `getTotal`.
 
 
 ---
-This document is based on the SDK source in packages/jssdk/src and the docs under docs/reference and docs/guide. Use it as the authoritative prompt for generating code with this SDK.
+
+This document is based on the SDK source in `packages/jssdk/src` and the docs under `docs/content/docs/`. Use it as the authoritative prompt for generating code with this SDK. For agent-oriented routing (when to load which detailed reference), pair it with [`skills/b24-jssdk/SKILL.md`](../../skills/b24-jssdk/SKILL.md).
 
 
 ## Extras for AI agents (helpers, pull, core, tools)
 
-### Helper Methods (high-level data access)
+### Helper methods (high-level data access)
 
-- useB24Helper: lifecycle for helpers and Pull client in frame apps (see section above)
-- B24HelperManager: container for helper managers (profile/app/payment/license/currency/options) exposed via useB24Helper
-- ProfileManager: `helper.profileInfo.data` provides current user info
-- AppManager: `helper.appInfo.data` and `helper.appInfo.statusCode`
-- LicenseManager: adjusts Http Restriction Manager for enterprise automatically
-- CurrencyManager: formats amounts for a currency and language
-  
+- **`useB24Helper`** — lifecycle for helpers and Pull client in frame apps (see above).
+- **`B24HelperManager`** — container for `profile`, `app`, `payment`, `license`, `currency`, `options` managers; exposed via `useB24Helper`.
+- **`ProfileManager`** — `helper.profileInfo.data` provides current user info.
+- **`AppManager`** — `helper.appInfo.data` and `helper.appInfo.statusCode`.
+- **`LicenseManager`** — adjusts `RestrictionManager` for enterprise portals automatically.
+- **`CurrencyManager`** — formats amounts for a currency and language:
+
   ```ts
   const name = helper.currency.getCurrencyFullName('USD', 'en')
-  const literal = helper.currency.getCurrencyLiteral('USD', 'en') // currency symbol/wording
+  const literal = helper.currency.getCurrencyLiteral('USD', 'en')
   const price = helper.currency.format(1234.56, 'USD', 'en')
   ```
-- OptionsManager (helper level): bulk save options to REST + optional pull notification
- 
-  
+
+- **`OptionsManager`** (helper level) — bulk save options + optional Pull notification:
+
   ```ts
-  await helper.appOptions.save({ featureFlags: helper.appOptions.encode({ a: 1 }) }, {
-    moduleId: 'application',
-    command: 'FEATURES_UPDATED',
-    params: { source: 'app' }
-  })
+  await helper.appOptions.save(
+    { featureFlags: helper.appOptions.encode({ a: 1 }) },
+    {
+      moduleId: 'application',
+      command: 'FEATURES_UPDATED',
+      params: { source: 'app' }
+    }
+  )
   const cfg = helper.appOptions.getJsonObject('featureFlags', {})
   ```
 
 ### Push and Pull
 
-- Pull client helpers are provided via useB24Helper
-  
+- Pull client helpers are provided via `useB24Helper`:
+
   ```ts
   const { usePullClient, useSubscribePullClient, startPullClient } = useB24Helper()
   usePullClient('prefix')
@@ -571,32 +747,32 @@ This document is based on the SDK source in packages/jssdk/src and the docs unde
 
 ### Core utilities
 
-- AbstractB24: shared REST helpers (callMethod/batch/list/fetch/chunk)
-- Http: low-level transport; supports restriction throttling and auth refresh
-- RestrictionManager: automatic throttling to respect Bitrix24 limits
+- **`AbstractB24`** — shared base: exposes `actions`, `tools`, `setRestrictionManagerParams`, `getHttpClient`, `destroy`.
+- **`Http` (v2 + v3)** — low-level transport; supports restriction throttling and auth refresh. Not normally used directly.
+- **`RestrictionManager`** — automatic throttling to respect Bitrix24 limits:
 
-// fix
   ```ts
-  // Example: increase limits for enterprise (done automatically by LicenseManager)
-  // $b24.getHttpClient().setRestrictionManagerParams(RestrictionManagerParamsForEnterprise)
+  import { ParamsFactory } from '@bitrix24/b24jssdk'
+  // Done automatically by LicenseManager when useB24Helper is in scope:
+  await $b24.setRestrictionManagerParams(ParamsFactory.getEnterprise())
   ```
- 
-- Unique ID Generator: request IDs are appended automatically via Http
-- Result / AjaxResult: uniform result objects, error aggregation. (Legacy paging helpers `isMore`/`getNext`/`getTotal` are `@deprecated` for `2.0.0` — see Deprecation notice.)
-- Language List and LoggerBrowser
 
-### Tools
+- **Unique ID generator** — request IDs are appended automatically via `Http`. Pass an explicit `requestId` in `make(options)` for stable correlation in logs.
+- **`Result` / `AjaxResult`** — uniform result objects, error aggregation. Legacy paging helpers `isMore` / `getNext` / `getTotal` are `@deprecated` for `2.0.0` — see Deprecation notice.
+- **Language list** and **`LoggerBrowser`** — i18n + logging.
 
-- Type: runtime type helpers (isStringFilled, etc.)
-- Text: dates (Luxon), numbers (numberFormat), UUID v7, encode/decode, case transforms
-  
+### Tools (utilities)
+
+- **`Type`** — runtime type helpers (`isStringFilled`, `isPlainObject`, …).
+- **`Text`** — dates (Luxon), numbers (`numberFormat`), UUID v7, encode/decode, case transforms:
+
   ```ts
-  import Text from '@bitrix24/b24jssdk'
+  import { Text } from '@bitrix24/b24jssdk'
   const dt = Text.toDateTime('2024-01-01T10:00:00Z')
   const s = Text.numberFormat(12345.678, 2, '.', ' ')
   const id = Text.getUuidRfc4122()
   ```
- 
-- Browser: lightweight browser utilities
-- useFormatters: number/date formatting hooks
-- pick/omit/getEnumValue: object and enum helpers
+
+- **`Browser`** — lightweight browser utilities.
+- **`useFormatters`** — number/date formatting hooks.
+- **`pick` / `omit` / `getEnumValue`** — object and enum helpers.

--- a/packages/jssdk/README-AI.md
+++ b/packages/jssdk/README-AI.md
@@ -691,7 +691,7 @@ Available presets: `getDefault()`, `getEnterprise()`, `getBatchProcessing()`, `g
 **Types and enums:**
 
 - Prefer exported enums (e.g. `EnumCrmEntityTypeId`) and types (`ISODate`, payload types).
-- For new code prefer v3 methods; fall back to v2 only when v3 doesn't support the method (you'll get `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`).
+- Pick API version by method. v3 currently supports only `tasks.task.*`, `main.eventlog.*`, and meta endpoints (`batch`, `scopes`, `documentation`); everything else (CRM, IM, user, profile, placement, options, settings) is v2-only. See the v3 list in `core/version-manager.ts`. Calling a v2-only method via `actions.v3.*.make` throws `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3` — default to v2 unless the method is explicitly on the v3 list.
 
 
 ## UMD vs ESM cheat sheet

--- a/skills/b24-jssdk/SKILL.md
+++ b/skills/b24-jssdk/SKILL.md
@@ -26,7 +26,7 @@ Ships ESM + UMD only since v0.4.0. Nuxt users should prefer the [`@bitrix24/b24j
 
 This skill teaches **when to use which entry point and method** and **how to wire things up correctly**. For exact signatures, props, and payload shapes, prefer these primary sources:
 
-- [`packages/jssdk/README-AI.md`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/README-AI.md) — code-oriented API guide. **Note:** its examples currently use the deprecated `$b24.callMethod(...)` family. Translate to `$b24.actions.v{2,3}.*.make({ ... })` when generating new code; see [conventions](references/guidelines/conventions.md).
+- [`packages/jssdk/README-AI.md`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/README-AI.md) — code-oriented API guide. Aligned with the current `b24.actions.*` API and the deprecation notice at the top. Use this when generating SDK code.
 - [Documentation site](https://bitrix24.github.io/b24jssdk/) — public docs; pages under `/reference/` mirror types and managers.
 - [Bitrix24 REST documentation](https://apidocs.bitrix24.com/) — for REST method names, params, and payload shapes.
 
@@ -37,7 +37,7 @@ This skill teaches **when to use which entry point and method** and **how to wir
 3. **Cleanup on unmount** — call `$b24.destroy()` when a frame component/page unmounts. The Pull client and message listeners hold references otherwise.
 4. **Use named imports only** — the SDK has no default export and is `sideEffects: false`. Never destructure or rebind types under different names without need; tree-shaking depends on direct imports.
 5. **Use the action managers, not the deprecated `call*` methods** — write `$b24.actions.v3.call.make({ method, params })` (or `v2.call.make` for legacy CRM-style methods), not `$b24.callMethod(...)`. See [conventions](references/guidelines/conventions.md).
-6. **Treat `Result` / `AjaxResult` as the uniform return shape** — `getData()`, `isSuccess`, `getErrorMessages()`, `getTotal()`. `AjaxResult` adds `isMore()` / `getNext()` for manual paging when needed.
+6. **Treat `Result` / `AjaxResult` as the uniform return shape** — `getData()`, `isSuccess`, `getErrorMessages()`. `AjaxResult` adds `isMore()` / `getNext()` / `getTotal()` for **v2-only** manual paging — these are `@deprecated` and v3 has no equivalent (use `callList.make` / `fetchList.make` everywhere, and `aggregate` for counts in v3).
 7. **Pick the right list strategy** — `callList.make` only for small known sets (< 1000), `fetchList.make` for streaming, `call.make` + `AjaxResult.getNext()` for custom paging. See [list-pagination](references/recipes/list-pagination.md).
 8. **Respect rate limits** — the built-in `RestrictionManager` throttles automatically; for enterprise portals the `LicenseManager` swaps in higher-limit params. See [rate-limiting](references/guidelines/rate-limiting.md).
 

--- a/skills/b24-jssdk/SKILL.md
+++ b/skills/b24-jssdk/SKILL.md
@@ -11,7 +11,14 @@ JS/TS SDK for the Bitrix24 REST API. Three concrete entry points share one REST 
 - **`B24Hook`** — server-side incoming webhook; auth is embedded in the URL.
 - **`B24OAuth`** — OAuth-based local apps; manages access/refresh tokens.
 
-All three expose the same calling primitives: `callMethod`, `callBatch`, `callListMethod`, `fetchListMethod`, `callBatchByChunk`. Results are uniform `Result` / `AjaxResult` objects.
+All three expose the same REST surface via two manager namespaces:
+
+- `b24.actions.v{2,3}.{call, callList, fetchList, batch, batchByChunk}.make(options)` — REST calls.
+- `b24.tools.{healthCheck, ping}.make(options?)` — utility checks.
+
+Results are uniform `Result` / `AjaxResult` / `CallBatchResult` objects.
+
+> The legacy `$b24.callMethod`, `callBatch`, `callListMethod`, `fetchListMethod`, `callBatchByChunk` still exist for backwards compatibility but are deprecated and **will be removed in v2.0.0**. New code uses the action managers.
 
 Ships ESM + UMD only since v0.4.0. Nuxt users should prefer the [`@bitrix24/b24jssdk-nuxt`](references/recipes/nuxt-module.md) module.
 
@@ -19,19 +26,20 @@ Ships ESM + UMD only since v0.4.0. Nuxt users should prefer the [`@bitrix24/b24j
 
 This skill teaches **when to use which entry point and method** and **how to wire things up correctly**. For exact signatures, props, and payload shapes, prefer these primary sources:
 
-- [`packages/jssdk/README-AI.md`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/README-AI.md) — code-oriented API guide (load this when generating SDK usage code).
+- [`packages/jssdk/README-AI.md`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/README-AI.md) — code-oriented API guide. **Note:** its examples currently use the deprecated `$b24.callMethod(...)` family. Translate to `$b24.actions.v{2,3}.*.make({ ... })` when generating new code; see [conventions](references/guidelines/conventions.md).
 - [Documentation site](https://bitrix24.github.io/b24jssdk/) — public docs; pages under `/reference/` mirror types and managers.
 - [Bitrix24 REST documentation](https://apidocs.bitrix24.com/) — for REST method names, params, and payload shapes.
 
 ## Core rules (always apply)
 
 1. **Pick the right entry point** — see [entry-points](references/guidelines/entry-points.md). `B24Frame` for iframe placements, `B24Hook` for server scripts, `B24OAuth` for OAuth local apps. Never use `B24Hook` from the browser (it warns and leaks the secret).
-2. **Always `await` the initializer** — `initializeB24Frame()`, `B24Hook.fromWebhookUrl()`, or `B24OAuth` setup must complete before any `call*` method.
+2. **Always `await` the initializer** — `initializeB24Frame()`, `B24Hook.fromWebhookUrl()`, or `B24OAuth` setup must complete before any REST call.
 3. **Cleanup on unmount** — call `$b24.destroy()` when a frame component/page unmounts. The Pull client and message listeners hold references otherwise.
 4. **Use named imports only** — the SDK has no default export and is `sideEffects: false`. Never destructure or rebind types under different names without need; tree-shaking depends on direct imports.
-5. **Treat `Result` / `AjaxResult` as the uniform return shape** — `getData()`, `isSuccess`, `isMore()`, `getNext()`, `getTotal()`, `getErrors()`. See [conventions](references/guidelines/conventions.md).
-6. **Pick the right list strategy** — `callListMethod` only for small known sets (< 1000), `fetchListMethod` for streaming, manual `callMethod` + `getNext()` for custom paging. See [list-pagination](references/recipes/list-pagination.md).
-7. **Respect rate limits** — the built-in `RestrictionManager` throttles automatically; for enterprise portals the `LicenseManager` swaps in higher-limit params. See [rate-limiting](references/guidelines/rate-limiting.md).
+5. **Use the action managers, not the deprecated `call*` methods** — write `$b24.actions.v3.call.make({ method, params })` (or `v2.call.make` for legacy CRM-style methods), not `$b24.callMethod(...)`. See [conventions](references/guidelines/conventions.md).
+6. **Treat `Result` / `AjaxResult` as the uniform return shape** — `getData()`, `isSuccess`, `getErrorMessages()`, `getTotal()`. `AjaxResult` adds `isMore()` / `getNext()` for manual paging when needed.
+7. **Pick the right list strategy** — `callList.make` only for small known sets (< 1000), `fetchList.make` for streaming, `call.make` + `AjaxResult.getNext()` for custom paging. See [list-pagination](references/recipes/list-pagination.md).
+8. **Respect rate limits** — the built-in `RestrictionManager` throttles automatically; for enterprise portals the `LicenseManager` swaps in higher-limit params. See [rate-limiting](references/guidelines/rate-limiting.md).
 
 ## How to use this skill
 
@@ -105,7 +113,14 @@ The module registers a runtime plugin only — it does **not** wrap or rename SD
 ```html
 <script src="https://unpkg.com/@bitrix24/b24jssdk@latest/dist/umd/index.min.js"></script>
 <script>
-  const $b24 = await B24Js.initializeB24Frame()
+  document.addEventListener('DOMContentLoaded', async () => {
+    const $b24 = await B24Js.initializeB24Frame()
+    const response = await $b24.actions.v2.call.make({
+      method: 'crm.item.list',
+      params: { entityTypeId: B24Js.EnumCrmEntityTypeId.company, select: ['id', 'title'] }
+    })
+    console.log(response.getData().result.items)
+  })
 </script>
 ```
 

--- a/skills/b24-jssdk/SKILL.md
+++ b/skills/b24-jssdk/SKILL.md
@@ -36,7 +36,7 @@ This skill teaches **when to use which entry point and method** and **how to wir
 2. **Always `await` the initializer** — `initializeB24Frame()`, `B24Hook.fromWebhookUrl()`, or `B24OAuth` setup must complete before any REST call.
 3. **Cleanup on unmount** — call `$b24.destroy()` when a frame component/page unmounts. The Pull client and message listeners hold references otherwise.
 4. **Use named imports only** — the SDK has no default export and is `sideEffects: false`. Never destructure or rebind types under different names without need; tree-shaking depends on direct imports.
-5. **Use the action managers, not the deprecated `call*` methods** — write `$b24.actions.v3.call.make({ method, params })` (or `v2.call.make` for legacy CRM-style methods), not `$b24.callMethod(...)`. See [conventions](references/guidelines/conventions.md).
+5. **Use the action managers, not the deprecated `call*` methods** — write `$b24.actions.v{2,3}.call.make({ method, params })`, not `$b24.callMethod(...)`. **Default to v2** — most methods (CRM, IM, user, profile, …) are v2-only today. Reach for v3 only when calling `tasks.task.*` / `main.eventlog.*` / meta endpoints. See [conventions](references/guidelines/conventions.md), [rest-api-v2](references/recipes/rest-api-v2.md), [rest-api-v3](references/recipes/rest-api-v3.md).
 6. **Treat `Result` / `AjaxResult` as the uniform return shape** — `getData()`, `isSuccess`, `getErrorMessages()`. `AjaxResult` adds `isMore()` / `getNext()` / `getTotal()` for **v2-only** manual paging — these are `@deprecated` and v3 has no equivalent (use `callList.make` / `fetchList.make` everywhere, and `aggregate` for counts in v3).
 7. **Pick the right list strategy** — `callList.make` only for small known sets (< 1000), `fetchList.make` for streaming, `call.make` + `AjaxResult.getNext()` for custom paging. See [list-pagination](references/recipes/list-pagination.md).
 8. **Respect rate limits** — the built-in `RestrictionManager` throttles automatically; for enterprise portals the `LicenseManager` swaps in higher-limit params. See [rate-limiting](references/guidelines/rate-limiting.md).
@@ -55,15 +55,25 @@ Based on the task, load the relevant reference files **before writing any code**
 - [logger](references/guidelines/logger.md) — `LoggerBrowser.build`, dev mode, `LoggerFactory`, default null logger.
 
 **Recipes** — complete patterns for common tasks:
+
+REST surface (mirror pair):
+- [rest-api-v2](references/recipes/rest-api-v2.md) — `b24.actions.v2.{call, callList, fetchList, batch, batchByChunk}` — full code reference. Covers most methods today (CRM, IM, user, profile, …).
+- [rest-api-v3](references/recipes/rest-api-v3.md) — `b24.actions.v3.*` mirror. v3 currently supports a small set (`tasks.task.*`, `main.eventlog.*`, meta endpoints); prefer v2 elsewhere.
+
+Decision pages (point at the right v2/v3 example):
+- [batch-calls](references/recipes/batch-calls.md) — when to batch vs single, input shapes, halt-on-error.
+- [list-pagination](references/recipes/list-pagination.md) — `callList` vs `fetchList` vs manual paging.
+
+Entry points & integrations:
 - [frame-apps](references/recipes/frame-apps.md) — `initializeB24Frame()` boot, lifecycle, basic REST calls.
 - [webhook-server](references/recipes/webhook-server.md) — Node server with `B24Hook.fromWebhookUrl()`.
 - [oauth-apps](references/recipes/oauth-apps.md) — `B24OAuth` setup, refresh-token errors.
-- [batch-calls](references/recipes/batch-calls.md) — `callBatch` (object + array forms), `callBatchByChunk`, halt-on-error.
-- [list-pagination](references/recipes/list-pagination.md) — `callListMethod`, `fetchListMethod`, manual `callMethod` + `getNext()`.
+- [nuxt-module](references/recipes/nuxt-module.md) — `@bitrix24/b24jssdk-nuxt` module setup.
+
+Frame & helpers:
 - [ui-integrations](references/recipes/ui-integrations.md) — sliders, dialogs, parent window, placement, options (frame-only).
 - [helper-manager](references/recipes/helper-manager.md) — `useB24Helper()`, profile/app/currency/license/options managers.
 - [pull-client](references/recipes/pull-client.md) — Pull (push) subscription, channel manager.
-- [nuxt-module](references/recipes/nuxt-module.md) — `@bitrix24/b24jssdk-nuxt` module setup.
 
 **Quick reference:**
 - [api-surface](references/api-surface.md) — categorized index of public exports — entry points, REST helpers, types/enums, tools.
@@ -72,13 +82,14 @@ Based on the task, load the relevant reference files **before writing any code**
 
 | Task | Load these references |
 |---|---|
-| Build a Bitrix24 frame placement (iframe app) | entry-points, conventions, frame-apps |
+| Build a Bitrix24 frame placement (iframe app) | entry-points, conventions, frame-apps, rest-api-v2 |
 | Open sliders / dialogs / interact with portal UI | conventions, ui-integrations |
-| Server-side script / cron / Node service against Bitrix24 | entry-points, conventions, webhook-server |
-| OAuth-based local app (refresh tokens) | entry-points, conventions, oauth-apps |
+| Server-side script / cron / Node service against Bitrix24 | entry-points, conventions, webhook-server, rest-api-v2 |
+| OAuth-based local app (refresh tokens) | entry-points, conventions, oauth-apps, rest-api-v2 |
 | Use the SDK from a Nuxt app | conventions, frame-apps, nuxt-module |
-| Fetch large data sets from REST | conventions, list-pagination |
-| Call multiple related methods efficiently | conventions, batch-calls |
+| Fetch large data sets from REST | conventions, list-pagination, rest-api-v2 (or rest-api-v3) |
+| Call multiple related methods efficiently | conventions, batch-calls, rest-api-v2 (or rest-api-v3) |
+| Call a `tasks.task.*` / `main.eventlog.*` method | conventions, rest-api-v3 |
 | Show portal data (current user, currency, options) | conventions, helper-manager |
 | React to real-time events from the portal | conventions, helper-manager, pull-client |
 | Handle errors / write retry logic | conventions, error-handling, rate-limiting |

--- a/skills/b24-jssdk/SKILL.md
+++ b/skills/b24-jssdk/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: b24-jssdk
+description: Build Bitrix24 REST integrations with @bitrix24/b24jssdk — frame placements, server-side webhooks, OAuth apps, real-time Pull events, and the Nuxt module. Use when calling the Bitrix24 REST API from JS/TS code or generating SDK usage examples.
+---
+
+# Bitrix24 JS SDK
+
+JS/TS SDK for the Bitrix24 REST API. Three concrete entry points share one REST surface (`AbstractB24`):
+
+- **`B24Frame`** — runs inside a Bitrix24 placement iframe; auth comes from the parent window.
+- **`B24Hook`** — server-side incoming webhook; auth is embedded in the URL.
+- **`B24OAuth`** — OAuth-based local apps; manages access/refresh tokens.
+
+All three expose the same calling primitives: `callMethod`, `callBatch`, `callListMethod`, `fetchListMethod`, `callBatchByChunk`. Results are uniform `Result` / `AjaxResult` objects.
+
+Ships ESM + UMD only since v0.4.0. Nuxt users should prefer the [`@bitrix24/b24jssdk-nuxt`](references/recipes/nuxt-module.md) module.
+
+## Authoritative API references
+
+This skill teaches **when to use which entry point and method** and **how to wire things up correctly**. For exact signatures, props, and payload shapes, prefer these primary sources:
+
+- [`packages/jssdk/README-AI.md`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/README-AI.md) — code-oriented API guide (load this when generating SDK usage code).
+- [Documentation site](https://bitrix24.github.io/b24jssdk/) — public docs; pages under `/reference/` mirror types and managers.
+- [Bitrix24 REST documentation](https://apidocs.bitrix24.com/) — for REST method names, params, and payload shapes.
+
+## Core rules (always apply)
+
+1. **Pick the right entry point** — see [entry-points](references/guidelines/entry-points.md). `B24Frame` for iframe placements, `B24Hook` for server scripts, `B24OAuth` for OAuth local apps. Never use `B24Hook` from the browser (it warns and leaks the secret).
+2. **Always `await` the initializer** — `initializeB24Frame()`, `B24Hook.fromWebhookUrl()`, or `B24OAuth` setup must complete before any `call*` method.
+3. **Cleanup on unmount** — call `$b24.destroy()` when a frame component/page unmounts. The Pull client and message listeners hold references otherwise.
+4. **Use named imports only** — the SDK has no default export and is `sideEffects: false`. Never destructure or rebind types under different names without need; tree-shaking depends on direct imports.
+5. **Treat `Result` / `AjaxResult` as the uniform return shape** — `getData()`, `isSuccess`, `isMore()`, `getNext()`, `getTotal()`, `getErrors()`. See [conventions](references/guidelines/conventions.md).
+6. **Pick the right list strategy** — `callListMethod` only for small known sets (< 1000), `fetchListMethod` for streaming, manual `callMethod` + `getNext()` for custom paging. See [list-pagination](references/recipes/list-pagination.md).
+7. **Respect rate limits** — the built-in `RestrictionManager` throttles automatically; for enterprise portals the `LicenseManager` swaps in higher-limit params. See [rate-limiting](references/guidelines/rate-limiting.md).
+
+## How to use this skill
+
+Based on the task, load the relevant reference files **before writing any code**. Don't load everything — only what's needed.
+
+### Reference files
+
+**Guidelines** — decisions and conventions:
+- [entry-points](references/guidelines/entry-points.md) — decision matrix: `B24Frame` vs `B24Hook` vs `B24OAuth`, runtime constraints.
+- [conventions](references/guidelines/conventions.md) — imports, named exports, `Result` / `AjaxResult` shape, lifecycle, common pitfalls.
+- [error-handling](references/guidelines/error-handling.md) — `AjaxError`, `SdkError`, batch error aggregation, retry strategies.
+- [rate-limiting](references/guidelines/rate-limiting.md) — `RestrictionManager`, `OperatingLimiter`, `AdaptiveDelayer`, `ParamsFactory` presets.
+- [logger](references/guidelines/logger.md) — `LoggerBrowser.build`, dev mode, `LoggerFactory`, default null logger.
+
+**Recipes** — complete patterns for common tasks:
+- [frame-apps](references/recipes/frame-apps.md) — `initializeB24Frame()` boot, lifecycle, basic REST calls.
+- [webhook-server](references/recipes/webhook-server.md) — Node server with `B24Hook.fromWebhookUrl()`.
+- [oauth-apps](references/recipes/oauth-apps.md) — `B24OAuth` setup, refresh-token errors.
+- [batch-calls](references/recipes/batch-calls.md) — `callBatch` (object + array forms), `callBatchByChunk`, halt-on-error.
+- [list-pagination](references/recipes/list-pagination.md) — `callListMethod`, `fetchListMethod`, manual `callMethod` + `getNext()`.
+- [ui-integrations](references/recipes/ui-integrations.md) — sliders, dialogs, parent window, placement, options (frame-only).
+- [helper-manager](references/recipes/helper-manager.md) — `useB24Helper()`, profile/app/currency/license/options managers.
+- [pull-client](references/recipes/pull-client.md) — Pull (push) subscription, channel manager.
+- [nuxt-module](references/recipes/nuxt-module.md) — `@bitrix24/b24jssdk-nuxt` module setup.
+
+**Quick reference:**
+- [api-surface](references/api-surface.md) — categorized index of public exports — entry points, REST helpers, types/enums, tools.
+
+### Routing table
+
+| Task | Load these references |
+|---|---|
+| Build a Bitrix24 frame placement (iframe app) | entry-points, conventions, frame-apps |
+| Open sliders / dialogs / interact with portal UI | conventions, ui-integrations |
+| Server-side script / cron / Node service against Bitrix24 | entry-points, conventions, webhook-server |
+| OAuth-based local app (refresh tokens) | entry-points, conventions, oauth-apps |
+| Use the SDK from a Nuxt app | conventions, frame-apps, nuxt-module |
+| Fetch large data sets from REST | conventions, list-pagination |
+| Call multiple related methods efficiently | conventions, batch-calls |
+| Show portal data (current user, currency, options) | conventions, helper-manager |
+| React to real-time events from the portal | conventions, helper-manager, pull-client |
+| Handle errors / write retry logic | conventions, error-handling, rate-limiting |
+| Tune throttling for high-volume scripts | rate-limiting |
+| Set up logging | logger |
+| General SDK usage / "where is X exported from" | api-surface, conventions |
+
+## Installation
+
+### Core SDK (any JS/TS project)
+
+```bash
+pnpm add @bitrix24/b24jssdk
+```
+
+```ts
+import { initializeB24Frame, B24Hook, B24OAuth } from '@bitrix24/b24jssdk'
+```
+
+Supported Node versions: `^18`, `^20`, or `>=22`.
+
+### Nuxt module (preferred for Nuxt apps)
+
+```bash
+npx nuxi module add @bitrix24/b24jssdk-nuxt
+```
+
+The module registers a runtime plugin only — it does **not** wrap or rename SDK exports. Import the SDK as usual; the plugin handles SSR-safe access. See [nuxt-module](references/recipes/nuxt-module.md).
+
+### UMD (CDN, no bundler)
+
+```html
+<script src="https://unpkg.com/@bitrix24/b24jssdk@latest/dist/umd/index.min.js"></script>
+<script>
+  const $b24 = await B24Js.initializeB24Frame()
+</script>
+```
+
+The global is `window.B24Js`. UMD is intended for static iframe placements that can't run a bundler — server-side `B24Hook` and OAuth apps should always use ESM.

--- a/skills/b24-jssdk/references/api-surface.md
+++ b/skills/b24-jssdk/references/api-surface.md
@@ -25,7 +25,7 @@ Every entry point exposes `actions.v2` and `actions.v3` managers — independent
 | `BatchV2` / `BatchV3` | `b24.actions.v2.batch` / `v3.batch` | `Promise<CallBatchResult<T>>` |
 | `BatchByChunkV2` / `BatchByChunkV3` | `b24.actions.v2.batchByChunk` / `v3.batchByChunk` | `Promise<Result<T[]>>` |
 
-Default to v2; v3 currently supports only `tasks.task.*`, `main.eventlog.*`, and meta endpoints — see [rest-api-v3 → When to use](recipes/rest-api-v3.md#when-to-use-v3--and-when-not-to).
+Default to v2; v3 currently supports only `tasks.task.*`, `main.eventlog.*`, and meta endpoints — see [rest-api-v3](recipes/rest-api-v3.md).
 
 Options types (re-exported from the package root): `ActionCallV2`, `ActionCallV3`, `ActionCallListV2`, `ActionCallListV3`, `ActionFetchListV2`, `ActionFetchListV3`, `ActionBatchV2`, `ActionBatchV3`, `ActionBatchByChunkV2`, `ActionBatchByChunkV3`, `IB24BatchOptions`, `BatchCommandsArrayUniversal`, `BatchCommandsObjectUniversal`, `BatchNamedCommandsUniversal`.
 

--- a/skills/b24-jssdk/references/api-surface.md
+++ b/skills/b24-jssdk/references/api-surface.md
@@ -1,0 +1,98 @@
+# API surface
+
+Categorized index of public exports from `@bitrix24/b24jssdk` — useful for finding the right import name. For full signatures, parameters, and return shapes consult [`packages/jssdk/README-AI.md`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/README-AI.md), the [docs site](https://bitrix24.github.io/b24jssdk/), or the source under `packages/jssdk/src/`.
+
+## Entry points & loaders
+
+| Export | Purpose | Recipe |
+|---|---|---|
+| `initializeB24Frame()` | Boot a `B24Frame` (parent-window handshake, dedupes concurrent inits) | [frame-apps](recipes/frame-apps.md) |
+| `B24Frame` | iframe placement entry point — UI managers + REST | [frame-apps](recipes/frame-apps.md) |
+| `B24Hook` | Webhook-based server entry point | [webhook-server](recipes/webhook-server.md) |
+| `B24Hook.fromWebhookUrl(url)` | Construct from a full webhook URL | [webhook-server](recipes/webhook-server.md) |
+| `B24OAuth` | OAuth-based local app entry point | [oauth-apps](recipes/oauth-apps.md) |
+| `AbstractB24` | Shared REST surface (`callMethod`, `callBatch`, `callListMethod`, `fetchListMethod`, `callBatchByChunk`, `chunkArray`) — the base of the three concrete classes | [conventions](guidelines/conventions.md) |
+
+## Helpers & Pull
+
+| Export | Purpose |
+|---|---|
+| `useB24Helper()` | Closure-based composable that wires helper lifecycle + Pull |
+| `B24HelperManager` | Underlying helper container (profile / app / payment / license / currency / options) |
+| `LoadDataType` | Enum of preload datasets for `initB24Helper` |
+| `usePullClient`, `useSubscribePullClient`, `startPullClient` | Pull subscription helpers (returned from `useB24Helper()`) |
+
+See [helper-manager](recipes/helper-manager.md) and [pull-client](recipes/pull-client.md).
+
+## REST results
+
+| Export | Purpose |
+|---|---|
+| `Result` | Aggregated batch / list result (`getData`, `isSuccess`, `getErrors`, `getTotal`) |
+| `AjaxResult` | Single-call result (`getData`, `isMore`, `getNext`) |
+| `AjaxError` | REST/transport error (`code`, `description`, `status`, `requestInfo`) |
+| `SdkError` | SDK-internal error |
+
+See [conventions](guidelines/conventions.md) and [error-handling](guidelines/error-handling.md).
+
+## Limiters
+
+| Export | Purpose |
+|---|---|
+| `RestrictionManager` | Orchestrates rate / operating / adaptive limiters |
+| `RateLimiter` | Bucketed REST quota limiter |
+| `OperatingLimiter` | Guards bursty `OPERATING` errors |
+| `AdaptiveDelayer` | Backs off on temporary overload |
+| `ParamsFactory` | Preset limiter params (`getDefault()`, enterprise preset) |
+
+See [rate-limiting](guidelines/rate-limiting.md).
+
+## Tools
+
+| Export | Purpose |
+|---|---|
+| `Text` | Luxon-backed dates, number/format helpers, UUID v7 |
+| `Type` | Runtime type guards (`isStringFilled`, `isPlainObject`, …) |
+| `Browser` | Lightweight browser environment helpers |
+| `useFormatters` | Number/date formatter hook |
+| `pick`, `omit`, `getEnumValue` | Object/enum helpers |
+
+## Logging
+
+| Export | Purpose |
+|---|---|
+| `LoggerBrowser` | Default browser/Node logger with dev-mode gate (`build(name, isDev)`) |
+| `LoggerFactory` | Per-component logger factory (used internally by SDK modules) |
+
+See [logger](guidelines/logger.md).
+
+## Types & enums (frequently used)
+
+| Export | Purpose |
+|---|---|
+| `EnumCrmEntityTypeId` | CRM entity type ids (`company`, `contact`, `deal`, …) |
+| `ISODate` | ISO date string brand for `Text.toDateTime` |
+| `TypePullMessage` | Pull message shape |
+| `Messages`, `defineLocale`, `extendLocale` | i18n primitives (mainly used by `b24ui-nuxt` integrations) |
+| Type modules: `types/crm`, `types/catalog`, `types/bizproc`, `types/event`, `types/placement`, `types/payloads`, `types/pull`, `types/auth`, `types/handler`, `types/slider`, `types/user`, `types/b24`, `types/http`, `types/limiters`, `types/b24-helper`, `types/common` | Domain-specific types |
+
+The SDK re-exports everything from the package root — always `import { ... } from '@bitrix24/b24jssdk'`. Don't deep-import (`@bitrix24/b24jssdk/dist/...`).
+
+## Source map (for browsing)
+
+```
+packages/jssdk/src/
+├── core/                # AbstractB24, Result, SdkError, http/, language/, version-manager
+├── frame/               # B24Frame + UI managers (auth, parent, slider, dialog, placement, options)
+├── hook/                # B24Hook
+├── oauth/               # B24OAuth
+├── helper/              # useB24Helper, B24HelperManager, profile/app/currency/license/options/payment managers
+├── pullClient/          # Pull WebSocket + long-polling, channel manager, JSON-RPC, protobuf
+├── tools/               # Text, Type, Browser, useFormatters, pick/omit, scroll-size, environment
+├── types/               # public types (crm, catalog, bizproc, event, placement, payloads, pull, …)
+├── logger/              # LoggerBrowser, LoggerFactory
+├── loader-b24frame.ts   # initializeB24Frame
+└── index.ts             # public re-exports (this is the contract)
+```
+
+The contract is `packages/jssdk/src/index.ts` — anything not re-exported there is internal and may change without a deprecation cycle.

--- a/skills/b24-jssdk/references/api-surface.md
+++ b/skills/b24-jssdk/references/api-surface.md
@@ -1,6 +1,6 @@
 # API surface
 
-Categorized index of public exports from `@bitrix24/b24jssdk` — useful for finding the right import name. For full signatures, parameters, and return shapes consult the source under `packages/jssdk/src/`, the [docs site](https://bitrix24.github.io/b24jssdk/), or `packages/jssdk/README-AI.md` (note: README-AI.md examples still use the deprecated `call*` API — translate to `b24.actions.v{2,3}.*.make({ ... })` when generating new code).
+Categorized index of public exports from `@bitrix24/b24jssdk` — useful for finding the right import name. For full signatures, parameters, and return shapes consult the source under `packages/jssdk/src/`, the [docs site](https://bitrix24.github.io/b24jssdk/), or `packages/jssdk/README-AI.md` (aligned with the current `b24.actions.*` API).
 
 ## Entry points & loaders
 

--- a/skills/b24-jssdk/references/api-surface.md
+++ b/skills/b24-jssdk/references/api-surface.md
@@ -1,6 +1,6 @@
 # API surface
 
-Categorized index of public exports from `@bitrix24/b24jssdk` — useful for finding the right import name. For full signatures, parameters, and return shapes consult [`packages/jssdk/README-AI.md`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/README-AI.md), the [docs site](https://bitrix24.github.io/b24jssdk/), or the source under `packages/jssdk/src/`.
+Categorized index of public exports from `@bitrix24/b24jssdk` — useful for finding the right import name. For full signatures, parameters, and return shapes consult the source under `packages/jssdk/src/`, the [docs site](https://bitrix24.github.io/b24jssdk/), or `packages/jssdk/README-AI.md` (note: README-AI.md examples still use the deprecated `call*` API — translate to `b24.actions.v{2,3}.*.make({ ... })` when generating new code).
 
 ## Entry points & loaders
 
@@ -9,9 +9,36 @@ Categorized index of public exports from `@bitrix24/b24jssdk` — useful for fin
 | `initializeB24Frame()` | Boot a `B24Frame` (parent-window handshake, dedupes concurrent inits) | [frame-apps](recipes/frame-apps.md) |
 | `B24Frame` | iframe placement entry point — UI managers + REST | [frame-apps](recipes/frame-apps.md) |
 | `B24Hook` | Webhook-based server entry point | [webhook-server](recipes/webhook-server.md) |
-| `B24Hook.fromWebhookUrl(url)` | Construct from a full webhook URL | [webhook-server](recipes/webhook-server.md) |
+| `B24Hook.fromWebhookUrl(url, options?)` | Construct from a full webhook URL (v2 or v3 shape) | [webhook-server](recipes/webhook-server.md) |
 | `B24OAuth` | OAuth-based local app entry point | [oauth-apps](recipes/oauth-apps.md) |
-| `AbstractB24` | Shared REST surface (`callMethod`, `callBatch`, `callListMethod`, `fetchListMethod`, `callBatchByChunk`, `chunkArray`) — the base of the three concrete classes | [conventions](guidelines/conventions.md) |
+| `AbstractB24` | Shared base class — exposes `actions`, `tools`, `getHttpClient`, `setRestrictionManagerParams`, `destroy` | [conventions](guidelines/conventions.md) |
+
+## REST surface — `b24.actions.*`
+
+Every entry point exposes `actions.v2` and `actions.v3` managers. Each action is a class with a `make(options)` method.
+
+| Action class | Path | Returns |
+|---|---|---|
+| `CallV3` / `CallV2` | `b24.actions.v3.call` / `v2.call` | `Promise<AjaxResult<T>>` |
+| `CallListV3` / `CallListV2` | `b24.actions.v3.callList` / `v2.callList` | `Promise<Result<T[]>>` |
+| `FetchListV3` / `FetchListV2` | `b24.actions.v3.fetchList` / `v2.fetchList` | `AsyncGenerator<T[]>` |
+| `BatchV3` / `BatchV2` | `b24.actions.v3.batch` / `v2.batch` | `Promise<CallBatchResult<T>>` |
+| `BatchByChunkV3` / `BatchByChunkV2` | `b24.actions.v3.batchByChunk` / `v2.batchByChunk` | `Promise<Result<T[]>>` |
+
+Options types (re-exported from the package root): `ActionCallV3`, `ActionCallV2`, `ActionCallListV3`, `ActionCallListV2`, `ActionFetchListV3`, `ActionFetchListV2`, `ActionBatchV3`, `ActionBatchV2`, `ActionBatchByChunkV3`, `ActionBatchByChunkV2`, `IB24BatchOptions`, `BatchCommandsArrayUniversal`, `BatchCommandsObjectUniversal`, `BatchNamedCommandsUniversal`.
+
+See [batch-calls](recipes/batch-calls.md) and [list-pagination](recipes/list-pagination.md).
+
+### Deprecated REST helpers on `AbstractB24`
+
+For backwards compatibility, `AbstractB24` still exposes `callMethod`, `callBatch`, `callListMethod`, `fetchListMethod`, `callBatchByChunk`, `chunkArray`. All log deprecation warnings and **will be removed in v2.0.0** — translate to the action managers above.
+
+## Tools — `b24.tools.*`
+
+| Path | Returns | Purpose |
+|---|---|---|
+| `b24.tools.healthCheck.make({ requestId? })` | `Promise<boolean>` | Reach the portal? |
+| `b24.tools.ping.make({ requestId? })` | `Promise<number>` | Latency in ms |
 
 ## Helpers & Pull
 
@@ -24,14 +51,15 @@ Categorized index of public exports from `@bitrix24/b24jssdk` — useful for fin
 
 See [helper-manager](recipes/helper-manager.md) and [pull-client](recipes/pull-client.md).
 
-## REST results
+## REST results & errors
 
 | Export | Purpose |
 |---|---|
-| `Result` | Aggregated batch / list result (`getData`, `isSuccess`, `getErrors`, `getTotal`) |
-| `AjaxResult` | Single-call result (`getData`, `isMore`, `getNext`) |
+| `Result` | Aggregated batch / list result (`getData`, `isSuccess`, `getErrorMessages`, `errors`, `getTotal`) |
+| `AjaxResult` | Single-call result (`getData`, `isMore`, `getNext`, `errors`) |
 | `AjaxError` | REST/transport error (`code`, `description`, `status`, `requestInfo`) |
-| `SdkError` | SDK-internal error |
+| `SdkError` | SDK-internal error (`code`, `description`, `status`) |
+| `RefreshTokenError` | OAuth-specific failure when refresh fails (thrown by `B24OAuth`) |
 
 See [conventions](guidelines/conventions.md) and [error-handling](guidelines/error-handling.md).
 
@@ -40,19 +68,20 @@ See [conventions](guidelines/conventions.md) and [error-handling](guidelines/err
 | Export | Purpose |
 |---|---|
 | `RestrictionManager` | Orchestrates rate / operating / adaptive limiters |
-| `RateLimiter` | Bucketed REST quota limiter |
-| `OperatingLimiter` | Guards bursty `OPERATING` errors |
+| `RateLimiter` | Token-bucket REST quota limiter |
+| `OperatingLimiter` | Guards bursty `OPERATING` budget |
 | `AdaptiveDelayer` | Backs off on temporary overload |
-| `ParamsFactory` | Preset limiter params (`getDefault()`, enterprise preset) |
+| `ParamsFactory` | Preset limiter params: `getDefault()`, `getEnterprise()`, `getBatchProcessing()`, `getRealtime()`, `fromTariffPlan(plan)` |
+| `RestrictionParams` (type) | Full param shape: `rateLimit`, `operatingLimit`, `adaptiveConfig`, `maxRetries`, `retryDelay`, `retryOnNetworkError` |
 
 See [rate-limiting](guidelines/rate-limiting.md).
 
-## Tools
+## Tools (utilities)
 
 | Export | Purpose |
 |---|---|
-| `Text` | Luxon-backed dates, number/format helpers, UUID v7 |
-| `Type` | Runtime type guards (`isStringFilled`, `isPlainObject`, …) |
+| `Text` | Luxon-backed dates (`toDateTime`, `toB24Format`), number formatting (`numberFormat`), UUID v7 (`getUuidRfc4122`) |
+| `Type` | Runtime type guards (`isStringFilled`, `isPlainObject`, `isArray`, …) |
 | `Browser` | Lightweight browser environment helpers |
 | `useFormatters` | Number/date formatter hook |
 | `pick`, `omit`, `getEnumValue` | Object/enum helpers |
@@ -62,7 +91,7 @@ See [rate-limiting](guidelines/rate-limiting.md).
 | Export | Purpose |
 |---|---|
 | `LoggerBrowser` | Default browser/Node logger with dev-mode gate (`build(name, isDev)`) |
-| `LoggerFactory` | Per-component logger factory (used internally by SDK modules) |
+| `LoggerFactory` | Per-component logger factory (used internally) |
 
 See [logger](guidelines/logger.md).
 
@@ -71,9 +100,11 @@ See [logger](guidelines/logger.md).
 | Export | Purpose |
 |---|---|
 | `EnumCrmEntityTypeId` | CRM entity type ids (`company`, `contact`, `deal`, …) |
+| `ApiVersion` | `v2` / `v3` enum |
 | `ISODate` | ISO date string brand for `Text.toDateTime` |
+| `TypeCallParams` | Param shape for REST calls (`filter`, `select`, `order`, `pagination`, `start`) |
 | `TypePullMessage` | Pull message shape |
-| `Messages`, `defineLocale`, `extendLocale` | i18n primitives (mainly used by `b24ui-nuxt` integrations) |
+| `B24OAuthParams`, `B24OAuthSecret`, `B24HookParams` | Auth config shapes for entry-point constructors |
 | Type modules: `types/crm`, `types/catalog`, `types/bizproc`, `types/event`, `types/placement`, `types/payloads`, `types/pull`, `types/auth`, `types/handler`, `types/slider`, `types/user`, `types/b24`, `types/http`, `types/limiters`, `types/b24-helper`, `types/common` | Domain-specific types |
 
 The SDK re-exports everything from the package root — always `import { ... } from '@bitrix24/b24jssdk'`. Don't deep-import (`@bitrix24/b24jssdk/dist/...`).
@@ -82,17 +113,25 @@ The SDK re-exports everything from the package root — always `import { ... } f
 
 ```
 packages/jssdk/src/
-├── core/                # AbstractB24, Result, SdkError, http/, language/, version-manager
-├── frame/               # B24Frame + UI managers (auth, parent, slider, dialog, placement, options)
-├── hook/                # B24Hook
-├── oauth/               # B24OAuth
-├── helper/              # useB24Helper, B24HelperManager, profile/app/currency/license/options/payment managers
-├── pullClient/          # Pull WebSocket + long-polling, channel manager, JSON-RPC, protobuf
-├── tools/               # Text, Type, Browser, useFormatters, pick/omit, scroll-size, environment
-├── types/               # public types (crm, catalog, bizproc, event, placement, payloads, pull, …)
-├── logger/              # LoggerBrowser, LoggerFactory
-├── loader-b24frame.ts   # initializeB24Frame
-└── index.ts             # public re-exports (this is the contract)
+├── core/
+│   ├── abstract-b24.ts         # AbstractB24 base
+│   ├── actions/                # actions.{v2,v3}.{call,callList,fetchList,batch,batchByChunk}
+│   ├── tools/                  # tools.{healthCheck, ping}
+│   ├── http/                   # transport + limiter stack
+│   ├── language/               # language list
+│   ├── result.ts               # Result
+│   ├── sdk-error.ts            # SdkError
+│   └── version-manager.ts      # v2/v3 method routing
+├── frame/                      # B24Frame + UI managers (auth, parent, slider, dialog, placement, options)
+├── hook/                       # B24Hook
+├── oauth/                      # B24OAuth + RefreshTokenError
+├── helper/                     # useB24Helper, B24HelperManager, profile/app/currency/license/options/payment managers
+├── pullClient/                 # Pull WebSocket + long-polling, channel manager, JSON-RPC, protobuf
+├── tools/                      # Text, Type, Browser, useFormatters, pick/omit, scroll-size, environment
+├── types/                      # public types (crm, catalog, bizproc, event, placement, payloads, pull, …)
+├── logger/                     # LoggerBrowser, LoggerFactory
+├── loader-b24frame.ts          # initializeB24Frame
+└── index.ts                    # public re-exports (this is the contract)
 ```
 
 The contract is `packages/jssdk/src/index.ts` — anything not re-exported there is internal and may change without a deprecation cycle.

--- a/skills/b24-jssdk/references/api-surface.md
+++ b/skills/b24-jssdk/references/api-surface.md
@@ -15,19 +15,21 @@ Categorized index of public exports from `@bitrix24/b24jssdk` — useful for fin
 
 ## REST surface — `b24.actions.*`
 
-Every entry point exposes `actions.v2` and `actions.v3` managers. Each action is a class with a `make(options)` method.
+Every entry point exposes `actions.v2` and `actions.v3` managers — independent mirror trees, not old-vs-new. Each action is a class with a `make(options)` method.
 
 | Action class | Path | Returns |
 |---|---|---|
-| `CallV3` / `CallV2` | `b24.actions.v3.call` / `v2.call` | `Promise<AjaxResult<T>>` |
-| `CallListV3` / `CallListV2` | `b24.actions.v3.callList` / `v2.callList` | `Promise<Result<T[]>>` |
-| `FetchListV3` / `FetchListV2` | `b24.actions.v3.fetchList` / `v2.fetchList` | `AsyncGenerator<T[]>` |
-| `BatchV3` / `BatchV2` | `b24.actions.v3.batch` / `v2.batch` | `Promise<CallBatchResult<T>>` |
-| `BatchByChunkV3` / `BatchByChunkV2` | `b24.actions.v3.batchByChunk` / `v2.batchByChunk` | `Promise<Result<T[]>>` |
+| `CallV2` / `CallV3` | `b24.actions.v2.call` / `v3.call` | `Promise<AjaxResult<T>>` |
+| `CallListV2` / `CallListV3` | `b24.actions.v2.callList` / `v3.callList` | `Promise<Result<T[]>>` |
+| `FetchListV2` / `FetchListV3` | `b24.actions.v2.fetchList` / `v3.fetchList` | `AsyncGenerator<T[]>` |
+| `BatchV2` / `BatchV3` | `b24.actions.v2.batch` / `v3.batch` | `Promise<CallBatchResult<T>>` |
+| `BatchByChunkV2` / `BatchByChunkV3` | `b24.actions.v2.batchByChunk` / `v3.batchByChunk` | `Promise<Result<T[]>>` |
 
-Options types (re-exported from the package root): `ActionCallV3`, `ActionCallV2`, `ActionCallListV3`, `ActionCallListV2`, `ActionFetchListV3`, `ActionFetchListV2`, `ActionBatchV3`, `ActionBatchV2`, `ActionBatchByChunkV3`, `ActionBatchByChunkV2`, `IB24BatchOptions`, `BatchCommandsArrayUniversal`, `BatchCommandsObjectUniversal`, `BatchNamedCommandsUniversal`.
+Default to v2; v3 currently supports only `tasks.task.*`, `main.eventlog.*`, and meta endpoints — see [rest-api-v3 → When to use](recipes/rest-api-v3.md#when-to-use-v3--and-when-not-to).
 
-See [batch-calls](recipes/batch-calls.md) and [list-pagination](recipes/list-pagination.md).
+Options types (re-exported from the package root): `ActionCallV2`, `ActionCallV3`, `ActionCallListV2`, `ActionCallListV3`, `ActionFetchListV2`, `ActionFetchListV3`, `ActionBatchV2`, `ActionBatchV3`, `ActionBatchByChunkV2`, `ActionBatchByChunkV3`, `IB24BatchOptions`, `BatchCommandsArrayUniversal`, `BatchCommandsObjectUniversal`, `BatchNamedCommandsUniversal`.
+
+Full per-version reference: [rest-api-v2](recipes/rest-api-v2.md), [rest-api-v3](recipes/rest-api-v3.md). Decision pages: [batch-calls](recipes/batch-calls.md), [list-pagination](recipes/list-pagination.md).
 
 ### Deprecated REST helpers on `AbstractB24`
 

--- a/skills/b24-jssdk/references/guidelines/conventions.md
+++ b/skills/b24-jssdk/references/guidelines/conventions.md
@@ -19,12 +19,13 @@ import {
   Result,
   AjaxError,
   AjaxResult,
+  ParamsFactory,
   type ISODate
 } from '@bitrix24/b24jssdk'
 ```
 
 - The package is `sideEffects: false` — direct imports keep tree-shaking working.
-- There is **no default export**. Code like `import b24jssdk from '@bitrix24/b24jssdk'` is wrong.
+- There is **no default export**. `import b24jssdk from '@bitrix24/b24jssdk'` is wrong.
 - Prefer importing `EnumCrmEntityTypeId` and other enums from the root over hard-coding numeric ids.
 - Types and runtime values share the same module specifier; use `import type` only for pure type imports.
 
@@ -35,7 +36,6 @@ let $b24: B24Frame
 
 async function boot() {
   $b24 = await initializeB24Frame()
-  // ... use $b24
 }
 
 function teardown() {
@@ -43,53 +43,81 @@ function teardown() {
 }
 ```
 
-- **Always `await`** the initializer before any `call*` method.
+- **Always `await`** the initializer before any call.
 - **Always `destroy()`** on component/page unmount. The Pull client and message listeners hold references otherwise — you'll leak handlers and `postMessage` listeners across HMR reloads.
 - `initializeB24Frame()` deduplicates concurrent calls — calling it twice in flight returns the same promise.
 
+## REST surface — `b24.actions.*` and `b24.tools.*`
+
+Every concrete entry point (`B24Frame`, `B24Hook`, `B24OAuth`) exposes two manager namespaces from `AbstractB24`:
+
+- **`b24.actions.v3.*`** — REST API v3 (the current, growing surface). Use for new code.
+- **`b24.actions.v2.*`** — REST API v2 (mature, covers legacy CRM-style methods like `crm.item.list`, `crm.deal.list`). Use when v3 doesn't yet support a method.
+- **`b24.tools.*`** — utility checks (`healthCheck`, `ping`).
+
+Each action is a class with a single `make(options)` method that returns the appropriate result type. Action classes by version:
+
+| Action | v3 path | v2 path | Returns |
+|---|---|---|---|
+| Single call | `b24.actions.v3.call.make` | `b24.actions.v2.call.make` | `Promise<AjaxResult<T>>` |
+| Auto-paged list (in memory) | `b24.actions.v3.callList.make` | `b24.actions.v2.callList.make` | `Promise<Result<T[]>>` |
+| Streamed list (async generator) | `b24.actions.v3.fetchList.make` | `b24.actions.v2.fetchList.make` | `AsyncGenerator<T[]>` |
+| Batch (≤ 50 commands) | `b24.actions.v3.batch.make` | `b24.actions.v2.batch.make` | `Promise<CallBatchResult<T>>` |
+| Auto-chunked batch (any size) | `b24.actions.v3.batchByChunk.make` | `b24.actions.v2.batchByChunk.make` | `Promise<Result<T[]>>` |
+
+See [batch-calls](../recipes/batch-calls.md) and [list-pagination](../recipes/list-pagination.md) for full patterns.
+
+### Minimal example
+
+```ts
+import { initializeB24Frame, EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
+
+const $b24 = await initializeB24Frame()
+
+interface Company { id: number, title: string }
+
+const response = await $b24.actions.v2.call.make<{ items: Company[] }>({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.company,
+    select: ['id', 'title']
+  },
+  requestId: 'companies-1'
+})
+
+if (!response.isSuccess) {
+  throw new Error(response.getErrorMessages().join('; '))
+}
+console.log(response.getData().result.items)
+```
+
+### Legacy `call*` methods are deprecated
+
+`$b24.callMethod()`, `$b24.callBatch()`, `$b24.callListMethod()`, `$b24.fetchListMethod()`, `$b24.callBatchByChunk()` still exist on `AbstractB24` for backwards compatibility but log a deprecation warning and **will be removed in v2.0.0**. The `README-AI.md` and older examples still use them — when you see those forms, mentally translate to `b24.actions.v{2,3}.*.make({ ... })`. New code should always use the action managers.
+
 ## `Result` and `AjaxResult` (uniform return shape)
 
-Every REST helper returns one of these two:
-
-- `callMethod(...)` → `Promise<AjaxResult>` (single REST call; supports paging via `isMore()` + `getNext(httpClient)`).
-- `callBatch(...)` → `Promise<Result>` (aggregated batch; per-command results accessible via `getData()`).
-- `callListMethod(...)` → `Promise<Result>` (auto-paged list; `getData()` returns the full array).
-- `fetchListMethod(...)` → `AsyncGenerator<any[]>` (chunked stream; iterate with `for await`).
-- `callBatchByChunk(...)` → `Promise<Result>` (chunks a large batch, returns aggregated result).
+- `call.make(...)` → `AjaxResult<T>` for single calls. `getData()` returns the raw REST payload (`{ result: T }` typically).
+- `callList.make(...)` → `Result<T[]>` (full array in memory). `getData()` returns `T[]`.
+- `fetchList.make(...)` → `AsyncGenerator<T[]>` (chunked stream). Iterate with `for await`.
+- `batch.make(...)` → `CallBatchResult<T>` — shape mirrors the input: array of items for array-shaped calls, keyed object for named calls. `returnAjaxResult: true` makes each entry an `AjaxResult` so you can inspect individual command status.
+- `batchByChunk.make(...)` → `Result<T[]>` (flattened success rows).
 
 Common methods on `Result` / `AjaxResult`:
 
-- `getData()` — raw REST payload (object for single calls, array for list calls).
-- `isSuccess` — boolean; `false` if the call accumulated errors.
-- `getErrors()` — iterable of error objects when `isHaltOnError=false`.
-- `getTotal()` — total count for list calls.
-- `isMore()` — `AjaxResult` only; `true` when more pages remain.
-- `getNext(httpClient)` — fetch the next page; returns `AjaxResult | false`.
+- `getData()` — raw payload or `T[]`, depending on the action.
+- `isSuccess` — boolean; `false` when errors accumulated.
+- `getErrorMessages()` — array of `string`; convenient for thrown messages.
+- `errors` — iterable of `[index, error]` tuples for granular handling.
+- `getTotal()` — total count, when the REST method returns one (`AjaxResult` only).
 
-## Slot for a typical app
-
-```ts
-import { initializeB24Frame, type B24Frame } from '@bitrix24/b24jssdk'
-
-let $b24: B24Frame | null = null
-
-export async function getB24(): Promise<B24Frame> {
-  if ($b24) return $b24
-  $b24 = await initializeB24Frame()
-  return $b24
-}
-
-export function disposeB24() {
-  $b24?.destroy()
-  $b24 = null
-}
-```
+`AjaxResult` also still carries the cursor primitives `isMore()` / `getNext(httpClient)` for manual paging through `call.make` — useful only when you can't use `callList`/`fetchList`.
 
 ## Tools
 
 The SDK ships utilities under named exports — don't reach for third-party libs when these cover the case:
 
-- `Text` — Luxon-backed dates (`Text.toDateTime(iso)`), `Text.numberFormat`, `Text.getUuidRfc4122` (UUID v7).
+- `Text` — Luxon-backed dates (`Text.toDateTime(iso)`, `Text.toB24Format(date)`), `Text.numberFormat`, `Text.getUuidRfc4122` (UUID v7).
 - `Type` — runtime guards (`Type.isStringFilled`, `Type.isPlainObject`, `Type.isArray`, …).
 - `Browser` — lightweight environment helpers.
 - `useFormatters` — number/date formatting hooks.
@@ -97,12 +125,14 @@ The SDK ships utilities under named exports — don't reach for third-party libs
 
 ## Build-time tokens
 
-`__SDK_VERSION__` and `__SDK_USER_AGENT__` are replaced at build time. Don't reference them in user code — they exist for unbuild substitution inside the SDK only.
+`__SDK_VERSION__` and `__SDK_USER_AGENT__` are replaced at build time by unbuild ([packages/jssdk/build.config.ts](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/build.config.ts)). Don't reference them in user code — they exist for SDK-internal substitution.
 
 ## Common pitfalls
 
-- **Calling REST before init.** Always `await initializeB24Frame()` (or construct `B24Hook`/`B24OAuth`) before the first `call*`.
-- **Using `B24Hook` in the browser.** The webhook secret leaks. Use `B24Frame` (frame placements) or `B24OAuth` (local apps) on the client.
+- **Using deprecated `call*` directly on `$b24`.** Use `$b24.actions.v{2,3}.*.make({ ... })`.
+- **Calling REST before init.** Always `await initializeB24Frame()` (or construct `B24Hook`/`B24OAuth`) first.
+- **Using `B24Hook` in the browser.** The webhook secret leaks. Use `B24Frame` (placements) or `B24OAuth` (local apps) on the client.
 - **Forgetting `destroy()`.** Causes Pull subscriptions and `postMessage` listeners to pile up across navigations and HMR.
-- **Treating `getData()` shape as fixed.** It mirrors the underlying REST response — single calls return the REST payload, list calls return an array, batches return a keyed object.
+- **Forgetting `customKeyForResult` in v3 list/fetch actions.** It's required (no default). For `crm.item.list` it's `'items'`.
+- **Passing `order` to `callList.make`/`fetchList.make`.** It's ignored (cursor pagination orders by `idKey`); a warning is logged. Use `filter` to narrow the set.
 - **Mocking REST in tests.** The repo's integration tests hit a real portal on purpose. Don't mock — see `CLAUDE.md` Tests section.

--- a/skills/b24-jssdk/references/guidelines/conventions.md
+++ b/skills/b24-jssdk/references/guidelines/conventions.md
@@ -51,21 +51,23 @@ function teardown() {
 
 Every concrete entry point (`B24Frame`, `B24Hook`, `B24OAuth`) exposes two manager namespaces from `AbstractB24`:
 
-- **`b24.actions.v3.*`** — REST API v3 (the current, growing surface). Use for new code.
-- **`b24.actions.v2.*`** — REST API v2 (mature, covers legacy CRM-style methods like `crm.item.list`, `crm.deal.list`). Use when v3 doesn't yet support a method.
+- **`b24.actions.v2.*`** — REST API v2 (mature). Covers most current methods: `crm.*`, `im.*`, `user.*`, `profile`, placement, options, settings, etc.
+- **`b24.actions.v3.*`** — REST API v3 (growing surface). Currently supports only `tasks.task.*`, `main.eventlog.*`, and meta endpoints (`batch`, `scopes`, `documentation`). Will expand over time.
 - **`b24.tools.*`** — utility checks (`healthCheck`, `ping`).
 
-Each action is a class with a single `make(options)` method that returns the appropriate result type. Action classes by version:
+**Pick by method, not by preference.** v2 and v3 are mirror trees, not old-vs-new. Default to v2; switch a specific call to v3 only when its method is on the v3 list. Calling a v2-only method via `v3.call.make` throws `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`, and a `v3.batch.make` containing any v2-only method throws the same error. See [rest-api-v3 → When to use](../recipes/rest-api-v3.md#when-to-use-v3--and-when-not-to) for the current v3 method list.
 
-| Action | v3 path | v2 path | Returns |
+Each action is a class with a single `make(options)` method that returns the appropriate result type:
+
+| Action | v2 path | v3 path | Returns |
 |---|---|---|---|
-| Single call | `b24.actions.v3.call.make` | `b24.actions.v2.call.make` | `Promise<AjaxResult<T>>` |
-| Auto-paged list (in memory) | `b24.actions.v3.callList.make` | `b24.actions.v2.callList.make` | `Promise<Result<T[]>>` |
-| Streamed list (async generator) | `b24.actions.v3.fetchList.make` | `b24.actions.v2.fetchList.make` | `AsyncGenerator<T[]>` |
-| Batch (≤ 50 commands) | `b24.actions.v3.batch.make` | `b24.actions.v2.batch.make` | `Promise<CallBatchResult<T>>` |
-| Auto-chunked batch (any size) | `b24.actions.v3.batchByChunk.make` | `b24.actions.v2.batchByChunk.make` | `Promise<Result<T[]>>` |
+| Single call | `b24.actions.v2.call.make` | `b24.actions.v3.call.make` | `Promise<AjaxResult<T>>` |
+| Auto-paged list (in memory) | `b24.actions.v2.callList.make` | `b24.actions.v3.callList.make` | `Promise<Result<T[]>>` |
+| Streamed list (async generator) | `b24.actions.v2.fetchList.make` | `b24.actions.v3.fetchList.make` | `AsyncGenerator<T[]>` |
+| Batch (≤ 50 commands) | `b24.actions.v2.batch.make` | `b24.actions.v3.batch.make` | `Promise<CallBatchResult<T>>` |
+| Auto-chunked batch (any size) | `b24.actions.v2.batchByChunk.make` | `b24.actions.v3.batchByChunk.make` | `Promise<Result<T[]>>` |
 
-See [batch-calls](../recipes/batch-calls.md) and [list-pagination](../recipes/list-pagination.md) for full patterns.
+Full per-version reference: [rest-api-v2](../recipes/rest-api-v2.md), [rest-api-v3](../recipes/rest-api-v3.md). Decision pages: [batch-calls](../recipes/batch-calls.md), [list-pagination](../recipes/list-pagination.md).
 
 ### Minimal example
 

--- a/skills/b24-jssdk/references/guidelines/conventions.md
+++ b/skills/b24-jssdk/references/guidelines/conventions.md
@@ -55,7 +55,7 @@ Every concrete entry point (`B24Frame`, `B24Hook`, `B24OAuth`) exposes two manag
 - **`b24.actions.v3.*`** — REST API v3 (growing surface). Currently supports only `tasks.task.*`, `main.eventlog.*`, and meta endpoints (`batch`, `scopes`, `documentation`). Will expand over time.
 - **`b24.tools.*`** — utility checks (`healthCheck`, `ping`).
 
-**Pick by method, not by preference.** v2 and v3 are mirror trees, not old-vs-new. Default to v2; switch a specific call to v3 only when its method is on the v3 list. Calling a v2-only method via `v3.call.make` throws `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`, and a `v3.batch.make` containing any v2-only method throws the same error. See [rest-api-v3 → When to use](../recipes/rest-api-v3.md#when-to-use-v3--and-when-not-to) for the current v3 method list.
+**Pick by method, not by preference.** v2 and v3 are mirror trees, not old-vs-new. Default to v2; switch a specific call to v3 only when its method is on the v3 list. Calling a v2-only method via `v3.call.make` throws `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`, and a `v3.batch.make` containing any v2-only method throws the same error. See [rest-api-v3](../recipes/rest-api-v3.md) for the current v3 method list.
 
 Each action is a class with a single `make(options)` method that returns the appropriate result type:
 

--- a/skills/b24-jssdk/references/guidelines/conventions.md
+++ b/skills/b24-jssdk/references/guidelines/conventions.md
@@ -93,7 +93,7 @@ console.log(response.getData().result.items)
 
 ### Legacy `call*` methods are deprecated
 
-`$b24.callMethod()`, `$b24.callBatch()`, `$b24.callListMethod()`, `$b24.fetchListMethod()`, `$b24.callBatchByChunk()` still exist on `AbstractB24` for backwards compatibility but log a deprecation warning and **will be removed in v2.0.0**. The `README-AI.md` and older examples still use them — when you see those forms, mentally translate to `b24.actions.v{2,3}.*.make({ ... })`. New code should always use the action managers.
+`$b24.callMethod()`, `$b24.callBatch()`, `$b24.callListMethod()`, `$b24.fetchListMethod()`, `$b24.callBatchByChunk()` still exist on `AbstractB24` for backwards compatibility but log a deprecation warning and **will be removed in v2.0.0**. You'll still encounter them in older codebases — when you see those forms, mentally translate to `b24.actions.v{2,3}.*.make({ ... })`. New code should always use the action managers.
 
 ## `Result` and `AjaxResult` (uniform return shape)
 
@@ -111,7 +111,7 @@ Common methods on `Result` / `AjaxResult`:
 - `errors` — iterable of `[index, error]` tuples for granular handling.
 - `getTotal()` — total count, when the REST method returns one (`AjaxResult` only).
 
-`AjaxResult` also still carries the cursor primitives `isMore()` / `getNext(httpClient)` for manual paging through `call.make` — useful only when you can't use `callList`/`fetchList`.
+`AjaxResult` also carries the cursor primitives `isMore()` / `getNext(httpClient)` / `getTotal()` for manual paging — but they're **`@deprecated` and v2-only**. They rely on the v2 `next` / `total` envelope fields, which v3 doesn't return. Use `callList.make` / `fetchList.make` for both versions; for element counts in v3 use the `aggregate` action with `count` / `countDistinct`.
 
 ## Tools
 

--- a/skills/b24-jssdk/references/guidelines/conventions.md
+++ b/skills/b24-jssdk/references/guidelines/conventions.md
@@ -1,0 +1,108 @@
+# Conventions
+
+Coding patterns specific to `@bitrix24/b24jssdk`.
+
+## Imports
+
+Always use named imports from the package root:
+
+```ts
+import {
+  initializeB24Frame,
+  B24Frame,
+  B24Hook,
+  B24OAuth,
+  EnumCrmEntityTypeId,
+  Text,
+  Type,
+  LoggerBrowser,
+  Result,
+  AjaxError,
+  AjaxResult,
+  type ISODate
+} from '@bitrix24/b24jssdk'
+```
+
+- The package is `sideEffects: false` — direct imports keep tree-shaking working.
+- There is **no default export**. Code like `import b24jssdk from '@bitrix24/b24jssdk'` is wrong.
+- Prefer importing `EnumCrmEntityTypeId` and other enums from the root over hard-coding numeric ids.
+- Types and runtime values share the same module specifier; use `import type` only for pure type imports.
+
+## Initialization & lifecycle
+
+```ts
+let $b24: B24Frame
+
+async function boot() {
+  $b24 = await initializeB24Frame()
+  // ... use $b24
+}
+
+function teardown() {
+  $b24?.destroy()
+}
+```
+
+- **Always `await`** the initializer before any `call*` method.
+- **Always `destroy()`** on component/page unmount. The Pull client and message listeners hold references otherwise — you'll leak handlers and `postMessage` listeners across HMR reloads.
+- `initializeB24Frame()` deduplicates concurrent calls — calling it twice in flight returns the same promise.
+
+## `Result` and `AjaxResult` (uniform return shape)
+
+Every REST helper returns one of these two:
+
+- `callMethod(...)` → `Promise<AjaxResult>` (single REST call; supports paging via `isMore()` + `getNext(httpClient)`).
+- `callBatch(...)` → `Promise<Result>` (aggregated batch; per-command results accessible via `getData()`).
+- `callListMethod(...)` → `Promise<Result>` (auto-paged list; `getData()` returns the full array).
+- `fetchListMethod(...)` → `AsyncGenerator<any[]>` (chunked stream; iterate with `for await`).
+- `callBatchByChunk(...)` → `Promise<Result>` (chunks a large batch, returns aggregated result).
+
+Common methods on `Result` / `AjaxResult`:
+
+- `getData()` — raw REST payload (object for single calls, array for list calls).
+- `isSuccess` — boolean; `false` if the call accumulated errors.
+- `getErrors()` — iterable of error objects when `isHaltOnError=false`.
+- `getTotal()` — total count for list calls.
+- `isMore()` — `AjaxResult` only; `true` when more pages remain.
+- `getNext(httpClient)` — fetch the next page; returns `AjaxResult | false`.
+
+## Slot for a typical app
+
+```ts
+import { initializeB24Frame, type B24Frame } from '@bitrix24/b24jssdk'
+
+let $b24: B24Frame | null = null
+
+export async function getB24(): Promise<B24Frame> {
+  if ($b24) return $b24
+  $b24 = await initializeB24Frame()
+  return $b24
+}
+
+export function disposeB24() {
+  $b24?.destroy()
+  $b24 = null
+}
+```
+
+## Tools
+
+The SDK ships utilities under named exports — don't reach for third-party libs when these cover the case:
+
+- `Text` — Luxon-backed dates (`Text.toDateTime(iso)`), `Text.numberFormat`, `Text.getUuidRfc4122` (UUID v7).
+- `Type` — runtime guards (`Type.isStringFilled`, `Type.isPlainObject`, `Type.isArray`, …).
+- `Browser` — lightweight environment helpers.
+- `useFormatters` — number/date formatting hooks.
+- `pick`, `omit`, `getEnumValue` — object/enum helpers.
+
+## Build-time tokens
+
+`__SDK_VERSION__` and `__SDK_USER_AGENT__` are replaced at build time. Don't reference them in user code — they exist for unbuild substitution inside the SDK only.
+
+## Common pitfalls
+
+- **Calling REST before init.** Always `await initializeB24Frame()` (or construct `B24Hook`/`B24OAuth`) before the first `call*`.
+- **Using `B24Hook` in the browser.** The webhook secret leaks. Use `B24Frame` (frame placements) or `B24OAuth` (local apps) on the client.
+- **Forgetting `destroy()`.** Causes Pull subscriptions and `postMessage` listeners to pile up across navigations and HMR.
+- **Treating `getData()` shape as fixed.** It mirrors the underlying REST response — single calls return the REST payload, list calls return an array, batches return a keyed object.
+- **Mocking REST in tests.** The repo's integration tests hit a real portal on purpose. Don't mock — see `CLAUDE.md` Tests section.

--- a/skills/b24-jssdk/references/guidelines/entry-points.md
+++ b/skills/b24-jssdk/references/guidelines/entry-points.md
@@ -1,0 +1,26 @@
+# Entry points
+
+Pick the right concrete class before writing any code. All three inherit `AbstractB24` and share the same REST surface — only their auth and runtime constraints differ.
+
+## Decision matrix
+
+| Need | Entry point | Docs | Why |
+|---|---|---|---|
+| App embedded in Bitrix24 (iframe placement) | `B24Frame` via `initializeB24Frame()` | [frame-apps](../recipes/frame-apps.md) | Auth handed over by parent window; auto-refresh on 401; UI managers (slider, dialog, parent, placement, options) only available here |
+| Server script, cron job, queue worker, backend service | `B24Hook` via `B24Hook.fromWebhookUrl(url)` | [webhook-server](../recipes/webhook-server.md) | Webhook secret in URL; no parent window; meant for trusted server environments |
+| Local app that needs OAuth (multi-portal, refresh tokens) | `B24OAuth` | [oauth-apps](../recipes/oauth-apps.md) | Manages access/refresh tokens; raises a typed error so the app can re-auth |
+
+## Rules
+
+- **`B24Frame` requires a Bitrix24 placement context.** It reads `window.name` for the portal handshake — outside an iframe placement, init throws. Frame-only managers: `auth`, `parent`, `slider`, `dialog`, `placement`, `options`.
+- **`B24Hook` is unsafe in the browser.** The webhook URL contains a long-lived secret. The class warns when constructed in a browser context. Server-side scripts can silence the warning with `$b24.offClientSideWarning?.()` — never silence it on the client.
+- **`B24OAuth` is for OAuth local apps.** When the refresh token is invalid or expired, the manager throws a recognisable error so the app can redirect to re-auth. Don't catch it generically.
+- **All three return the same shapes.** Whatever differs (UI managers, auth) is exposed through entry-point-specific properties; REST results are uniform `Result` / `AjaxResult`.
+- **Initialize once per scope.** `initializeB24Frame()` deduplicates concurrent calls but you should still keep one `$b24` reference per app/page and `destroy()` it on teardown.
+
+## Anti-patterns
+
+- Don't use `B24Hook` in a frame placement just because it's "simpler" — you'll leak the webhook secret to every user that opens the app.
+- Don't try to call `slider`, `dialog`, `placement`, `parent`, or `options` on a `B24Hook` or `B24OAuth` instance — those managers exist only on `B24Frame`.
+- Don't construct `B24Frame` directly with `new B24Frame(...)` — use `initializeB24Frame()`. The loader parses `window.name` and handles the parent-window handshake.
+- Don't share a single `B24Hook` between portals — one instance is bound to one webhook URL.

--- a/skills/b24-jssdk/references/guidelines/error-handling.md
+++ b/skills/b24-jssdk/references/guidelines/error-handling.md
@@ -1,0 +1,90 @@
+# Error handling
+
+Two error shapes cover everything the SDK throws.
+
+## `AjaxError` — REST/transport errors
+
+Thrown by `callMethod`, returned inside `Result.getErrors()` for batches with `isHaltOnError=false`.
+
+```ts
+import { AjaxError } from '@bitrix24/b24jssdk'
+
+try {
+  const res = await $b24.callMethod('crm.item.get', { entityTypeId: 1, id: 10 })
+  // ...
+} catch (e) {
+  if (e instanceof AjaxError) {
+    console.error(e.code, e.description, e.status, e.requestInfo)
+  } else {
+    throw e
+  }
+}
+```
+
+Fields:
+
+- `code` — server error code (e.g. `'ERROR_METHOD_NOT_FOUND'`, `'INVALID_TOKEN'`).
+- `description` — human-readable description from the REST endpoint.
+- `status` — HTTP status code.
+- `requestInfo` — the request that failed (method, params, time).
+
+## `SdkError` — SDK-internal errors
+
+Thrown for SDK-level problems: misconfiguration, invalid initialization, OAuth refresh failure, etc. Carries a stable error code so callers can branch on it without parsing strings.
+
+```ts
+import { SdkError } from '@bitrix24/b24jssdk'
+
+try {
+  await initializeB24Frame()
+} catch (e) {
+  if (e instanceof SdkError) {
+    // Branch on e.code; surface a user-friendly message
+  }
+  throw e
+}
+```
+
+## Batch error aggregation
+
+`callBatch(calls, isHaltOnError, returnAjaxResult)`:
+
+| `isHaltOnError` | Behaviour |
+|---|---|
+| `true` (default) | Promise rejects on the first failing command — typical for transactional flows |
+| `false` | Promise resolves; per-command errors are accumulated in the returned `Result`. Inspect with `result.isSuccess` and `result.getErrors()` |
+
+```ts
+const batch = await $b24.callBatch([
+  ['crm.item.list', { entityTypeId: 1, select: ['id'] }],
+  ['crm.item.list', { entityTypeId: 2, select: ['id'] }]
+], false) // do not halt — collect all errors
+
+if (!batch.isSuccess) {
+  for (const err of batch.getErrors()) {
+    console.warn('partial failure:', err)
+  }
+}
+
+const data = batch.getData()
+```
+
+## Auth refresh in `B24Frame`
+
+`B24Frame` automatically refreshes auth on `401`. You don't need to catch and retry. If refresh itself fails (e.g. session ended in parent), the original call's promise rejects with an `AjaxError` whose `status` reflects the failure — re-init the frame or redirect to re-auth.
+
+## Refresh token failures in `B24OAuth`
+
+`B24OAuth` raises a typed error when the refresh token is invalid/expired. Catch it specifically and trigger your re-auth flow (e.g. redirect the user to the OAuth consent URL).
+
+## Retry strategy
+
+- **Transient network errors**: rely on the built-in `RestrictionManager` and `AdaptiveDelayer` (see [rate-limiting](rate-limiting.md)) — they back off automatically on `503`/`QUERY_LIMIT_EXCEEDED`. Don't add an outer retry loop on top.
+- **Application errors** (`ERROR_NOT_FOUND`, validation): don't retry — fix the input.
+- **Auth errors** in frame: handled internally. In `B24OAuth`: refresh tokens; if that fails, re-auth.
+
+## Anti-patterns
+
+- Catching every error and swallowing it (`catch (e) { /* ignore */ }`). Always at least log via `LoggerBrowser`.
+- Wrapping `callBatch` in a `try/catch` *and* using `isHaltOnError=false` — pick one strategy.
+- Parsing `e.message` strings — use `e.code` (`AjaxError`) or instance checks.

--- a/skills/b24-jssdk/references/guidelines/error-handling.md
+++ b/skills/b24-jssdk/references/guidelines/error-handling.md
@@ -10,7 +10,7 @@ Thrown by `call.make` (and by underlying calls inside `callList.make` / `fetchLi
 import { AjaxError } from '@bitrix24/b24jssdk'
 
 try {
-  const response = await $b24.actions.v3.call.make({
+  const response = await $b24.actions.v2.call.make({
     method: 'crm.item.get',
     params: { entityTypeId: 1, id: 10 }
   })
@@ -62,7 +62,7 @@ try {
 | `false` | Promise resolves; per-command errors accumulate on the returned `Result`. Inspect `response.isSuccess`, `response.getErrorMessages()`, or iterate `response.errors` |
 
 ```ts
-const response = await $b24.actions.v3.batch.make({
+const response = await $b24.actions.v2.batch.make({
   calls: [
     ['crm.item.list', { entityTypeId: 1, select: ['id'] }],
     ['crm.item.list', { entityTypeId: 2, select: ['id'] }]
@@ -93,7 +93,7 @@ Set `returnAjaxResult: true` to inspect each command's `AjaxResult` individually
 import { RefreshTokenError } from '@bitrix24/b24jssdk'
 
 try {
-  await $b24.actions.v3.call.make({ method: 'user.current' })
+  await $b24.actions.v2.call.make({ method: 'user.current' })
 } catch (e) {
   if (e instanceof RefreshTokenError) {
     redirectToReauth()

--- a/skills/b24-jssdk/references/guidelines/error-handling.md
+++ b/skills/b24-jssdk/references/guidelines/error-handling.md
@@ -1,17 +1,24 @@
 # Error handling
 
-Two error shapes cover everything the SDK throws.
+Three error shapes cover everything the SDK throws.
 
 ## `AjaxError` — REST/transport errors
 
-Thrown by `callMethod`, returned inside `Result.getErrors()` for batches with `isHaltOnError=false`.
+Thrown by `call.make` (and by underlying calls inside `callList.make` / `fetchList.make` / `batch.make` when `isHaltOnError: true`).
 
 ```ts
 import { AjaxError } from '@bitrix24/b24jssdk'
 
 try {
-  const res = await $b24.callMethod('crm.item.get', { entityTypeId: 1, id: 10 })
-  // ...
+  const response = await $b24.actions.v3.call.make({
+    method: 'crm.item.get',
+    params: { entityTypeId: 1, id: 10 }
+  })
+
+  if (!response.isSuccess) {
+    console.error(response.getErrorMessages())
+    return
+  }
 } catch (e) {
   if (e instanceof AjaxError) {
     console.error(e.code, e.description, e.status, e.requestInfo)
@@ -47,27 +54,32 @@ try {
 
 ## Batch error aggregation
 
-`callBatch(calls, isHaltOnError, returnAjaxResult)`:
+`b24.actions.v{2,3}.batch.make({ calls, options: { isHaltOnError, returnAjaxResult, requestId } })`:
 
 | `isHaltOnError` | Behaviour |
 |---|---|
 | `true` (default) | Promise rejects on the first failing command — typical for transactional flows |
-| `false` | Promise resolves; per-command errors are accumulated in the returned `Result`. Inspect with `result.isSuccess` and `result.getErrors()` |
+| `false` | Promise resolves; per-command errors accumulate on the returned `Result`. Inspect `response.isSuccess`, `response.getErrorMessages()`, or iterate `response.errors` |
 
 ```ts
-const batch = await $b24.callBatch([
-  ['crm.item.list', { entityTypeId: 1, select: ['id'] }],
-  ['crm.item.list', { entityTypeId: 2, select: ['id'] }]
-], false) // do not halt — collect all errors
+const response = await $b24.actions.v3.batch.make({
+  calls: [
+    ['crm.item.list', { entityTypeId: 1, select: ['id'] }],
+    ['crm.item.list', { entityTypeId: 2, select: ['id'] }]
+  ],
+  options: { isHaltOnError: false }
+})
 
-if (!batch.isSuccess) {
-  for (const err of batch.getErrors()) {
-    console.warn('partial failure:', err)
+if (!response.isSuccess) {
+  for (const [index, err] of response.errors) {
+    console.warn('partial failure', index, err)
   }
 }
 
-const data = batch.getData()
+const data = response.getData()
 ```
+
+Set `returnAjaxResult: true` to inspect each command's `AjaxResult` individually (useful for paginated commands inside a batch).
 
 ## Auth refresh in `B24Frame`
 
@@ -75,7 +87,23 @@ const data = batch.getData()
 
 ## Refresh token failures in `B24OAuth`
 
-`B24OAuth` raises a typed error when the refresh token is invalid/expired. Catch it specifically and trigger your re-auth flow (e.g. redirect the user to the OAuth consent URL).
+`B24OAuth` throws `RefreshTokenError` when the refresh token itself is invalid/expired (token revoked, app uninstalled). Catch it specifically and trigger your re-auth flow (e.g. redirect the user to the OAuth consent URL):
+
+```ts
+import { RefreshTokenError } from '@bitrix24/b24jssdk'
+
+try {
+  await $b24.actions.v3.call.make({ method: 'user.current' })
+} catch (e) {
+  if (e instanceof RefreshTokenError) {
+    redirectToReauth()
+    return
+  }
+  throw e
+}
+```
+
+Successful refreshes are also observable — register a callback via `$b24.setCallbackRefreshAuth(cb)` and persist the rotated tokens. See [oauth-apps](../recipes/oauth-apps.md).
 
 ## Retry strategy
 
@@ -86,5 +114,6 @@ const data = batch.getData()
 ## Anti-patterns
 
 - Catching every error and swallowing it (`catch (e) { /* ignore */ }`). Always at least log via `LoggerBrowser`.
-- Wrapping `callBatch` in a `try/catch` *and* using `isHaltOnError=false` — pick one strategy.
-- Parsing `e.message` strings — use `e.code` (`AjaxError`) or instance checks.
+- Wrapping `batch.make` in `try/catch` *and* using `isHaltOnError: false` — pick one strategy.
+- Parsing `e.message` strings — use `e.code` (`AjaxError`/`SdkError`) or `instanceof` checks.
+- Treating `response.isSuccess === false` as a thrown error — it's a structured outcome, branch on it instead.

--- a/skills/b24-jssdk/references/guidelines/logger.md
+++ b/skills/b24-jssdk/references/guidelines/logger.md
@@ -1,0 +1,42 @@
+# Logger
+
+The SDK exposes a small logger (`packages/jssdk/src/logger`) and defaults entry-point instances to a **null logger** — so by default nothing is written to the console. Wire a real logger when you need visibility.
+
+## `LoggerBrowser.build`
+
+```ts
+import { LoggerBrowser } from '@bitrix24/b24jssdk'
+
+const logger = LoggerBrowser.build('MyApp', import.meta.env?.DEV === true)
+logger.info('boot', { ts: Date.now() })
+logger.warn('low quota')
+logger.error(new Error('boom'))
+```
+
+- First arg: a short tag prepended to every line — typically your app name.
+- Second arg: dev mode flag. When `false`, `info`/`debug` are silenced; `warn`/`error` still pass through.
+
+## Attach to an SDK instance
+
+```ts
+const $b24 = await initializeB24Frame()
+$b24.setLogger(logger)
+```
+
+The same pattern applies to `B24Hook` and `B24OAuth`. Once attached, the limiter stack, HTTP transport, and managers all log through it.
+
+## `LoggerFactory`
+
+For libraries embedding the SDK, prefer `LoggerFactory` to produce per-component loggers with a consistent prefix scheme. End-user apps almost always want one `LoggerBrowser.build('AppName', isDev)` and that's it.
+
+## Conventions
+
+- One logger per app, built once at boot. Don't rebuild it on every render.
+- Keep messages short and structured: `logger.info('event', { id, count })`. The browser console renders the second arg as a tree.
+- For server scripts that pipe logs to a file, use `JSON.stringify` in a small wrapper instead of relying on console formatting.
+
+## Anti-patterns
+
+- Using `console.log` directly — bypasses the tag prefix and the dev/prod gate.
+- Building a logger inside a request handler — creates a logger per request and clutters output.
+- Logging every REST call payload at `info` — payloads are large; reserve `info` for lifecycle and key decisions, use `debug` for high-volume traces.

--- a/skills/b24-jssdk/references/guidelines/rate-limiting.md
+++ b/skills/b24-jssdk/references/guidelines/rate-limiting.md
@@ -1,0 +1,50 @@
+# Rate limiting & restrictions
+
+The SDK throttles REST requests automatically — most callers never need to touch this. Read this page when:
+
+- A long-running script triggers `QUERY_LIMIT_EXCEEDED`.
+- You're building a bulk migration / nightly sync against an enterprise portal.
+- You need to tune throughput for a specific workload.
+
+## The limiter stack (`packages/jssdk/src/core/http`)
+
+- **`RateLimiter`** — bucketed limiter for the standard Bitrix24 REST quota.
+- **`OperatingLimiter`** — guards against bursty server-side `OPERATING` errors.
+- **`AdaptiveDelayer`** — backs off when the server reports temporary overload.
+- **`RestrictionManager`** — orchestrates the above; lives on every `Http` instance.
+- **`ParamsFactory`** — produces preconfigured limiter params.
+
+## Default behaviour
+
+- Standard portals: `ParamsFactory.getDefault()` is applied automatically.
+- Enterprise portals: when [`useB24Helper()`](../recipes/helper-manager.md) loads license info, `LicenseManager` swaps in the enterprise preset (higher concurrency / quotas) without any code change on your side.
+
+## Manual tuning
+
+```ts
+import { ParamsFactory } from '@bitrix24/b24jssdk'
+
+const http = $b24.getHttpClient()
+http.setRestrictionManagerParams(ParamsFactory.getForEnterprise())
+```
+
+Tune only when:
+
+- You're running a backend script outside of `useB24Helper()` (so license-based auto-tuning doesn't apply) **and** you know the portal is enterprise.
+- You've measured a bottleneck — random tuning typically makes things worse.
+
+## Choosing the right list strategy
+
+Throttling is most visible on list calls. The right call shape often beats limiter tuning:
+
+- Small set (< 1000): `callListMethod` — single in-memory call, simplest.
+- Large set: `fetchListMethod` — streams chunks, lets the limiter pace itself.
+- Need precise control / pauses: manual `callMethod` + `getNext()` with your own `await new Promise(r => setTimeout(r, …))` between pages.
+
+See [list-pagination](../recipes/list-pagination.md).
+
+## Anti-patterns
+
+- Adding a manual `setTimeout` between every `callMethod` "to be safe" — the limiter already paces requests; your sleeps just slow down the happy path.
+- Catching `AjaxError` with code `QUERY_LIMIT_EXCEEDED` and retrying immediately — the limiter already retries with backoff. Manual retry causes a thundering herd.
+- Disabling the restriction manager. Don't.

--- a/skills/b24-jssdk/references/guidelines/rate-limiting.md
+++ b/skills/b24-jssdk/references/guidelines/rate-limiting.md
@@ -2,49 +2,79 @@
 
 The SDK throttles REST requests automatically — most callers never need to touch this. Read this page when:
 
-- A long-running script triggers `QUERY_LIMIT_EXCEEDED`.
+- A long-running script hits `QUERY_LIMIT_EXCEEDED`.
 - You're building a bulk migration / nightly sync against an enterprise portal.
-- You need to tune throughput for a specific workload.
+- You need to tune throughput or retry behaviour for a specific workload.
 
-## The limiter stack (`packages/jssdk/src/core/http`)
+Authoritative reference: the docs page [`docs/content/docs/2.working-with-the-rest-api/77.limiters.md`](https://github.com/bitrix24/b24jssdk/blob/main/docs/content/docs/2.working-with-the-rest-api/77.limiters.md). This page summarises decisions; the docs cover field-by-field details and edge cases.
 
-- **`RateLimiter`** — bucketed limiter for the standard Bitrix24 REST quota.
-- **`OperatingLimiter`** — guards against bursty server-side `OPERATING` errors.
-- **`AdaptiveDelayer`** — backs off when the server reports temporary overload.
+## The limiter stack (`packages/jssdk/src/core/http/limiters/`)
+
+- **`RateLimiter`** — token-bucket limiter (`burstLimit`, `drainRate`).
+- **`OperatingLimiter`** — guards against the 10-minute `OPERATING` budget (`windowMs`, `limitMs`, `heavyPercent`).
+- **`AdaptiveDelayer`** — backs off when the server reports temporary overload (`thresholdPercent`, `coefficient`, `maxDelay`).
 - **`RestrictionManager`** — orchestrates the above; lives on every `Http` instance.
-- **`ParamsFactory`** — produces preconfigured limiter params.
+- **`ParamsFactory`** — produces preconfigured `RestrictionParams`.
 
-## Default behaviour
+`RestrictionParams` also covers retry behaviour: `maxRetries`, `retryDelay`, and `retryOnNetworkError` (controls whether *transport-level* errors are retried — when in doubt leave it at the preset's default; see PR #32 for the rationale).
 
-- Standard portals: `ParamsFactory.getDefault()` is applied automatically.
-- Enterprise portals: when [`useB24Helper()`](../recipes/helper-manager.md) loads license info, `LicenseManager` swaps in the enterprise preset (higher concurrency / quotas) without any code change on your side.
+## Built-in presets
 
-## Manual tuning
+Static methods on `ParamsFactory`:
+
+| Preset | When to use |
+|---|---|
+| `getDefault()` | Standard portals (the implicit default if you never tune anything) |
+| `getEnterprise()` | Enterprise portals — higher burst (250 vs 50) and drain rate (5 vs 2) |
+| `getBatchProcessing()` | Bulk migrations / nightly syncs — gentler bucket, larger `maxRetries` (5), tighter adaptive threshold |
+| `getRealtime()` | Latency-sensitive UI calls — adaptive delay disabled, `maxRetries: 1` |
+| `fromTariffPlan(plan)` | Dispatch based on a portal's tariff string (`'enterprise'` → enterprise, others → default) |
+
+When [`useB24Helper()`](../recipes/helper-manager.md) loads license info (via `LoadDataType.App`), `LicenseManager` swaps in the enterprise preset automatically on enterprise portals. Outside of the helper context — i.e. raw `B24Hook` / `B24OAuth` server scripts — you have to choose explicitly.
+
+## Apply a preset
+
+Two equivalent ways:
 
 ```ts
 import { ParamsFactory } from '@bitrix24/b24jssdk'
 
-const http = $b24.getHttpClient()
-http.setRestrictionManagerParams(ParamsFactory.getForEnterprise())
+// At construction (B24Hook / B24OAuth)
+const $b24 = B24Hook.fromWebhookUrl(url, {
+  restrictionParams: ParamsFactory.getBatchProcessing()
+})
+
+// Or anytime after init (any entry point)
+await $b24.setRestrictionManagerParams(ParamsFactory.getEnterprise())
 ```
 
-Tune only when:
+`setRestrictionManagerParams` is async because it propagates the new params across both v2 and v3 HTTP clients on the instance.
 
-- You're running a backend script outside of `useB24Helper()` (so license-based auto-tuning doesn't apply) **and** you know the portal is enterprise.
-- You've measured a bottleneck — random tuning typically makes things worse.
+## Partial overrides
+
+```ts
+await $b24.setRestrictionManagerParams({
+  ...ParamsFactory.getDefault(),
+  rateLimit: { burstLimit: 100, drainRate: 3, adaptiveEnabled: true },
+  maxRetries: 5
+})
+```
+
+Tune only when you've measured a bottleneck — random tuning usually makes things worse.
 
 ## Choosing the right list strategy
 
 Throttling is most visible on list calls. The right call shape often beats limiter tuning:
 
-- Small set (< 1000): `callListMethod` — single in-memory call, simplest.
-- Large set: `fetchListMethod` — streams chunks, lets the limiter pace itself.
-- Need precise control / pauses: manual `callMethod` + `getNext()` with your own `await new Promise(r => setTimeout(r, …))` between pages.
+- Small set (< 1000): `b24.actions.v{2,3}.callList.make` — single in-memory call, simplest.
+- Large set: `b24.actions.v{2,3}.fetchList.make` — streams chunks, lets the limiter pace itself.
+- Need precise control / pauses: `b24.actions.v{2,3}.call.make` + `AjaxResult.getNext()` with your own `await new Promise(r => setTimeout(r, …))` between pages.
 
 See [list-pagination](../recipes/list-pagination.md).
 
 ## Anti-patterns
 
-- Adding a manual `setTimeout` between every `callMethod` "to be safe" — the limiter already paces requests; your sleeps just slow down the happy path.
-- Catching `AjaxError` with code `QUERY_LIMIT_EXCEEDED` and retrying immediately — the limiter already retries with backoff. Manual retry causes a thundering herd.
+- Adding a manual `setTimeout` between every call "to be safe" — the limiter already paces requests; your sleeps just slow down the happy path.
+- Catching `AjaxError` with code `QUERY_LIMIT_EXCEEDED` and retrying immediately — the limiter retries with backoff; manual retry causes a thundering herd.
+- Forcing `getRealtime()` on bulk workloads — `maxRetries: 1` means transient errors fail the whole script.
 - Disabling the restriction manager. Don't.

--- a/skills/b24-jssdk/references/recipes/batch-calls.md
+++ b/skills/b24-jssdk/references/recipes/batch-calls.md
@@ -2,8 +2,8 @@
 
 When and which batch shape to use. Code examples live in the version-specific recipes:
 
-- **v2 examples:** [rest-api-v2 → Batch](rest-api-v2.md#batch--batchmake), [BatchByChunk](rest-api-v2.md#auto-chunked-batch--batchbychunkmake)
-- **v3 examples:** [rest-api-v3 → Batch](rest-api-v3.md#batch--batchmake), [BatchByChunk](rest-api-v3.md#auto-chunked-batch--batchbychunkmake)
+- **v2 examples:** [rest-api-v2](rest-api-v2.md) — see the "Batch" and "Auto-chunked batch" sections.
+- **v3 examples:** [rest-api-v3](rest-api-v3.md) — same sections, mirror structure.
 
 ## When to batch at all
 
@@ -22,7 +22,7 @@ When and which batch shape to use. Code examples live in the version-specific re
 - All commands are v3-supported (`tasks.task.*`, `main.eventlog.*`, meta endpoints) → `v3.batch.make`.
 - Mix of v2-only and v3 in the same group → **not allowed in one batch.** Split into two `batch.make` calls (one per version), or downgrade everything to v2 if the v3 methods also exist there.
 
-`b24.actions.v3.batch.make` throws `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3` at call time if any one command isn't v3-supported. See [rest-api-v3 → When to use](rest-api-v3.md#when-to-use-v3--and-when-not-to) for the current v3 method list.
+`b24.actions.v3.batch.make` throws `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3` at call time if any one command isn't v3-supported. See [rest-api-v3](rest-api-v3.md) for the current v3 method list.
 
 ## Input shapes
 
@@ -32,7 +32,7 @@ All three shapes work in both v2 and v3 `batch.make` (only the named-object shap
 - **Array of objects** — `[{ method, params }, ...]`. Same as tuples, more readable.
 - **Named object** — `{ Name: { method, params }, ... }`. Results keyed by the names you choose; best when the consumer code wants to address results by name.
 
-Pick whichever makes the consumer code clearest. See [rest-api-v2 → Batch](rest-api-v2.md#batch--batchmake) for a code sample of each.
+Pick whichever makes the consumer code clearest. See [rest-api-v2](rest-api-v2.md) (or [rest-api-v3](rest-api-v3.md)) for a code sample of each.
 
 ## `isHaltOnError`
 

--- a/skills/b24-jssdk/references/recipes/batch-calls.md
+++ b/skills/b24-jssdk/references/recipes/batch-calls.md
@@ -1,0 +1,108 @@
+# Batch calls
+
+`callBatch` lets you send multiple REST calls in one request. Use it whenever:
+
+- You need 2+ related calls and round-trip latency matters.
+- You want a transactional "all-or-nothing" group (`isHaltOnError=true`).
+- You're collecting independent data sets (list of companies + list of contacts) — `isHaltOnError=false` accumulates per-command errors.
+
+For batches larger than ~50 commands, use `callBatchByChunk` — the SDK chunks them for you.
+
+## Two call shapes
+
+### Object-keyed (frontend-friendly)
+
+```ts
+import { Result } from '@bitrix24/b24jssdk'
+
+const batch: Result = await $b24.callBatch({
+  CompanyList: {
+    method: 'crm.item.list',
+    params: {
+      entityTypeId: EnumCrmEntityTypeId.company,
+      order: { id: 'desc' },
+      select: ['id', 'title']
+    }
+  },
+  ContactList: {
+    method: 'crm.item.list',
+    params: {
+      entityTypeId: EnumCrmEntityTypeId.contact,
+      select: ['id', 'name']
+    }
+  }
+}, true) // isHaltOnError = true (default)
+
+const data = batch.getData()
+const companies = data.CompanyList.items ?? []
+const contacts = data.ContactList.items ?? []
+```
+
+Use the object form when keys make the receiving code clearer (named results map cleanly to UI sections, etc.).
+
+### Array (server-friendly)
+
+```ts
+const batch: Result = await $b24.callBatch([
+  ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.company, select: ['id'] }],
+  ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.contact, select: ['id'] }]
+], true)
+```
+
+Use the array form when the calls are homogeneous (e.g. paging through the same method) — `getData()` returns an indexed result.
+
+## Halt-on-error semantics
+
+| `isHaltOnError` | Behaviour |
+|---|---|
+| `true` (default) | Promise rejects on the first failing command. Use for transactional groups |
+| `false` | Promise resolves; per-command errors live in `result.getErrors()`. Use when partial results are still useful |
+
+```ts
+const batch = await $b24.callBatch(calls, false)
+if (!batch.isSuccess) {
+  for (const err of batch.getErrors()) {
+    console.warn('partial failure', err)
+  }
+}
+```
+
+## `returnAjaxResult` — per-command `AjaxResult`
+
+```ts
+const batch = await $b24.callBatch(calls, true, true)
+// batch.getData() now contains AjaxResult objects per command
+// — useful when individual commands return paginated results
+```
+
+Reach for this only when you actually need `isMore()` / `getNext()` per command. Otherwise the default flat shape is simpler.
+
+## `callBatchByChunk` — large batches
+
+Bitrix24 caps batch size at 50 commands. For larger groups:
+
+```ts
+import { type AjaxResultParams } from '@bitrix24/b24jssdk'
+
+const calls = ids.map(id => ([
+  'crm.item.update',
+  { entityTypeId: EnumCrmEntityTypeId.deal, id, fields: { stageId: 'WON' } }
+]) as [string, AjaxResultParams])
+
+const result = await $b24.callBatchByChunk(calls, true)
+```
+
+The SDK splits into 50-command chunks, executes them sequentially, and merges results into a single `Result`. Limiter throttling applies between chunks.
+
+## Choosing batch vs list
+
+- Need a known set of *different* methods → `callBatch` (object form).
+- Need *all* rows of one method → `callListMethod` or `fetchListMethod` (see [list-pagination](list-pagination.md)).
+- Need to mutate a known array of rows → `callBatchByChunk` with one update per row.
+
+## Anti-patterns
+
+- Wrapping every call in a one-element batch — adds overhead for no benefit.
+- Writing your own `chunkArray` loop around `callBatch` — `callBatchByChunk` already exists.
+- Mixing object and array shapes inside a single `callBatch` call.
+- Using `isHaltOnError=true` then a `try/catch` *and* expecting partial results — pick one strategy.

--- a/skills/b24-jssdk/references/recipes/batch-calls.md
+++ b/skills/b24-jssdk/references/recipes/batch-calls.md
@@ -1,137 +1,56 @@
-# Batch calls
+# Batch calls — decision page
 
-`b24.actions.v3.batch.make` (or `v2.batch.make`) packs multiple REST calls into one round-trip. Reach for it whenever you need 2+ related calls and latency matters. For batches larger than 50 commands use `batchByChunk.make` — the SDK splits and merges for you.
+When and which batch shape to use. Code examples live in the version-specific recipes:
 
-The legacy `$b24.callBatch(...)` still works but is deprecated; new code uses the action managers.
+- **v2 examples:** [rest-api-v2 → Batch](rest-api-v2.md#batch--batchmake), [BatchByChunk](rest-api-v2.md#auto-chunked-batch--batchbychunkmake)
+- **v3 examples:** [rest-api-v3 → Batch](rest-api-v3.md#batch--batchmake), [BatchByChunk](rest-api-v3.md#auto-chunked-batch--batchbychunkmake)
 
-## Three input shapes
+## When to batch at all
 
-`b24.actions.v{2,3}.batch.make` accepts any of:
+| Need | Action |
+|---|---|
+| Single REST call | `call.make` (not `batch.make` with one item) |
+| 2 – 50 related calls in one round-trip | `batch.make` |
+| > 50 calls, or unknown / dynamic length | `batchByChunk.make` |
+| All rows of one list method | `callList.make` / `fetchList.make`, not batch — see [list-pagination](list-pagination.md) |
 
-1. **Array of tuples** — homogeneous batch of similar calls:
+## v2 vs v3 batching — both directions exist
 
-```ts
-import { Result } from '@bitrix24/b24jssdk'
+`b24.actions.v2.batch.make` and `b24.actions.v3.batch.make` are independent endpoints, not a v3-replacement-for-v2. Pick the version that matches the methods you're calling:
 
-const response = await $b24.actions.v3.batch.make({
-  calls: [
-    ['tasks.task.get', { id: 1, select: ['id', 'title'] }],
-    ['tasks.task.get', { id: 2, select: ['id', 'title'] }],
-    ['tasks.task.get', { id: 3, select: ['id', 'title'] }]
-  ],
-  options: {
-    isHaltOnError: true,
-    requestId: 'tasks-batch'
-  }
-})
-```
+- All commands are v2 methods → `v2.batch.make`. This is most batches today (CRM, IM, user, options, …).
+- All commands are v3-supported (`tasks.task.*`, `main.eventlog.*`, meta endpoints) → `v3.batch.make`.
+- Mix of v2-only and v3 in the same group → **not allowed in one batch.** Split into two `batch.make` calls (one per version), or downgrade everything to v2 if the v3 methods also exist there.
 
-2. **Array of objects** — same as tuples but with named keys for readability:
+`b24.actions.v3.batch.make` throws `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3` at call time if any one command isn't v3-supported. See [rest-api-v3 → When to use](rest-api-v3.md#when-to-use-v3--and-when-not-to) for the current v3 method list.
 
-```ts
-await $b24.actions.v3.batch.make({
-  calls: [
-    { method: 'tasks.task.get', params: { id: 1, select: ['id', 'title'] } },
-    { method: 'tasks.task.get', params: { id: 2, select: ['id', 'title'] } }
-  ]
-})
-```
+## Input shapes
 
-3. **Named object** — when you want results keyed for the consumer:
+All three shapes work in both v2 and v3 `batch.make` (only the named-object shape is unsupported by `batchByChunk.make`):
 
-```ts
-interface TaskItem { id: number, title: string }
-interface LogItem { id: number, userId: number }
+- **Array of tuples** — `[[method, params], ...]`. Compact; best for homogeneous lists.
+- **Array of objects** — `[{ method, params }, ...]`. Same as tuples, more readable.
+- **Named object** — `{ Name: { method, params }, ... }`. Results keyed by the names you choose; best when the consumer code wants to address results by name.
 
-const response = await $b24.actions.v3.batch.make<{ item: TaskItem } | { items: LogItem[] }>({
-  calls: {
-    Task: { method: 'tasks.task.get', params: { id: 1, select: ['id', 'title'] } },
-    Log: ['main.eventlog.list', { select: ['id', 'userId'], pagination: { limit: 5 } }]
-  },
-  options: {
-    isHaltOnError: true,
-    returnAjaxResult: true
-  }
-})
+Pick whichever makes the consumer code clearest. See [rest-api-v2 → Batch](rest-api-v2.md#batch--batchmake) for a code sample of each.
 
-const data = response.getData() as Record<string, AjaxResult<any>>
-console.log(data.Task.getData().result.item)
-console.log(data.Log.getData().result.items)
-```
+## `isHaltOnError`
 
-Pick the shape that makes the consuming code clearest. The action class handles all three uniformly.
+| Value | Behaviour |
+|---|---|
+| `true` (default) | Reject on first failing command. Use for transactional groups |
+| `false` | Resolve; per-command errors accumulate on the returned `Result` (`response.errors`, `response.getErrorMessages()`). v2 only — v3 batches are all-or-nothing regardless |
 
-## `options` block
+## `returnAjaxResult`
 
-| Field | Default | Meaning |
-|---|---|---|
-| `isHaltOnError` | `true` | Stop on first failing command; the whole promise rejects. Set `false` to accumulate per-command errors |
-| `returnAjaxResult` | `false` | Wrap each result in `AjaxResult` so you can call `isMore()`, `getData()` etc. per command |
-| `requestId` | `undefined` | Stable id for tracking / dedup / debug logs |
-
-```ts
-const response = await $b24.actions.v3.batch.make({
-  calls,
-  options: {
-    isHaltOnError: false,
-    requestId: 'crm-sync-2026-05'
-  }
-})
-
-if (!response.isSuccess) {
-  for (const [index, err] of response.errors) {
-    console.warn('partial failure', index, err)
-  }
-}
-```
-
-## Auto-chunked batch — `batchByChunk.make`
-
-A single batch is capped at 50 commands. For larger groups (e.g. updating 500 deals), `batchByChunk` splits internally and runs the chunks sequentially, respecting the limiter:
-
-```ts
-import type { BatchCommandsArrayUniversal } from '@bitrix24/b24jssdk'
-
-const commands: BatchCommandsArrayUniversal = ids.map((id) => [
-  'tasks.task.get',
-  { id, select: ['id', 'title'] }
-])
-
-const response = await $b24.actions.v3.batchByChunk.make<{ item: TaskItem }>({
-  calls: commands,
-  options: {
-    isHaltOnError: false,
-    requestId: 'tasks-bulk-fetch'
-  }
-})
-
-const items = response.getData() // flat T[] of successful rows
-```
-
-Notes:
-
-- **Named-object input is not supported** for `batchByChunk` — chunks couldn't preserve named keys reliably. Use array shapes.
-- **`returnAjaxResult` is forced to `false`** — the action flattens results to `T[]`.
-- For very large operations (10 000+ commands) consider server-side task queues instead.
-
-## v2 vs v3
-
-Both versions expose identical action names and option shapes. Differences live in the REST methods themselves:
-
-- v3 — newer methods (`tasks.task.*`, `main.eventlog.*`, …). Some methods only exist in v3.
-- v2 — older surface, mandatory for legacy CRM-style methods (`crm.item.list`, `crm.deal.list`, etc.).
-
-If a method exists in v3 but you call it through `v2.call.make`, the SDK logs a warning suggesting the migration. Pick the version that matches the REST method — when in doubt, try v3 first; if you get `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`, fall back to v2.
-
-## Choosing batch vs list
-
-- Different methods, known set → `batch.make` (named object form).
-- All rows of one list method → `callList.make` / `fetchList.make` (see [list-pagination](list-pagination.md)).
-- Update/mutate a known array of rows → `batchByChunk.make`.
+- `false` (default) — `response.getData()` returns flat data per command.
+- `true` — each value is an `AjaxResult` so you can call `isSuccess`, `getData`, etc. per command. Useful when individual commands return paginated results.
+- **Not supported by `batchByChunk.make`** — it forces `false` and flattens output to `T[]`.
 
 ## Anti-patterns
 
-- Wrapping a single call in `batch.make` — adds overhead for no benefit. Use `call.make`.
-- Hand-rolling chunking around `batch.make` — `batchByChunk.make` already does it correctly.
-- Mixing shapes in one call — pick array OR named object, don't combine.
-- Both `isHaltOnError: true` AND `try/catch` for partial recovery — pick one strategy.
+- Wrapping one call in `batch.make` — overhead with no benefit. Use `call.make`.
+- Hand-rolling 50-command chunking around `batch.make` — `batchByChunk.make` already does this.
+- Mixing v2-only and v3 methods inside one `v3.batch.make` — throws. Split or downgrade.
+- Both `isHaltOnError: true` *and* a `try/catch` for partial recovery — pick one strategy.
+- Using a named-object shape with `batchByChunk.make` — not supported (chunks can't preserve named keys reliably).

--- a/skills/b24-jssdk/references/recipes/batch-calls.md
+++ b/skills/b24-jssdk/references/recipes/batch-calls.md
@@ -1,108 +1,137 @@
 # Batch calls
 
-`callBatch` lets you send multiple REST calls in one request. Use it whenever:
+`b24.actions.v3.batch.make` (or `v2.batch.make`) packs multiple REST calls into one round-trip. Reach for it whenever you need 2+ related calls and latency matters. For batches larger than 50 commands use `batchByChunk.make` — the SDK splits and merges for you.
 
-- You need 2+ related calls and round-trip latency matters.
-- You want a transactional "all-or-nothing" group (`isHaltOnError=true`).
-- You're collecting independent data sets (list of companies + list of contacts) — `isHaltOnError=false` accumulates per-command errors.
+The legacy `$b24.callBatch(...)` still works but is deprecated; new code uses the action managers.
 
-For batches larger than ~50 commands, use `callBatchByChunk` — the SDK chunks them for you.
+## Three input shapes
 
-## Two call shapes
+`b24.actions.v{2,3}.batch.make` accepts any of:
 
-### Object-keyed (frontend-friendly)
+1. **Array of tuples** — homogeneous batch of similar calls:
 
 ```ts
 import { Result } from '@bitrix24/b24jssdk'
 
-const batch: Result = await $b24.callBatch({
-  CompanyList: {
-    method: 'crm.item.list',
-    params: {
-      entityTypeId: EnumCrmEntityTypeId.company,
-      order: { id: 'desc' },
-      select: ['id', 'title']
-    }
-  },
-  ContactList: {
-    method: 'crm.item.list',
-    params: {
-      entityTypeId: EnumCrmEntityTypeId.contact,
-      select: ['id', 'name']
-    }
+const response = await $b24.actions.v3.batch.make({
+  calls: [
+    ['tasks.task.get', { id: 1, select: ['id', 'title'] }],
+    ['tasks.task.get', { id: 2, select: ['id', 'title'] }],
+    ['tasks.task.get', { id: 3, select: ['id', 'title'] }]
+  ],
+  options: {
+    isHaltOnError: true,
+    requestId: 'tasks-batch'
   }
-}, true) // isHaltOnError = true (default)
-
-const data = batch.getData()
-const companies = data.CompanyList.items ?? []
-const contacts = data.ContactList.items ?? []
+})
 ```
 
-Use the object form when keys make the receiving code clearer (named results map cleanly to UI sections, etc.).
-
-### Array (server-friendly)
+2. **Array of objects** — same as tuples but with named keys for readability:
 
 ```ts
-const batch: Result = await $b24.callBatch([
-  ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.company, select: ['id'] }],
-  ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.contact, select: ['id'] }]
-], true)
+await $b24.actions.v3.batch.make({
+  calls: [
+    { method: 'tasks.task.get', params: { id: 1, select: ['id', 'title'] } },
+    { method: 'tasks.task.get', params: { id: 2, select: ['id', 'title'] } }
+  ]
+})
 ```
 
-Use the array form when the calls are homogeneous (e.g. paging through the same method) — `getData()` returns an indexed result.
-
-## Halt-on-error semantics
-
-| `isHaltOnError` | Behaviour |
-|---|---|
-| `true` (default) | Promise rejects on the first failing command. Use for transactional groups |
-| `false` | Promise resolves; per-command errors live in `result.getErrors()`. Use when partial results are still useful |
+3. **Named object** — when you want results keyed for the consumer:
 
 ```ts
-const batch = await $b24.callBatch(calls, false)
-if (!batch.isSuccess) {
-  for (const err of batch.getErrors()) {
-    console.warn('partial failure', err)
+interface TaskItem { id: number, title: string }
+interface LogItem { id: number, userId: number }
+
+const response = await $b24.actions.v3.batch.make<{ item: TaskItem } | { items: LogItem[] }>({
+  calls: {
+    Task: { method: 'tasks.task.get', params: { id: 1, select: ['id', 'title'] } },
+    Log: ['main.eventlog.list', { select: ['id', 'userId'], pagination: { limit: 5 } }]
+  },
+  options: {
+    isHaltOnError: true,
+    returnAjaxResult: true
+  }
+})
+
+const data = response.getData() as Record<string, AjaxResult<any>>
+console.log(data.Task.getData().result.item)
+console.log(data.Log.getData().result.items)
+```
+
+Pick the shape that makes the consuming code clearest. The action class handles all three uniformly.
+
+## `options` block
+
+| Field | Default | Meaning |
+|---|---|---|
+| `isHaltOnError` | `true` | Stop on first failing command; the whole promise rejects. Set `false` to accumulate per-command errors |
+| `returnAjaxResult` | `false` | Wrap each result in `AjaxResult` so you can call `isMore()`, `getData()` etc. per command |
+| `requestId` | `undefined` | Stable id for tracking / dedup / debug logs |
+
+```ts
+const response = await $b24.actions.v3.batch.make({
+  calls,
+  options: {
+    isHaltOnError: false,
+    requestId: 'crm-sync-2026-05'
+  }
+})
+
+if (!response.isSuccess) {
+  for (const [index, err] of response.errors) {
+    console.warn('partial failure', index, err)
   }
 }
 ```
 
-## `returnAjaxResult` — per-command `AjaxResult`
+## Auto-chunked batch — `batchByChunk.make`
+
+A single batch is capped at 50 commands. For larger groups (e.g. updating 500 deals), `batchByChunk` splits internally and runs the chunks sequentially, respecting the limiter:
 
 ```ts
-const batch = await $b24.callBatch(calls, true, true)
-// batch.getData() now contains AjaxResult objects per command
-// — useful when individual commands return paginated results
+import type { BatchCommandsArrayUniversal } from '@bitrix24/b24jssdk'
+
+const commands: BatchCommandsArrayUniversal = ids.map((id) => [
+  'tasks.task.get',
+  { id, select: ['id', 'title'] }
+])
+
+const response = await $b24.actions.v3.batchByChunk.make<{ item: TaskItem }>({
+  calls: commands,
+  options: {
+    isHaltOnError: false,
+    requestId: 'tasks-bulk-fetch'
+  }
+})
+
+const items = response.getData() // flat T[] of successful rows
 ```
 
-Reach for this only when you actually need `isMore()` / `getNext()` per command. Otherwise the default flat shape is simpler.
+Notes:
 
-## `callBatchByChunk` — large batches
+- **Named-object input is not supported** for `batchByChunk` — chunks couldn't preserve named keys reliably. Use array shapes.
+- **`returnAjaxResult` is forced to `false`** — the action flattens results to `T[]`.
+- For very large operations (10 000+ commands) consider server-side task queues instead.
 
-Bitrix24 caps batch size at 50 commands. For larger groups:
+## v2 vs v3
 
-```ts
-import { type AjaxResultParams } from '@bitrix24/b24jssdk'
+Both versions expose identical action names and option shapes. Differences live in the REST methods themselves:
 
-const calls = ids.map(id => ([
-  'crm.item.update',
-  { entityTypeId: EnumCrmEntityTypeId.deal, id, fields: { stageId: 'WON' } }
-]) as [string, AjaxResultParams])
+- v3 — newer methods (`tasks.task.*`, `main.eventlog.*`, …). Some methods only exist in v3.
+- v2 — older surface, mandatory for legacy CRM-style methods (`crm.item.list`, `crm.deal.list`, etc.).
 
-const result = await $b24.callBatchByChunk(calls, true)
-```
-
-The SDK splits into 50-command chunks, executes them sequentially, and merges results into a single `Result`. Limiter throttling applies between chunks.
+If a method exists in v3 but you call it through `v2.call.make`, the SDK logs a warning suggesting the migration. Pick the version that matches the REST method — when in doubt, try v3 first; if you get `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`, fall back to v2.
 
 ## Choosing batch vs list
 
-- Need a known set of *different* methods → `callBatch` (object form).
-- Need *all* rows of one method → `callListMethod` or `fetchListMethod` (see [list-pagination](list-pagination.md)).
-- Need to mutate a known array of rows → `callBatchByChunk` with one update per row.
+- Different methods, known set → `batch.make` (named object form).
+- All rows of one list method → `callList.make` / `fetchList.make` (see [list-pagination](list-pagination.md)).
+- Update/mutate a known array of rows → `batchByChunk.make`.
 
 ## Anti-patterns
 
-- Wrapping every call in a one-element batch — adds overhead for no benefit.
-- Writing your own `chunkArray` loop around `callBatch` — `callBatchByChunk` already exists.
-- Mixing object and array shapes inside a single `callBatch` call.
-- Using `isHaltOnError=true` then a `try/catch` *and* expecting partial results — pick one strategy.
+- Wrapping a single call in `batch.make` — adds overhead for no benefit. Use `call.make`.
+- Hand-rolling chunking around `batch.make` — `batchByChunk.make` already does it correctly.
+- Mixing shapes in one call — pick array OR named object, don't combine.
+- Both `isHaltOnError: true` AND `try/catch` for partial recovery — pick one strategy.

--- a/skills/b24-jssdk/references/recipes/frame-apps.md
+++ b/skills/b24-jssdk/references/recipes/frame-apps.md
@@ -1,0 +1,119 @@
+# Frame apps (iframe placements)
+
+For apps embedded in Bitrix24 as a placement. `B24Frame` talks to the parent window via `postMessage`, auto-refreshes auth on `401`, and exposes UI managers (`auth`, `parent`, `slider`, `dialog`, `placement`, `options`).
+
+Always bootstrap via `initializeB24Frame()` — never `new B24Frame(...)` directly. The loader parses `window.name` for the portal handshake and deduplicates concurrent inits.
+
+## Minimal boot
+
+```ts
+import {
+  initializeB24Frame,
+  B24Frame,
+  EnumCrmEntityTypeId,
+  Text,
+  LoggerBrowser,
+  type ISODate
+} from '@bitrix24/b24jssdk'
+
+const logger = LoggerBrowser.build('MyApp', import.meta.env?.DEV === true)
+let $b24: B24Frame
+
+async function boot() {
+  $b24 = await initializeB24Frame()
+  $b24.setLogger(logger)
+
+  const res = await $b24.callMethod('crm.item.list', {
+    entityTypeId: EnumCrmEntityTypeId.company,
+    order: { id: 'desc' },
+    select: ['id', 'title', 'createdTime']
+  })
+
+  const items = res.getData().result.map((it: any) => ({
+    id: Number(it.id),
+    title: it.title as string,
+    createdTime: Text.toDateTime(it.createdTime as ISODate)
+  }))
+
+  logger.info('items', items)
+}
+
+function teardown() {
+  $b24?.destroy()
+}
+```
+
+## Vue / Nuxt component lifecycle
+
+```ts
+import { onBeforeUnmount, onMounted, ref, shallowRef } from 'vue'
+import { initializeB24Frame, type B24Frame } from '@bitrix24/b24jssdk'
+
+const $b24 = shallowRef<B24Frame | null>(null)
+const ready = ref(false)
+
+onMounted(async () => {
+  $b24.value = await initializeB24Frame()
+  ready.value = true
+})
+
+onBeforeUnmount(() => {
+  $b24.value?.destroy()
+  $b24.value = null
+})
+```
+
+For Nuxt apps prefer the [Nuxt module](nuxt-module.md) — it ensures SSR-safe access.
+
+## React component lifecycle
+
+```ts
+import { useEffect, useRef, useState } from 'react'
+import { initializeB24Frame, type B24Frame } from '@bitrix24/b24jssdk'
+
+export function useB24() {
+  const ref = useRef<B24Frame | null>(null)
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const $b24 = await initializeB24Frame()
+      if (cancelled) {
+        $b24.destroy()
+        return
+      }
+      ref.current = $b24
+      setReady(true)
+    })()
+    return () => {
+      cancelled = true
+      ref.current?.destroy()
+      ref.current = null
+    }
+  }, [])
+
+  return { $b24: ref.current, ready }
+}
+```
+
+## Frame-only services on `$b24`
+
+Available only on `B24Frame` (not `B24Hook` / `B24OAuth`):
+
+- `auth` — `getAuthData()`, `refreshAuth()`, `isAdmin`, `getAppSid()`, `getUniq(prefix)`.
+- `parent` — `fitWindow()`, `resizeWindow(w,h)`, `resizeWindowAuto(node?, minH?, minW?)`, `setTitle(title)`, `closeApplication()`, `reloadWindow()`, `scrollParentWindow(scroll)`.
+- `slider` — `getUrl(path)`, `openPath(url[, width])`, `openSliderAppPage(params)`, `closeSliderAppPage()`.
+- `dialog` — `selectUser()`, `selectUsers()`. `selectAccess()` and `selectCRM()` exist but are deprecated.
+- `placement` — `title`, `options`, `isSliderMode`, `getInterface()`, `bindEvent(event, cb)`, `call(command, params)`, `callCustomBind(command, params?, cb)`.
+- `options` — `appGet/appSet`, `userGet/userSet`.
+- `getLang()` — portal UI language.
+
+For complete UI patterns see [ui-integrations](ui-integrations.md). For helper data (profile, currency, license) see [helper-manager](helper-manager.md).
+
+## Anti-patterns
+
+- Constructing `B24Frame` directly — bypasses the parent-window handshake.
+- Skipping `destroy()` on unmount — leaks `postMessage` listeners across navigations.
+- Calling `slider`/`dialog`/`parent` outside an iframe placement — those managers don't exist on `B24Hook` or `B24OAuth`.
+- Initializing on every render — keep one `$b24` per page/component scope.

--- a/skills/b24-jssdk/references/recipes/frame-apps.md
+++ b/skills/b24-jssdk/references/recipes/frame-apps.md
@@ -19,22 +19,32 @@ import {
 const logger = LoggerBrowser.build('MyApp', import.meta.env?.DEV === true)
 let $b24: B24Frame
 
+interface Company { id: number, title: string, createdTime: ISODate }
+
 async function boot() {
   $b24 = await initializeB24Frame()
   $b24.setLogger(logger)
 
-  const res = await $b24.callMethod('crm.item.list', {
-    entityTypeId: EnumCrmEntityTypeId.company,
-    order: { id: 'desc' },
-    select: ['id', 'title', 'createdTime']
+  const response = await $b24.actions.v2.call.make<{ items: Company[] }>({
+    method: 'crm.item.list',
+    params: {
+      entityTypeId: EnumCrmEntityTypeId.company,
+      order: { id: 'desc' },
+      select: ['id', 'title', 'createdTime']
+    },
+    requestId: 'companies-recent'
   })
 
-  const items = res.getData().result.map((it: any) => ({
-    id: Number(it.id),
-    title: it.title as string,
-    createdTime: Text.toDateTime(it.createdTime as ISODate)
-  }))
+  if (!response.isSuccess) {
+    logger.error('failed', response.getErrorMessages())
+    return
+  }
 
+  const items = response.getData().result.items.map((it) => ({
+    id: it.id,
+    title: it.title,
+    createdTime: Text.toDateTime(it.createdTime)
+  }))
   logger.info('items', items)
 }
 
@@ -97,6 +107,19 @@ export function useB24() {
 }
 ```
 
+## REST surface (shared with `B24Hook` / `B24OAuth`)
+
+All REST calls go through the action managers:
+
+- `$b24.actions.v3.call.make({ method, params, requestId })` — single v3 call.
+- `$b24.actions.v2.call.make(...)` — single v2 call (legacy CRM-style methods).
+- `$b24.actions.v{2,3}.callList.make(...)` — auto-paged list, in memory.
+- `$b24.actions.v{2,3}.fetchList.make(...)` — async generator for large lists.
+- `$b24.actions.v{2,3}.batch.make({ calls, options })` — ≤ 50 commands per batch.
+- `$b24.actions.v{2,3}.batchByChunk.make({ calls, options })` — auto-chunked.
+
+See [conventions](../guidelines/conventions.md) for the full overview, [batch-calls](batch-calls.md), [list-pagination](list-pagination.md) for patterns.
+
 ## Frame-only services on `$b24`
 
 Available only on `B24Frame` (not `B24Hook` / `B24OAuth`):
@@ -117,3 +140,4 @@ For complete UI patterns see [ui-integrations](ui-integrations.md). For helper d
 - Skipping `destroy()` on unmount — leaks `postMessage` listeners across navigations.
 - Calling `slider`/`dialog`/`parent` outside an iframe placement — those managers don't exist on `B24Hook` or `B24OAuth`.
 - Initializing on every render — keep one `$b24` per page/component scope.
+- Using the deprecated `$b24.callMethod(...)` — switch to `$b24.actions.v{2,3}.call.make(...)`.

--- a/skills/b24-jssdk/references/recipes/frame-apps.md
+++ b/skills/b24-jssdk/references/recipes/frame-apps.md
@@ -109,16 +109,7 @@ export function useB24() {
 
 ## REST surface (shared with `B24Hook` / `B24OAuth`)
 
-All REST calls go through the action managers:
-
-- `$b24.actions.v3.call.make({ method, params, requestId })` — single v3 call.
-- `$b24.actions.v2.call.make(...)` — single v2 call (legacy CRM-style methods).
-- `$b24.actions.v{2,3}.callList.make(...)` — auto-paged list, in memory.
-- `$b24.actions.v{2,3}.fetchList.make(...)` — async generator for large lists.
-- `$b24.actions.v{2,3}.batch.make({ calls, options })` — ≤ 50 commands per batch.
-- `$b24.actions.v{2,3}.batchByChunk.make({ calls, options })` — auto-chunked.
-
-See [conventions](../guidelines/conventions.md) for the full overview, [batch-calls](batch-calls.md), [list-pagination](list-pagination.md) for patterns.
+All REST calls go through the action managers. The full pattern reference lives in [rest-api-v2](rest-api-v2.md) and [rest-api-v3](rest-api-v3.md); the decision pages are [batch-calls](batch-calls.md) and [list-pagination](list-pagination.md). Most methods today are v2-only (CRM, IM, user, profile, placement); v3 currently covers only `tasks.task.*` / `main.eventlog.*` + a few meta endpoints.
 
 ## Frame-only services on `$b24`
 

--- a/skills/b24-jssdk/references/recipes/helper-manager.md
+++ b/skills/b24-jssdk/references/recipes/helper-manager.md
@@ -1,0 +1,97 @@
+# Helper manager
+
+`useB24Helper()` is a closure-based composable that wires lifecycle around `B24HelperManager`. It loads portal/app/user metadata up front and exposes the Pull client. Use it whenever you need:
+
+- Current user info (`profileInfo`).
+- App metadata (`appInfo`, `appInfo.statusCode`).
+- Currency formatting (`currency.format`, `currency.getCurrencyLiteral`).
+- License-aware throttling (enterprise auto-tunes `RestrictionManager`).
+- Bulk app/user options with optional Pull notifications.
+- Pull (push) subscription — see [pull-client](pull-client.md).
+
+## Boot
+
+```ts
+import {
+  initializeB24Frame,
+  useB24Helper,
+  LoadDataType,
+  type TypePullMessage
+} from '@bitrix24/b24jssdk'
+
+const {
+  initB24Helper,
+  destroyB24Helper,
+  getB24Helper,
+  usePullClient,
+  useSubscribePullClient,
+  startPullClient
+} = useB24Helper()
+
+const $b24 = await initializeB24Frame()
+await initB24Helper($b24, [
+  LoadDataType.Profile,
+  LoadDataType.App,
+  LoadDataType.Currency,
+  LoadDataType.AppOptions,
+  LoadDataType.UserOptions
+])
+
+const helper = getB24Helper()
+console.log(helper.profileInfo.data.id)
+```
+
+Pass only the `LoadDataType` entries you actually need — each adds REST calls to the boot path. `Profile` and `App` are the most common.
+
+## Cleanup
+
+```ts
+destroyB24Helper()
+$b24.destroy()
+```
+
+In a Vue component, call `destroyB24Helper()` in `onBeforeUnmount` *before* `$b24.destroy()`.
+
+## Currency
+
+```ts
+const helper = getB24Helper()
+
+const fullName = helper.currency.getCurrencyFullName('USD', 'en')
+const symbol = helper.currency.getCurrencyLiteral('USD', 'en')
+const formatted = helper.currency.format(1234.56, 'USD', 'en')
+```
+
+Use these for any UI that displays prices — they respect the portal's currency configuration. Don't hard-code `'$'` / decimal separators.
+
+## App options (helper level)
+
+The helper-level `OptionsManager` adds bulk save + optional Pull notifications on top of the frame-level `options.appSet/userSet`:
+
+```ts
+await helper.appOptions.save(
+  { featureFlags: helper.appOptions.encode({ a: 1 }) },
+  {
+    moduleId: 'application',
+    command: 'FEATURES_UPDATED',
+    params: { source: 'app' }
+  }
+)
+
+const cfg = helper.appOptions.getJsonObject('featureFlags', {})
+```
+
+Use this when:
+
+- You're saving multiple keys at once (one round-trip instead of N).
+- Other open instances of the app should react to the change — pass the Pull `command` and they'll receive it.
+
+## License-aware throttling
+
+`LicenseManager` (loaded as part of `LoadDataType.App`) detects enterprise portals and swaps `RestrictionManager` params automatically. No code change needed — just include `LoadDataType.App` in the boot list.
+
+## Anti-patterns
+
+- Loading all `LoadDataType.*` entries "to be safe" — adds REST calls at boot for data you don't use.
+- Calling `getB24Helper()` before `initB24Helper()` resolves — returns no data.
+- Bypassing `useB24Helper()` and using `B24HelperManager` directly — you lose the lifecycle wiring around Pull.

--- a/skills/b24-jssdk/references/recipes/list-pagination.md
+++ b/skills/b24-jssdk/references/recipes/list-pagination.md
@@ -1,91 +1,146 @@
 # List pagination
 
-Three strategies — pick by dataset size and control needs.
+Two action types — pick by dataset size. The legacy `$b24.callListMethod` / `$b24.fetchListMethod` are deprecated; new code uses the action managers.
 
 ## Decision matrix
 
-| Dataset | Control needed | Use | Returns |
-|---|---|---|---|
-| Small (< 1000 known) | None | `callListMethod` | `Promise<Result>` (full array via `getData()`) |
-| Large / unknown | None | `fetchListMethod` | `AsyncGenerator<any[]>` (iterate with `for await`) |
-| Any | Custom paging, pauses, dynamic stop conditions | `callMethod` + `getNext()` | manual `AjaxResult` chain |
+| Dataset | Use | Returns |
+|---|---|---|
+| Small (< 1000 known) | `b24.actions.v{2,3}.callList.make` | `Promise<Result<T[]>>` — full array in memory |
+| Large / unknown | `b24.actions.v{2,3}.fetchList.make` | `AsyncGenerator<T[]>` — iterate with `for await` |
+| Custom paging, dynamic stop, manual throttling | `b24.actions.v{2,3}.call.make` + `AjaxResult.isMore()` / `getNext()` | manual `AjaxResult` chain |
 
-## A) Small datasets — `callListMethod`
+## Required options
 
-Loads everything into memory. Simple, but watch heap usage above ~1000 items.
+Both `callList.make` and `fetchList.make` use **cursor-based pagination** by ordering on a unique id field. That has consequences:
+
+- **`customKeyForResult` is required in v3** (no default). For `crm.item.list` it's `'items'`. For most v3 list methods it's `'items'`. The action uses this to extract the array from the REST response payload.
+- **`customKeyForResult` is optional in v2** (defaults to `null` — the result array is the response root). Pass it explicitly when v2 wraps results under a key.
+- **`idKey` defaults to `'id'` in v3 and `'ID'` in v2.** Match the casing your method actually returns.
+- **`order` is ignored** if you pass it — the cursor must order by `idKey`. The action logs a warning. Use `filter` to narrow.
+
+## A) Small datasets — `callList.make`
 
 ```ts
-import { EnumCrmEntityTypeId, Result } from '@bitrix24/b24jssdk'
+import { EnumCrmEntityTypeId, Text } from '@bitrix24/b24jssdk'
 
-const response: Result = await $b24.callListMethod(
-  'crm.item.list',
-  {
+interface Company { id: number, title: string }
+
+const sixMonthAgo = new Date()
+sixMonthAgo.setMonth(sixMonthAgo.getMonth() - 6)
+
+const response = await $b24.actions.v2.callList.make<Company>({
+  method: 'crm.item.list',
+  params: {
     entityTypeId: EnumCrmEntityTypeId.company,
-    order: { id: 'asc' },
+    filter: {
+      '=%title': 'A%',
+      '>=createdTime': Text.toB24Format(sixMonthAgo)
+    },
     select: ['id', 'title']
   },
-  (progress: number) => {
-    // optional 0..100 callback
-  }
-)
+  idKey: 'id',                // crm.item.list uses lowercase 'id'
+  customKeyForResult: 'items',
+  requestId: 'companies-list'
+})
 
-const items = response.getData() as any[]
+if (!response.isSuccess) {
+  throw new Error(response.getErrorMessages().join('; '))
+}
+
+const items: Company[] = response.getData() ?? []
 ```
 
-A fourth `customKey` argument lets you target a non-default response key — needed for some non-CRM list methods.
+For a v3 method (e.g. `main.eventlog.list`):
 
-## B) Large datasets — `fetchListMethod` (preferred)
+```ts
+interface LogItem { id: number, userId: number }
 
-Streams chunks via async iterator; constant memory regardless of total size.
+const response = await $b24.actions.v3.callList.make<LogItem>({
+  method: 'main.eventlog.list',
+  params: {
+    filter: [
+      ['timestampX', '>=', Text.toB24Format(sixMonthAgo)]
+    ],
+    select: ['id', 'userId']
+  },
+  idKey: 'id',
+  customKeyForResult: 'items',
+  requestId: 'eventlog-list',
+  limit: 60                   // v3 lets you tune page size; default 50, max 1000
+})
+```
+
+## B) Large datasets — `fetchList.make` (preferred)
+
+Streams chunks via async iterator — constant memory regardless of total size.
 
 ```ts
 import { EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
 
-for await (const chunk of $b24.fetchListMethod(
-  'crm.item.list',
-  { entityTypeId: EnumCrmEntityTypeId.deal, select: ['id', 'title'] },
-  'id' // idKey
-)) {
+interface Deal { id: number, title: string }
+
+const generator = $b24.actions.v2.fetchList.make<Deal>({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.deal,
+    select: ['id', 'title']
+  },
+  idKey: 'id',
+  customKeyForResult: 'items',
+  requestId: 'deals-stream'
+})
+
+for await (const chunk of generator) {
   for (const row of chunk) {
     // process row
   }
 }
 ```
 
-**`idKey` matters.** For `crm.item.list` payloads (v3 entities) the field is lowercase `id`. For older v2-style methods (`crm.deal.list`, `crm.lead.list`, …) it's uppercase `'ID'` (also the default). When in doubt, log one chunk and check the key casing.
+`fetchList.make` is **not async itself** — it returns the generator synchronously. Iteration drives the calls. Errors throw an `SdkError` with code `JSSDK_CORE_B24_FETCH_LIST_METHOD_API_V{2,3}` inside the `for await` loop.
 
-## C) Manual paging — `callMethod` + `getNext()`
+## C) Manual paging — `call.make` + `getNext()`
 
 Use when you need pauses, dynamic stop conditions, or custom backoff between pages.
 
 ```ts
 import { EnumCrmEntityTypeId, AjaxResult } from '@bitrix24/b24jssdk'
 
-const all: any[] = []
+interface Contact { id: number, name: string }
 
-let page: AjaxResult = await $b24.callMethod('crm.item.list', {
-  entityTypeId: EnumCrmEntityTypeId.contact,
-  order: { id: 'asc' },
-  select: ['id', 'name']
-}, 0) // start cursor
+const all: Contact[] = []
 
-all.push(...(page.getData().result as any[]))
+let page: AjaxResult<{ items: Contact[] }> = await $b24.actions.v2.call.make({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.contact,
+    order: { id: 'asc' },
+    select: ['id', 'name'],
+    start: 0
+  }
+})
+
+all.push(...page.getData().result.items)
 
 while (page.isMore()) {
   const next = await page.getNext($b24.getHttpClient())
   if (next === false) break
 
   // your throttling / dynamic stop checks here
-  all.push(...(next.getData().result as any[]))
-  page = next
+  all.push(...next.getData().result.items)
+  page = next as typeof page
 }
 ```
 
+Reach for this only when you genuinely need page-by-page control — otherwise B is simpler and respects the limiter automatically.
+
 ## Pitfalls
 
-- **Wrong `idKey` in `fetchListMethod`** — the iterator silently never advances. If a fetch loop hangs at the first chunk, double-check the key casing.
-- **Calling `getData()` on a list `Result` and expecting an object** — `callListMethod` returns an array. The single-call `getData()` shape is different.
-- **Building a `for ... of` over `fetchListMethod`** — it's async; use `for await ... of`.
-- **Manually re-implementing C** for what fits B — only reach for manual paging when you genuinely need control.
+- **Missing `customKeyForResult` in v3** — TypeScript catches it (it's required), but runtime users sometimes shape-cast around the type. Always pass it.
+- **Wrong `idKey` casing** — v2 default is `'ID'`, v3 default is `'id'`. For `crm.item.list` (a v2 method that uses lowercase fields) explicitly pass `idKey: 'id'`.
+- **Passing `order`** — silently ignored with a warning. Cursor pagination requires ordering by `idKey`.
+- **Iterating `fetchList.make` with `for ... of`** — it's async; use `for await ... of`.
+- **Using `callList.make` for 100 000+ rows** — that's a heap explosion. Switch to `fetchList.make`.
 
-See [batch-calls](batch-calls.md) for `callBatchByChunk` (mutating bulk arrays) and [rate-limiting](../guidelines/rate-limiting.md) for throttle tuning on long fetches.
+See [batch-calls](batch-calls.md) for `batchByChunk.make` (mutating bulk arrays) and [rate-limiting](../guidelines/rate-limiting.md) for throttle tuning on long fetches.

--- a/skills/b24-jssdk/references/recipes/list-pagination.md
+++ b/skills/b24-jssdk/references/recipes/list-pagination.md
@@ -2,8 +2,8 @@
 
 Choosing between `callList`, `fetchList`, and manual paging. Code examples live in the version-specific recipes:
 
-- **v2 examples:** [rest-api-v2 → callList](rest-api-v2.md#auto-paged-list--calllistmake), [fetchList](rest-api-v2.md#streamed-list--fetchlistmake-preferred-for-large-datasets)
-- **v3 examples:** [rest-api-v3 → callList](rest-api-v3.md#auto-paged-list--calllistmake), [fetchList](rest-api-v3.md#streamed-list--fetchlistmake-preferred-for-large-datasets)
+- **v2 examples:** [rest-api-v2](rest-api-v2.md) — see the "Auto-paged list" and "Streamed list" sections.
+- **v3 examples:** [rest-api-v3](rest-api-v3.md) — same sections, mirror structure.
 
 ## Decision matrix
 
@@ -25,7 +25,7 @@ The action names are identical (`callList`, `fetchList`) but the underlying APIs
 | Configurable `limit` | no | yes (default 50, max 1000) |
 | Counting without listing | use `AjaxResult.getTotal()` on `call.make` (deprecated, removed in 2.0.0) | use the `aggregate` action with `count` / `countDistinct` |
 
-Pick the version that matches the REST method. Most list methods today are v2 (`crm.item.list`, `crm.deal.list`, etc.); v3 currently has only `main.eventlog.list` and a handful of others. See [rest-api-v3 → When to use](rest-api-v3.md#when-to-use-v3--and-when-not-to) for the v3 method list.
+Pick the version that matches the REST method. Most list methods today are v2 (`crm.item.list`, `crm.deal.list`, etc.); v3 currently has only `main.eventlog.list` and a handful of others. See [rest-api-v3](rest-api-v3.md) for the v3 method list.
 
 ## `callList.make` vs `fetchList.make`
 
@@ -38,7 +38,7 @@ Cost-wise they're equivalent — both make the same number of REST calls with th
 
 **v2-only and deprecated.** `AjaxResult.isMore()` / `getNext()` / `getTotal()` rely on the v2 `next` / `total` envelope fields and are slated for removal in v2.0.0. v3 returns no `next` cursor at all — there's no v3 equivalent. Use `fetchList.make` for both versions.
 
-Reach for manual paging only when you genuinely need pauses, dynamic stop conditions, or custom backoff between pages on a v2 method that can't be expressed through `fetchList.make`. See [rest-api-v2 → Manual paging](rest-api-v2.md#manual-paging-via-ajaxresultgetnext-v2-only-deprecated) for the recipe.
+Reach for manual paging only when you genuinely need pauses, dynamic stop conditions, or custom backoff between pages on a v2 method that can't be expressed through `fetchList.make`. See [rest-api-v2](rest-api-v2.md) for the "Manual paging" recipe.
 
 ## Common pitfalls
 

--- a/skills/b24-jssdk/references/recipes/list-pagination.md
+++ b/skills/b24-jssdk/references/recipes/list-pagination.md
@@ -1,0 +1,91 @@
+# List pagination
+
+Three strategies — pick by dataset size and control needs.
+
+## Decision matrix
+
+| Dataset | Control needed | Use | Returns |
+|---|---|---|---|
+| Small (< 1000 known) | None | `callListMethod` | `Promise<Result>` (full array via `getData()`) |
+| Large / unknown | None | `fetchListMethod` | `AsyncGenerator<any[]>` (iterate with `for await`) |
+| Any | Custom paging, pauses, dynamic stop conditions | `callMethod` + `getNext()` | manual `AjaxResult` chain |
+
+## A) Small datasets — `callListMethod`
+
+Loads everything into memory. Simple, but watch heap usage above ~1000 items.
+
+```ts
+import { EnumCrmEntityTypeId, Result } from '@bitrix24/b24jssdk'
+
+const response: Result = await $b24.callListMethod(
+  'crm.item.list',
+  {
+    entityTypeId: EnumCrmEntityTypeId.company,
+    order: { id: 'asc' },
+    select: ['id', 'title']
+  },
+  (progress: number) => {
+    // optional 0..100 callback
+  }
+)
+
+const items = response.getData() as any[]
+```
+
+A fourth `customKey` argument lets you target a non-default response key — needed for some non-CRM list methods.
+
+## B) Large datasets — `fetchListMethod` (preferred)
+
+Streams chunks via async iterator; constant memory regardless of total size.
+
+```ts
+import { EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
+
+for await (const chunk of $b24.fetchListMethod(
+  'crm.item.list',
+  { entityTypeId: EnumCrmEntityTypeId.deal, select: ['id', 'title'] },
+  'id' // idKey
+)) {
+  for (const row of chunk) {
+    // process row
+  }
+}
+```
+
+**`idKey` matters.** For `crm.item.list` payloads (v3 entities) the field is lowercase `id`. For older v2-style methods (`crm.deal.list`, `crm.lead.list`, …) it's uppercase `'ID'` (also the default). When in doubt, log one chunk and check the key casing.
+
+## C) Manual paging — `callMethod` + `getNext()`
+
+Use when you need pauses, dynamic stop conditions, or custom backoff between pages.
+
+```ts
+import { EnumCrmEntityTypeId, AjaxResult } from '@bitrix24/b24jssdk'
+
+const all: any[] = []
+
+let page: AjaxResult = await $b24.callMethod('crm.item.list', {
+  entityTypeId: EnumCrmEntityTypeId.contact,
+  order: { id: 'asc' },
+  select: ['id', 'name']
+}, 0) // start cursor
+
+all.push(...(page.getData().result as any[]))
+
+while (page.isMore()) {
+  const next = await page.getNext($b24.getHttpClient())
+  if (next === false) break
+
+  // your throttling / dynamic stop checks here
+  all.push(...(next.getData().result as any[]))
+  page = next
+}
+```
+
+## Pitfalls
+
+- **Wrong `idKey` in `fetchListMethod`** — the iterator silently never advances. If a fetch loop hangs at the first chunk, double-check the key casing.
+- **Calling `getData()` on a list `Result` and expecting an object** — `callListMethod` returns an array. The single-call `getData()` shape is different.
+- **Building a `for ... of` over `fetchListMethod`** — it's async; use `for await ... of`.
+- **Manually re-implementing C** for what fits B — only reach for manual paging when you genuinely need control.
+
+See [batch-calls](batch-calls.md) for `callBatchByChunk` (mutating bulk arrays) and [rate-limiting](../guidelines/rate-limiting.md) for throttle tuning on long fetches.

--- a/skills/b24-jssdk/references/recipes/list-pagination.md
+++ b/skills/b24-jssdk/references/recipes/list-pagination.md
@@ -1,6 +1,9 @@
-# List pagination
+# List pagination — decision page
 
-Two action types — pick by dataset size. The legacy `$b24.callListMethod` / `$b24.fetchListMethod` are deprecated; new code uses the action managers.
+Choosing between `callList`, `fetchList`, and manual paging. Code examples live in the version-specific recipes:
+
+- **v2 examples:** [rest-api-v2 → callList](rest-api-v2.md#auto-paged-list--calllistmake), [fetchList](rest-api-v2.md#streamed-list--fetchlistmake-preferred-for-large-datasets)
+- **v3 examples:** [rest-api-v3 → callList](rest-api-v3.md#auto-paged-list--calllistmake), [fetchList](rest-api-v3.md#streamed-list--fetchlistmake-preferred-for-large-datasets)
 
 ## Decision matrix
 
@@ -8,141 +11,42 @@ Two action types — pick by dataset size. The legacy `$b24.callListMethod` / `$
 |---|---|---|
 | Small (< 1000 known) | `b24.actions.v{2,3}.callList.make` | `Promise<Result<T[]>>` — full array in memory |
 | Large / unknown | `b24.actions.v{2,3}.fetchList.make` | `AsyncGenerator<T[]>` — iterate with `for await` |
-| Custom paging, dynamic stop, manual throttling (v2 only) | `b24.actions.v2.call.make` + `AjaxResult.isMore()` / `getNext()` | manual `AjaxResult` chain |
+| Custom paging on a v2 method (pauses, dynamic stop) | `b24.actions.v2.call.make` + `AjaxResult.isMore()` / `getNext()` | manual `AjaxResult` chain |
 
-> **Manual paging is v2-only.** `AjaxResult.isMore()` / `getNext()` / `getTotal()` rely on the v2 `next` / `total` envelope fields and are `@deprecated`. v3 returns no `next` cursor — in v3 you must use `callList.make` / `fetchList.make`. For element counts in v3 use the `aggregate` action.
+## v2 vs v3 lists
 
-## Required options
+The action names are identical (`callList`, `fetchList`) but the underlying APIs differ:
 
-Both `callList.make` and `fetchList.make` use **cursor-based pagination** by ordering on a unique id field. That has consequences:
+| Aspect | v2 | v3 |
+|---|---|---|
+| Default `idKey` | `'ID'` | `'id'` |
+| `customKeyForResult` | optional (default `null` — array is at response root) | **required** |
+| Filter shape | object with operator-prefixed keys: `{ '>=createdTime': '...', '=%title': 'A%' }` | array of triples: `[['timestampX', '>=', '...']]` |
+| Configurable `limit` | no | yes (default 50, max 1000) |
+| Counting without listing | use `AjaxResult.getTotal()` on `call.make` (deprecated, removed in 2.0.0) | use the `aggregate` action with `count` / `countDistinct` |
 
-- **`customKeyForResult` is required in v3** (no default). For `crm.item.list` it's `'items'`. For most v3 list methods it's `'items'`. The action uses this to extract the array from the REST response payload.
-- **`customKeyForResult` is optional in v2** (defaults to `null` — the result array is the response root). Pass it explicitly when v2 wraps results under a key.
-- **`idKey` defaults to `'id'` in v3 and `'ID'` in v2.** Match the casing your method actually returns.
-- **`order` is ignored** if you pass it — the cursor must order by `idKey`. The action logs a warning. Use `filter` to narrow.
+Pick the version that matches the REST method. Most list methods today are v2 (`crm.item.list`, `crm.deal.list`, etc.); v3 currently has only `main.eventlog.list` and a handful of others. See [rest-api-v3 → When to use](rest-api-v3.md#when-to-use-v3--and-when-not-to) for the v3 method list.
 
-## A) Small datasets — `callList.make`
+## `callList.make` vs `fetchList.make`
 
-```ts
-import { EnumCrmEntityTypeId, Text } from '@bitrix24/b24jssdk'
+- **`callList.make`** — accumulates everything in memory before returning. Easier code, but a 100 000-row list will exhaust the heap.
+- **`fetchList.make`** — async generator, yields chunks as they arrive. Constant memory. Use this for anything you don't already know is small.
 
-interface Company { id: number, title: string }
+Cost-wise they're equivalent — both make the same number of REST calls with the same throttling. Pick by memory budget, not by REST budget.
 
-const sixMonthAgo = new Date()
-sixMonthAgo.setMonth(sixMonthAgo.getMonth() - 6)
+## Manual paging (`AjaxResult.isMore` / `getNext`)
 
-const response = await $b24.actions.v2.callList.make<Company>({
-  method: 'crm.item.list',
-  params: {
-    entityTypeId: EnumCrmEntityTypeId.company,
-    filter: {
-      '=%title': 'A%',
-      '>=createdTime': Text.toB24Format(sixMonthAgo)
-    },
-    select: ['id', 'title']
-  },
-  idKey: 'id',                // crm.item.list uses lowercase 'id'
-  customKeyForResult: 'items',
-  requestId: 'companies-list'
-})
+**v2-only and deprecated.** `AjaxResult.isMore()` / `getNext()` / `getTotal()` rely on the v2 `next` / `total` envelope fields and are slated for removal in v2.0.0. v3 returns no `next` cursor at all — there's no v3 equivalent. Use `fetchList.make` for both versions.
 
-if (!response.isSuccess) {
-  throw new Error(response.getErrorMessages().join('; '))
-}
+Reach for manual paging only when you genuinely need pauses, dynamic stop conditions, or custom backoff between pages on a v2 method that can't be expressed through `fetchList.make`. See [rest-api-v2 → Manual paging](rest-api-v2.md#manual-paging-via-ajaxresultgetnext-v2-only-deprecated) for the recipe.
 
-const items: Company[] = response.getData() ?? []
-```
+## Common pitfalls
 
-For a v3 method (e.g. `main.eventlog.list`):
+- **Wrong `idKey` casing** — v2 default `'ID'`, v3 default `'id'`. For v2 `crm.item.*` (lowercase fields) explicitly pass `idKey: 'id'`.
+- **Missing `customKeyForResult`** in v3 — required (no default). Forgetting it is caught by TypeScript at compile time.
+- **Passing `order`** to `callList.make` / `fetchList.make` — silently ignored with a warning. Cursor pagination orders by `idKey`. Use `filter` to narrow.
+- **`for ... of`** instead of `for await ... of` with `fetchList.make` — it's async.
+- **Mixing filter shapes between versions** — v2 wants the operator-prefixed object form; v3 wants array-of-triples. Cross-pasting examples breaks silently (filter ignored = full list).
+- **Using `callList.make` for 100 000+ rows** — heap explosion. Switch to `fetchList.make`.
 
-```ts
-interface LogItem { id: number, userId: number }
-
-const response = await $b24.actions.v3.callList.make<LogItem>({
-  method: 'main.eventlog.list',
-  params: {
-    filter: [
-      ['timestampX', '>=', Text.toB24Format(sixMonthAgo)]
-    ],
-    select: ['id', 'userId']
-  },
-  idKey: 'id',
-  customKeyForResult: 'items',
-  requestId: 'eventlog-list',
-  limit: 60                   // v3 lets you tune page size; default 50, max 1000
-})
-```
-
-## B) Large datasets — `fetchList.make` (preferred)
-
-Streams chunks via async iterator — constant memory regardless of total size.
-
-```ts
-import { EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
-
-interface Deal { id: number, title: string }
-
-const generator = $b24.actions.v2.fetchList.make<Deal>({
-  method: 'crm.item.list',
-  params: {
-    entityTypeId: EnumCrmEntityTypeId.deal,
-    select: ['id', 'title']
-  },
-  idKey: 'id',
-  customKeyForResult: 'items',
-  requestId: 'deals-stream'
-})
-
-for await (const chunk of generator) {
-  for (const row of chunk) {
-    // process row
-  }
-}
-```
-
-`fetchList.make` is **not async itself** — it returns the generator synchronously. Iteration drives the calls. Errors throw an `SdkError` with code `JSSDK_CORE_B24_FETCH_LIST_METHOD_API_V{2,3}` inside the `for await` loop.
-
-## C) Manual paging — `call.make` + `getNext()` (v2 only, deprecated)
-
-Use **only on v2 methods** when you need pauses, dynamic stop conditions, or custom backoff between pages. `AjaxResult.isMore()` / `getNext()` / `getTotal()` are `@deprecated` and slated for removal in v2.0.0 — there's no v3 equivalent (v3 has no `next` envelope; use `fetchList.make` instead).
-
-```ts
-import { EnumCrmEntityTypeId, AjaxResult } from '@bitrix24/b24jssdk'
-
-interface Contact { id: number, name: string }
-
-const all: Contact[] = []
-
-let page: AjaxResult<{ items: Contact[] }> = await $b24.actions.v2.call.make({
-  method: 'crm.item.list',
-  params: {
-    entityTypeId: EnumCrmEntityTypeId.contact,
-    order: { id: 'asc' },
-    select: ['id', 'name'],
-    start: 0
-  }
-})
-
-all.push(...page.getData().result.items)
-
-while (page.isMore()) {
-  const next = await page.getNext($b24.getHttpClient())
-  if (next === false) break
-
-  // your throttling / dynamic stop checks here
-  all.push(...next.getData().result.items)
-  page = next as typeof page
-}
-```
-
-Reach for this only when you genuinely need page-by-page control over a v2 method — otherwise B is simpler, works for both versions, and respects the limiter automatically.
-
-## Pitfalls
-
-- **Missing `customKeyForResult` in v3** — TypeScript catches it (it's required), but runtime users sometimes shape-cast around the type. Always pass it.
-- **Wrong `idKey` casing** — v2 default is `'ID'`, v3 default is `'id'`. For `crm.item.list` (a v2 method that uses lowercase fields) explicitly pass `idKey: 'id'`.
-- **Passing `order`** — silently ignored with a warning. Cursor pagination requires ordering by `idKey`.
-- **Iterating `fetchList.make` with `for ... of`** — it's async; use `for await ... of`.
-- **Using `callList.make` for 100 000+ rows** — that's a heap explosion. Switch to `fetchList.make`.
-
-See [batch-calls](batch-calls.md) for `batchByChunk.make` (mutating bulk arrays) and [rate-limiting](../guidelines/rate-limiting.md) for throttle tuning on long fetches.
+See [rate-limiting](../guidelines/rate-limiting.md) for throttle tuning on long fetches.

--- a/skills/b24-jssdk/references/recipes/list-pagination.md
+++ b/skills/b24-jssdk/references/recipes/list-pagination.md
@@ -8,7 +8,9 @@ Two action types — pick by dataset size. The legacy `$b24.callListMethod` / `$
 |---|---|---|
 | Small (< 1000 known) | `b24.actions.v{2,3}.callList.make` | `Promise<Result<T[]>>` — full array in memory |
 | Large / unknown | `b24.actions.v{2,3}.fetchList.make` | `AsyncGenerator<T[]>` — iterate with `for await` |
-| Custom paging, dynamic stop, manual throttling | `b24.actions.v{2,3}.call.make` + `AjaxResult.isMore()` / `getNext()` | manual `AjaxResult` chain |
+| Custom paging, dynamic stop, manual throttling (v2 only) | `b24.actions.v2.call.make` + `AjaxResult.isMore()` / `getNext()` | manual `AjaxResult` chain |
+
+> **Manual paging is v2-only.** `AjaxResult.isMore()` / `getNext()` / `getTotal()` rely on the v2 `next` / `total` envelope fields and are `@deprecated`. v3 returns no `next` cursor — in v3 you must use `callList.make` / `fetchList.make`. For element counts in v3 use the `aggregate` action.
 
 ## Required options
 
@@ -100,9 +102,9 @@ for await (const chunk of generator) {
 
 `fetchList.make` is **not async itself** — it returns the generator synchronously. Iteration drives the calls. Errors throw an `SdkError` with code `JSSDK_CORE_B24_FETCH_LIST_METHOD_API_V{2,3}` inside the `for await` loop.
 
-## C) Manual paging — `call.make` + `getNext()`
+## C) Manual paging — `call.make` + `getNext()` (v2 only, deprecated)
 
-Use when you need pauses, dynamic stop conditions, or custom backoff between pages.
+Use **only on v2 methods** when you need pauses, dynamic stop conditions, or custom backoff between pages. `AjaxResult.isMore()` / `getNext()` / `getTotal()` are `@deprecated` and slated for removal in v2.0.0 — there's no v3 equivalent (v3 has no `next` envelope; use `fetchList.make` instead).
 
 ```ts
 import { EnumCrmEntityTypeId, AjaxResult } from '@bitrix24/b24jssdk'
@@ -133,7 +135,7 @@ while (page.isMore()) {
 }
 ```
 
-Reach for this only when you genuinely need page-by-page control — otherwise B is simpler and respects the limiter automatically.
+Reach for this only when you genuinely need page-by-page control over a v2 method — otherwise B is simpler, works for both versions, and respects the limiter automatically.
 
 ## Pitfalls
 

--- a/skills/b24-jssdk/references/recipes/nuxt-module.md
+++ b/skills/b24-jssdk/references/recipes/nuxt-module.md
@@ -54,14 +54,20 @@ import { B24Hook, EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
 
 export default defineEventHandler(async () => {
   const $b24 = B24Hook.fromWebhookUrl(useRuntimeConfig().b24Hook)
-  $b24.offClientSideWarning?.()
+  $b24.offClientSideWarning()
 
-  const res = await $b24.callListMethod('crm.item.list', {
-    entityTypeId: EnumCrmEntityTypeId.company,
-    select: ['id', 'title']
+  const response = await $b24.actions.v2.callList.make({
+    method: 'crm.item.list',
+    params: {
+      entityTypeId: EnumCrmEntityTypeId.company,
+      select: ['id', 'title']
+    },
+    idKey: 'id',
+    customKeyForResult: 'items',
+    requestId: 'nuxt-companies'
   })
 
-  return res.getData()
+  return response.getData()
 })
 ```
 

--- a/skills/b24-jssdk/references/recipes/nuxt-module.md
+++ b/skills/b24-jssdk/references/recipes/nuxt-module.md
@@ -1,0 +1,78 @@
+# Nuxt module (`@bitrix24/b24jssdk-nuxt`)
+
+Thin Nuxt module wrapper — registers a single runtime plugin that makes the SDK SSR-safe. It does **not** wrap or rename SDK exports; you import from `@bitrix24/b24jssdk` exactly as in any other project.
+
+Use this module when building a Nuxt app that runs as a Bitrix24 placement or talks to the SDK from the client side. For pure server use (`B24Hook` in a Nuxt server route) the module isn't required, but it doesn't hurt.
+
+## Install
+
+```bash
+npx nuxi module add @bitrix24/b24jssdk-nuxt
+```
+
+This adds the module to `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@bitrix24/b24jssdk-nuxt']
+})
+```
+
+Compatibility: Nuxt `>=4.2.2`.
+
+## Use the SDK from a component
+
+```vue
+<script setup lang="ts">
+import { onBeforeUnmount, ref, shallowRef } from 'vue'
+import { initializeB24Frame, type B24Frame } from '@bitrix24/b24jssdk'
+
+const $b24 = shallowRef<B24Frame | null>(null)
+const ready = ref(false)
+
+if (import.meta.client) {
+  initializeB24Frame().then((b24) => {
+    $b24.value = b24
+    ready.value = true
+  })
+}
+
+onBeforeUnmount(() => {
+  $b24.value?.destroy()
+  $b24.value = null
+})
+</script>
+```
+
+Always guard `initializeB24Frame()` with `import.meta.client` (or `<ClientOnly>`) — it relies on `window` and the parent-window handshake, neither of which exist during SSR.
+
+## Server routes (`B24Hook`)
+
+```ts
+// server/api/companies.get.ts
+import { B24Hook, EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
+
+export default defineEventHandler(async () => {
+  const $b24 = B24Hook.fromWebhookUrl(useRuntimeConfig().b24Hook)
+  $b24.offClientSideWarning?.()
+
+  const res = await $b24.callListMethod('crm.item.list', {
+    entityTypeId: EnumCrmEntityTypeId.company,
+    select: ['id', 'title']
+  })
+
+  return res.getData()
+})
+```
+
+Keep webhook URLs in `runtimeConfig` (server-only secret), never in `runtimeConfig.public`.
+
+## When to update the module
+
+Per `CLAUDE.md`: **whenever the core SDK exposes a new public surface that needs SSR-safe access or Nuxt auto-imports, the module's runtime plugin must be updated.** A pure REST helper added to `AbstractB24` typically needs no module change; a new browser-only manager probably does.
+
+## Anti-patterns
+
+- Calling `initializeB24Frame()` in `<script setup>` without an `import.meta.client` guard — SSR throws.
+- Putting the webhook URL in `runtimeConfig.public` — leaks the secret to the client bundle.
+- Re-creating `B24Hook` per request when a singleton would work — the limiter state is per-instance and is more effective when shared.

--- a/skills/b24-jssdk/references/recipes/oauth-apps.md
+++ b/skills/b24-jssdk/references/recipes/oauth-apps.md
@@ -15,15 +15,26 @@ import {
   type B24OAuthSecret
 } from '@bitrix24/b24jssdk'
 
+// Persisted per-portal/user state — typically stored after the OAuth code exchange
 const authOptions: B24OAuthParams = {
+  applicationToken: '1xxxxx1694',
+  userId: 1,
+  memberId: '3xx2030386cyy1b',
+  accessToken: '1xxxxx1694',
+  refreshToken: '0xxxx4e000011e700000001000000260dc83b47c40e9b5fd501093674c4f5',
+  expires: 1745997853,           // epoch seconds
+  expiresIn: 3600,
+  scope: 'crm,catalog,bizproc,placement,user_brief',
   domain: 'your_domain.bitrix24.com',
-  // … remaining auth params (memberId, accessToken, refreshToken, expiresIn, …)
-  // see types/auth.ts for the full shape
+  clientEndpoint: 'https://your_domain.bitrix24.com/rest/',
+  serverEndpoint: 'https://oauth.bitrix.info/rest/',
+  status: 'L'
 }
 
+// App credentials from the Bitrix24 marketplace listing — never embed in client code
 const oAuthSecret: B24OAuthSecret = {
-  // client_id / client_secret + token-refresh endpoint config
-  // see types/auth.ts for the full shape
+  clientId: process.env.B24_CLIENT_ID!,
+  clientSecret: process.env.B24_CLIENT_SECRET!
 }
 
 const $b24 = new B24OAuth(authOptions, oAuthSecret, {
@@ -34,40 +45,49 @@ $b24.setLogger(LoggerBrowser.build('OAuthApp', true))
 $b24.offClientSideWarning() // server-side only — silence the browser warning
 ```
 
-The third argument is optional and accepts `restrictionParams` (partial) for the limiter stack. See [rate-limiting](../guidelines/rate-limiting.md). For the exact `B24OAuthParams` / `B24OAuthSecret` field lists, read [`packages/jssdk/src/types/auth.ts`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts) — those types are the contract.
+The third argument is optional and accepts a partial `restrictionParams` for the limiter stack — see [rate-limiting](../guidelines/rate-limiting.md). The authoritative shapes are in [`packages/jssdk/src/types/auth.ts`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts).
 
 ## REST calls — same as everywhere
 
 ```ts
-const response = await $b24.actions.v3.call.make({
+const response = await $b24.actions.v2.call.make({
   method: 'user.current'
 })
 
 console.log(response.getData().result)
 ```
 
-`$b24.actions.v{2,3}.{call,callList,fetchList,batch,batchByChunk}.make(options)` work identically to `B24Frame` and `B24Hook`. See [batch-calls](batch-calls.md) and [list-pagination](list-pagination.md).
+`$b24.actions.v{2,3}.{call,callList,fetchList,batch,batchByChunk}.make(options)` work identically to `B24Frame` and `B24Hook`. See [rest-api-v2](rest-api-v2.md) and [rest-api-v3](rest-api-v3.md). Most methods are v2-only today — `user.current` and `profile` included; only `tasks.task.*` / `main.eventlog.*` and meta endpoints are on v3 so far.
 
 ## Refresh-token lifecycle
 
 `B24OAuth` will use the refresh token automatically when the access token expires. Two callbacks let you plug into the cycle:
 
 ```ts
-$b24.setCallbackRefreshAuth((newAuth) => {
-  // Called after a successful refresh — persist the new tokens
-  // so a restart doesn't lose them.
-  saveTokens(newAuth)
+// Notification: a refresh just succeeded and the SDK now holds fresh tokens.
+// Persist them so a restart picks up where this process left off.
+$b24.setCallbackRefreshAuth(async ({ authData, b24OAuthParams }) => {
+  await saveTokens(b24OAuthParams) // { applicationToken, accessToken, refreshToken, expires, ... }
 })
 
-$b24.setCustomRefreshAuth(async (currentAuth) => {
-  // Optional: override how a new token is obtained.
-  // Useful when refresh lives in a separate service / database.
-  return fetchNewTokensFromYourBackend(currentAuth)
+// Override: produce a new token pair yourself, e.g. by calling a central
+// token-refresh service. Called instead of the SDK's built-in refresh.
+$b24.setCustomRefreshAuth(async () => {
+  return fetchNewTokensFromYourBackend()
+  // -> { access_token, refresh_token, expires, expires_in, client_endpoint,
+  //      server_endpoint, member_id, scope, status, domain }
 })
 
 // Tear down later if needed
 $b24.removeCallbackRefreshAuth()
 $b24.removeCustomRefreshAuth()
+```
+
+Signatures (from `types/auth.ts`):
+
+```ts
+type CallbackRefreshAuth = (params: { authData: AuthData, b24OAuthParams: B24OAuthParams }) => Promise<void>
+type CustomRefreshAuth = () => Promise<HandlerRefreshAuth>
 ```
 
 When the refresh itself fails (token revoked, app uninstalled), `B24OAuth` throws a typed `RefreshTokenError`. Catch it specifically and trigger your re-auth flow — don't catch it generically:
@@ -76,7 +96,7 @@ When the refresh itself fails (token revoked, app uninstalled), `B24OAuth` throw
 import { RefreshTokenError } from '@bitrix24/b24jssdk'
 
 try {
-  await $b24.actions.v3.call.make({ method: 'user.current' })
+  await $b24.actions.v2.call.make({ method: 'user.current' })
 } catch (e) {
   if (e instanceof RefreshTokenError) {
     // Token revoked or app uninstalled — redirect user to OAuth consent

--- a/skills/b24-jssdk/references/recipes/oauth-apps.md
+++ b/skills/b24-jssdk/references/recipes/oauth-apps.md
@@ -1,0 +1,51 @@
+# OAuth apps
+
+For local apps that authenticate via OAuth — the SDK manages access/refresh tokens and exposes the same REST surface as the other entry points. Use this when the app needs to operate across portals or sessions where a webhook isn't appropriate.
+
+For the full OAuth dance (redirect, code exchange) follow Bitrix24's [OAuth documentation](https://apidocs.bitrix24.com/api-reference/oauth/index.html). The SDK takes over once you have the token pair.
+
+## Construction
+
+`B24OAuth` is exported from `@bitrix24/b24jssdk` and is constructed with the access/refresh tokens and the portal endpoint. Inspect the type via [`api-surface`](../api-surface.md) or the source under `packages/jssdk/src/oauth/`.
+
+```ts
+import { B24OAuth, LoggerBrowser } from '@bitrix24/b24jssdk'
+
+const $b24 = new B24OAuth(/* access token, refresh token, endpoint */)
+$b24.setLogger(LoggerBrowser.build('OAuthApp', true))
+```
+
+## REST calls — same as everywhere
+
+```ts
+const res = await $b24.callMethod('user.current')
+console.log(res.getData().result)
+```
+
+`callMethod`, `callBatch`, `callListMethod`, `fetchListMethod`, `callBatchByChunk` work identically to `B24Frame` and `B24Hook`. See [batch-calls](batch-calls.md) and [list-pagination](list-pagination.md).
+
+## Refresh-token failures
+
+When the refresh token is invalid or expired, `B24OAuth` raises a typed error. Catch it specifically and trigger your re-auth flow — don't catch generically:
+
+```ts
+try {
+  const res = await $b24.callMethod('user.current')
+} catch (e) {
+  // Inspect e — if it's the refresh-token error, redirect to OAuth consent
+  // For other errors (AjaxError), follow normal error handling
+  throw e
+}
+```
+
+For details on error shapes and recommended branching, see [error-handling](../guidelines/error-handling.md).
+
+## Storing tokens
+
+The SDK does not persist tokens for you. Persist them in your app's database / session store and reconstruct `B24OAuth` from the stored values on each request (or keep an instance alive in a long-running process).
+
+## Anti-patterns
+
+- Re-using a single `B24OAuth` across users in a multi-tenant server — tokens are user-scoped.
+- Logging access tokens (even at `debug`). Treat them like passwords.
+- Catching the refresh-token error generically and retrying — the user must re-auth; retrying just spins.

--- a/skills/b24-jssdk/references/recipes/oauth-apps.md
+++ b/skills/b24-jssdk/references/recipes/oauth-apps.md
@@ -4,48 +4,107 @@ For local apps that authenticate via OAuth — the SDK manages access/refresh to
 
 For the full OAuth dance (redirect, code exchange) follow Bitrix24's [OAuth documentation](https://apidocs.bitrix24.com/api-reference/oauth/index.html). The SDK takes over once you have the token pair.
 
-## Construction
-
-`B24OAuth` is exported from `@bitrix24/b24jssdk` and is constructed with the access/refresh tokens and the portal endpoint. Inspect the type via [`api-surface`](../api-surface.md) or the source under `packages/jssdk/src/oauth/`.
+## Construct
 
 ```ts
-import { B24OAuth, LoggerBrowser } from '@bitrix24/b24jssdk'
+import {
+  B24OAuth,
+  ParamsFactory,
+  LoggerBrowser,
+  type B24OAuthParams,
+  type B24OAuthSecret
+} from '@bitrix24/b24jssdk'
 
-const $b24 = new B24OAuth(/* access token, refresh token, endpoint */)
+const authOptions: B24OAuthParams = {
+  domain: 'your_domain.bitrix24.com',
+  // … remaining auth params (memberId, accessToken, refreshToken, expiresIn, …)
+  // see types/auth.ts for the full shape
+}
+
+const oAuthSecret: B24OAuthSecret = {
+  // client_id / client_secret + token-refresh endpoint config
+  // see types/auth.ts for the full shape
+}
+
+const $b24 = new B24OAuth(authOptions, oAuthSecret, {
+  restrictionParams: ParamsFactory.getDefault()
+})
+
 $b24.setLogger(LoggerBrowser.build('OAuthApp', true))
+$b24.offClientSideWarning() // server-side only — silence the browser warning
 ```
+
+The third argument is optional and accepts `restrictionParams` (partial) for the limiter stack. See [rate-limiting](../guidelines/rate-limiting.md). For the exact `B24OAuthParams` / `B24OAuthSecret` field lists, read [`packages/jssdk/src/types/auth.ts`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/auth.ts) — those types are the contract.
 
 ## REST calls — same as everywhere
 
 ```ts
-const res = await $b24.callMethod('user.current')
-console.log(res.getData().result)
+const response = await $b24.actions.v3.call.make({
+  method: 'user.current'
+})
+
+console.log(response.getData().result)
 ```
 
-`callMethod`, `callBatch`, `callListMethod`, `fetchListMethod`, `callBatchByChunk` work identically to `B24Frame` and `B24Hook`. See [batch-calls](batch-calls.md) and [list-pagination](list-pagination.md).
+`$b24.actions.v{2,3}.{call,callList,fetchList,batch,batchByChunk}.make(options)` work identically to `B24Frame` and `B24Hook`. See [batch-calls](batch-calls.md) and [list-pagination](list-pagination.md).
 
-## Refresh-token failures
+## Refresh-token lifecycle
 
-When the refresh token is invalid or expired, `B24OAuth` raises a typed error. Catch it specifically and trigger your re-auth flow — don't catch generically:
+`B24OAuth` will use the refresh token automatically when the access token expires. Two callbacks let you plug into the cycle:
 
 ```ts
+$b24.setCallbackRefreshAuth((newAuth) => {
+  // Called after a successful refresh — persist the new tokens
+  // so a restart doesn't lose them.
+  saveTokens(newAuth)
+})
+
+$b24.setCustomRefreshAuth(async (currentAuth) => {
+  // Optional: override how a new token is obtained.
+  // Useful when refresh lives in a separate service / database.
+  return fetchNewTokensFromYourBackend(currentAuth)
+})
+
+// Tear down later if needed
+$b24.removeCallbackRefreshAuth()
+$b24.removeCustomRefreshAuth()
+```
+
+When the refresh itself fails (token revoked, app uninstalled), `B24OAuth` throws a typed `RefreshTokenError`. Catch it specifically and trigger your re-auth flow — don't catch it generically:
+
+```ts
+import { RefreshTokenError } from '@bitrix24/b24jssdk'
+
 try {
-  const res = await $b24.callMethod('user.current')
+  await $b24.actions.v3.call.make({ method: 'user.current' })
 } catch (e) {
-  // Inspect e — if it's the refresh-token error, redirect to OAuth consent
-  // For other errors (AjaxError), follow normal error handling
+  if (e instanceof RefreshTokenError) {
+    // Token revoked or app uninstalled — redirect user to OAuth consent
+    redirectToReauth()
+    return
+  }
   throw e
 }
 ```
 
-For details on error shapes and recommended branching, see [error-handling](../guidelines/error-handling.md).
+## `initIsAdmin`
+
+Optional — call once after construction if you need `$b24.auth.isAdmin`:
+
+```ts
+await $b24.initIsAdmin('init-1')
+console.log($b24.auth.isAdmin)
+```
+
+It calls the `profile` REST method internally and caches the admin flag on the auth manager.
 
 ## Storing tokens
 
-The SDK does not persist tokens for you. Persist them in your app's database / session store and reconstruct `B24OAuth` from the stored values on each request (or keep an instance alive in a long-running process).
+The SDK does not persist tokens for you. Store them in your app's database / session store. On each request (or worker startup) construct a `B24OAuth` from the stored values; on every successful refresh, your `setCallbackRefreshAuth` handler should write the new tokens back.
 
 ## Anti-patterns
 
 - Re-using a single `B24OAuth` across users in a multi-tenant server — tokens are user-scoped.
-- Logging access tokens (even at `debug`). Treat them like passwords.
-- Catching the refresh-token error generically and retrying — the user must re-auth; retrying just spins.
+- Logging access/refresh tokens (even at `debug`). Treat them like passwords.
+- Catching `RefreshTokenError` generically and retrying — the user must re-auth; retrying just spins.
+- Skipping `setCallbackRefreshAuth` — tokens silently rotate and your stored copy goes stale.

--- a/skills/b24-jssdk/references/recipes/pull-client.md
+++ b/skills/b24-jssdk/references/recipes/pull-client.md
@@ -1,0 +1,65 @@
+# Pull client (real-time events)
+
+The Bitrix24 Pull (push) channel delivers real-time events to the portal — chat messages, CRM updates, custom app events. The SDK ships a Pull client with WebSocket + long-polling connectors, channel manager, JSON-RPC, and protobuf decoders.
+
+The simplest entry is via `useB24Helper()` — see [helper-manager](helper-manager.md) for the surrounding lifecycle.
+
+## Subscribe to events
+
+```ts
+import {
+  initializeB24Frame,
+  useB24Helper,
+  LoadDataType,
+  type TypePullMessage
+} from '@bitrix24/b24jssdk'
+
+const {
+  initB24Helper,
+  destroyB24Helper,
+  usePullClient,
+  useSubscribePullClient,
+  startPullClient
+} = useB24Helper()
+
+const $b24 = await initializeB24Frame()
+await initB24Helper($b24, [LoadDataType.Profile, LoadDataType.App])
+
+usePullClient('myAppPrefix')
+useSubscribePullClient((m: TypePullMessage) => {
+  console.log('pull message', m.command, m.params)
+}, 'application')
+startPullClient()
+```
+
+Order matters:
+
+1. `initializeB24Frame()` — get a frame.
+2. `initB24Helper(...)` — load helper data (license-aware throttling, currency, etc.).
+3. `usePullClient(prefix)` — pass an app-specific prefix; identifies your channel within the portal.
+4. `useSubscribePullClient(handler, moduleId)` — register handlers per module (`'application'` for app-specific events).
+5. `startPullClient()` — open the connection.
+
+## Cleanup
+
+```ts
+destroyB24Helper()
+$b24.destroy()
+```
+
+The helper teardown stops the Pull client; `$b24.destroy()` removes the parent-window listener. **Always run both** on unmount, otherwise you'll leak WebSocket connections across navigations / HMR.
+
+## Notify other instances of the app
+
+`helper.appOptions.save(...)` accepts a Pull command parameter — when one instance of the app updates a setting, other instances receive a Pull message and can refresh their state. See [helper-manager](helper-manager.md) → "App options".
+
+## Direct access (advanced)
+
+`packages/jssdk/src/pullClient` exports the underlying client classes for cases where the helper-managed flow is too constrained. Most apps should not need this — reach for it only when you have a specific reason (custom transport, non-helper context).
+
+## Anti-patterns
+
+- Subscribing inside a component without unsubscribing — handlers accumulate across navigations.
+- Multiple `startPullClient()` calls — opens parallel connections.
+- Filtering events in the handler when you could pass the right `moduleId` to `useSubscribePullClient` — let the SDK route to your handler.
+- Relying on Pull for *guaranteed* delivery — treat it as an event hint and re-fetch authoritative state via REST when needed.

--- a/skills/b24-jssdk/references/recipes/rest-api-v2.md
+++ b/skills/b24-jssdk/references/recipes/rest-api-v2.md
@@ -1,0 +1,248 @@
+# REST API v2 (`b24.actions.v2.*`)
+
+Comprehensive reference for the v2 REST surface. Covers single calls, list retrieval (in-memory and streaming), and batched calls (≤ 50 and auto-chunked).
+
+The v3 mirror is in [rest-api-v3](rest-api-v3.md). The two trees are independent — `b24.actions.v2` and `b24.actions.v3` route through separate HTTP clients with separate cursor schemes. You cannot mix v2-only and v3-supported methods inside a single `batch.make` call.
+
+## When to use v2
+
+**Most code today.** The Bitrix24 v3 endpoint only supports a small set of `tasks.task.*` / `main.eventlog.*` methods + some meta endpoints. Everything CRM (`crm.item.*`, `crm.deal.*`, `crm.contact.*`, …), IM (`im.chat.*`, `im.message.*`, …), user/profile (`user.current`, `profile`), placement, options, and most settings is **v2-only**.
+
+When v3 doesn't have your method (you get `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`), use v2. See [rest-api-v3](rest-api-v3.md) for the current v3 method list.
+
+## Surface
+
+| Action | Path | Returns |
+|---|---|---|
+| Single call | `b24.actions.v2.call.make` | `Promise<AjaxResult<T>>` |
+| Auto-paged list | `b24.actions.v2.callList.make` | `Promise<Result<T[]>>` |
+| Streamed list | `b24.actions.v2.fetchList.make` | `AsyncGenerator<T[]>` |
+| Batch (≤ 50) | `b24.actions.v2.batch.make` | `Promise<CallBatchResult<T>>` |
+| Auto-chunked batch | `b24.actions.v2.batchByChunk.make` | `Promise<Result<T[]>>` |
+
+## Single call — `call.make`
+
+```ts
+import { EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
+
+interface Company { id: number, title: string }
+
+const response = await $b24.actions.v2.call.make<{ item: Company }>({
+  method: 'crm.item.get',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.company,
+    id: 123
+  },
+  requestId: 'company-123'
+})
+
+if (!response.isSuccess) {
+  throw new Error(response.getErrorMessages().join('; '))
+}
+console.log(response.getData().result.item.title)
+```
+
+Options: `{ method, params?, requestId? }`. `params` are the REST method's own parameters.
+
+## Auto-paged list — `callList.make`
+
+Loads the entire dataset into memory. Use for known small sets (< 1000 items).
+
+```ts
+import { EnumCrmEntityTypeId, Text } from '@bitrix24/b24jssdk'
+
+interface Company { id: number, title: string }
+
+const sixMonthAgo = new Date()
+sixMonthAgo.setMonth(sixMonthAgo.getMonth() - 6)
+
+const response = await $b24.actions.v2.callList.make<Company>({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.company,
+    filter: {
+      '=%title': 'A%',
+      '>=createdTime': Text.toB24Format(sixMonthAgo)
+    },
+    select: ['id', 'title']
+  },
+  idKey: 'id',                  // crm.item.list returns lowercase 'id'
+  customKeyForResult: 'items',
+  requestId: 'companies-recent'
+})
+
+const items: Company[] = response.getData() ?? []
+```
+
+Options: `{ method, params?, idKey?, customKeyForResult?, requestId? }`.
+
+- `idKey?` — id field used for cursor pagination. Default `'ID'`. For `crm.item.*` (lowercase fields) pass `idKey: 'id'`.
+- `customKeyForResult?` — payload-array key. Default `null` (= response root is the array). Pass `'items'` for `crm.item.list`, etc.
+- `order` (if provided) is **ignored** — cursor pagination orders by `idKey`. The action logs a warning. Use `filter` to narrow.
+- v2 filter shape is an object: `{ '>=createdTime': '...', '=%title': 'A%' }` (operator-prefixed keys).
+
+## Streamed list — `fetchList.make` (preferred for large datasets)
+
+Async generator — constant memory regardless of total size.
+
+```ts
+import { EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
+
+interface Deal { id: number, title: string }
+
+const generator = $b24.actions.v2.fetchList.make<Deal>({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.deal,
+    select: ['id', 'title']
+  },
+  idKey: 'id',
+  customKeyForResult: 'items',
+  requestId: 'deals-stream'
+})
+
+for await (const chunk of generator) {
+  for (const row of chunk) {
+    // process row
+  }
+}
+```
+
+Same options as `callList.make`. Errors throw `SdkError` with code `JSSDK_CORE_B24_FETCH_LIST_METHOD_API_V2` on the `for await` iteration.
+
+`fetchList.make` is **not async itself** — it returns the generator synchronously; iteration drives the calls.
+
+## Batch — `batch.make`
+
+Up to 50 commands per call. Three input shapes:
+
+```ts
+// 1) Array of tuples — homogeneous batches
+await $b24.actions.v2.batch.make({
+  calls: [
+    ['crm.item.get', { entityTypeId: 3, id: 1 }],
+    ['crm.item.get', { entityTypeId: 3, id: 2 }]
+  ],
+  options: { isHaltOnError: true, requestId: 'company-pair' }
+})
+
+// 2) Array of objects — same data, more readable
+await $b24.actions.v2.batch.make({
+  calls: [
+    { method: 'crm.item.get', params: { entityTypeId: 3, id: 1 } },
+    { method: 'crm.item.get', params: { entityTypeId: 3, id: 2 } }
+  ]
+})
+
+// 3) Named object — results keyed by name
+interface CompanyItem { id: number, title: string }
+interface ContactItem { id: number, name: string }
+
+const response = await $b24.actions.v2.batch.make<{ item: CompanyItem } | { item: ContactItem }>({
+  calls: {
+    Company: { method: 'crm.item.get', params: { entityTypeId: 3, id: 1 } },
+    Contact: ['crm.item.get', { entityTypeId: 4, id: 2 }]
+  },
+  options: {
+    isHaltOnError: true,
+    returnAjaxResult: true,
+    requestId: 'mixed-fetch'
+  }
+})
+
+const data = response.getData() as Record<'Company' | 'Contact', AjaxResult<{ item: CompanyItem | ContactItem }>>
+console.log(data.Company.getData().result.item)
+console.log(data.Contact.getData().result.item)
+```
+
+`options`:
+
+- `isHaltOnError?: boolean` — `true` (default): reject on first failing command. `false`: accumulate per-command errors on the returned `Result`.
+- `returnAjaxResult?: boolean` — `false` (default): flat data values; `true`: each value is an `AjaxResult` so you can inspect individual command status / pagination.
+- `requestId?: string` — for tracing.
+
+## Auto-chunked batch — `batchByChunk.make`
+
+For batches > 50 commands. Splits into 50-command chunks, runs them sequentially through the limiter, merges results.
+
+```ts
+import type { BatchCommandsArrayUniversal } from '@bitrix24/b24jssdk'
+
+const commands: BatchCommandsArrayUniversal = ids.map((id) => [
+  'crm.item.update',
+  { entityTypeId: EnumCrmEntityTypeId.deal, id, fields: { stageId: 'WON' } }
+])
+
+const response = await $b24.actions.v2.batchByChunk.make({
+  calls: commands,
+  options: {
+    isHaltOnError: false,
+    requestId: 'mark-deals-won'
+  }
+})
+
+if (!response.isSuccess) {
+  for (const [index, err] of response.errors) {
+    console.warn('chunk failure', index, err)
+  }
+}
+
+const okRows = response.getData() // flat T[] of successful rows
+```
+
+- **Named-object input is not supported** for `batchByChunk` — chunks can't preserve named keys. Use array shapes.
+- **`returnAjaxResult` is forced to `false`** — output is flattened `T[]`.
+
+## Choosing between actions
+
+| Need | Use |
+|---|---|
+| One call, one method | `call.make` |
+| All rows of one list method, known small | `callList.make` |
+| All rows of one list method, large/unknown | `fetchList.make` |
+| Different methods in one round-trip (≤ 50) | `batch.make` |
+| Mutate / read N rows where N > 50 | `batchByChunk.make` |
+| Custom paging on a v2 list method (pauses, dynamic stop) | `call.make` + `AjaxResult.getNext()` (deprecated, v2-only) |
+
+## Manual paging via `AjaxResult.getNext()` (v2-only, deprecated)
+
+`AjaxResult.isMore()` / `getNext()` / `getTotal()` are v2-only legacy helpers, `@deprecated` and slated for removal in v2.0.0. They rely on the v2 `next` / `total` envelope fields, which v3 doesn't return.
+
+Use only when you genuinely need page-by-page control over a v2 method that can't be expressed through `fetchList.make`:
+
+```ts
+import { EnumCrmEntityTypeId, type AjaxResult } from '@bitrix24/b24jssdk'
+
+interface Contact { id: number, name: string }
+
+const all: Contact[] = []
+
+let page: AjaxResult<{ items: Contact[] }> = await $b24.actions.v2.call.make({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.contact,
+    order: { id: 'asc' },
+    select: ['id', 'name'],
+    start: 0
+  }
+})
+
+all.push(...page.getData().result.items)
+
+while (page.isMore()) {
+  const next = await page.getNext($b24.getHttpClient())
+  if (next === false) break
+  all.push(...next.getData().result.items)
+  page = next as typeof page
+}
+```
+
+## Pitfalls
+
+- **Wrong `idKey` casing** — default is `'ID'` (uppercase). For `crm.item.*` payloads the field is lowercase `id` — pass `idKey: 'id'` explicitly.
+- **Missing `customKeyForResult`** — for methods that wrap rows under a key (e.g. `crm.item.list` → `'items'`), forgetting this makes the action return the whole response object instead of the array.
+- **Passing `order`** to `callList.make` / `fetchList.make` — silently ignored with a warning. Use `filter` to narrow.
+- **Using `for ... of`** instead of `for await ... of` with `fetchList.make` — it's an async generator.
+- **Putting `crm.item.list` in `v3.batch.make`** — throws `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`. Use this file's `v2.batch.make` instead.
+
+See [rate-limiting](../guidelines/rate-limiting.md) for tuning throughput on long fetches, and [error-handling](../guidelines/error-handling.md) for batch error semantics.

--- a/skills/b24-jssdk/references/recipes/rest-api-v3.md
+++ b/skills/b24-jssdk/references/recipes/rest-api-v3.md
@@ -1,0 +1,216 @@
+# REST API v3 (`b24.actions.v3.*`)
+
+Comprehensive reference for the v3 REST surface. Mirrors [rest-api-v2](rest-api-v2.md) — same action names, same `make({ … })` shape, different HTTP client and cursor schemes underneath.
+
+## When to use v3 — and when not to
+
+> **At this stage of the SDK, v3 supports only a small set of methods.** For most real-world code you'll be calling [v2](rest-api-v2.md). Use v3 when your method is in the supported list below; otherwise reach for v2 and switch later as the v3 surface grows.
+
+**Currently v3-supported methods** (from `packages/jssdk/src/core/version-manager.ts`):
+
+- `/batch`, `/scopes`, `/rest.scope.list`, `/rest.documentation.openapi`, `/documentation`
+- `/main.eventlog.list`, `/main.eventlog.get`, `/main.eventlog.tail`
+- `/tasks.task.add`, `/tasks.task.get`, `/tasks.task.update`, `/tasks.task.delete`
+- `/tasks.task.access.get`, `/tasks.task.file.attach`, `/tasks.task.chat.message.send`
+
+CRM (`crm.item.*`, `crm.deal.*`, …), IM (`im.*`), `user.current`, `profile`, placement, options, and the rest of the surface area is **v2-only** at the moment.
+
+Behaviour when you reach outside the supported list:
+
+- `b24.actions.v3.call.make({ method: 'crm.item.list', ... })` throws `SdkError(JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3)` immediately.
+- `b24.actions.v3.batch.make({ calls: [...] })` checks every method in the batch; if even one isn't v3, the whole call throws the same error. You cannot mix v2-only and v3-supported methods inside a single v3 batch.
+
+Practical guidance: **prefer v2 by default; switch the specific call to v3 only when the method is on the list above.** Skill recipes use v2 in their examples for that reason.
+
+## Surface
+
+| Action | Path | Returns |
+|---|---|---|
+| Single call | `b24.actions.v3.call.make` | `Promise<AjaxResult<T>>` |
+| Auto-paged list | `b24.actions.v3.callList.make` | `Promise<Result<T[]>>` |
+| Streamed list | `b24.actions.v3.fetchList.make` | `AsyncGenerator<T[]>` |
+| Batch (≤ 50) | `b24.actions.v3.batch.make` | `Promise<CallBatchResult<T>>` |
+| Auto-chunked batch | `b24.actions.v3.batchByChunk.make` | `Promise<Result<T[]>>` |
+
+## Single call — `call.make`
+
+```ts
+interface TaskItem { id: number, title: string }
+
+const response = await $b24.actions.v3.call.make<{ task: TaskItem }>({
+  method: 'tasks.task.get',
+  params: {
+    id: 123,
+    select: ['id', 'title']
+  },
+  requestId: 'task-123'
+})
+
+if (!response.isSuccess) {
+  throw new Error(response.getErrorMessages().join('; '))
+}
+console.log(response.getData().result.task.title)
+```
+
+Options: `{ method, params?, requestId? }`.
+
+## Auto-paged list — `callList.make`
+
+Loads the entire dataset into memory. Use for known small sets (< 1000 items).
+
+```ts
+import { Text } from '@bitrix24/b24jssdk'
+
+interface LogItem { id: number, userId: number }
+
+const sixMonthAgo = new Date()
+sixMonthAgo.setMonth(sixMonthAgo.getMonth() - 6)
+
+const response = await $b24.actions.v3.callList.make<LogItem>({
+  method: 'main.eventlog.list',
+  params: {
+    filter: [
+      ['timestampX', '>=', Text.toB24Format(sixMonthAgo)]
+    ],
+    select: ['id', 'userId']
+  },
+  idKey: 'id',
+  customKeyForResult: 'items',
+  requestId: 'eventlog-list',
+  limit: 200
+})
+
+const items: LogItem[] = response.getData() ?? []
+```
+
+Options: `{ method, params?, idKey?, customKeyForResult, requestId?, limit? }`.
+
+- **`customKeyForResult` is required** (no default in v3). Pass the payload-array key, e.g. `'items'`.
+- `idKey?` — id field for cursor pagination. Default `'id'` (lowercase).
+- `limit?` — page size; default `50`, max `1000`.
+- `order` (if provided) is **ignored** — cursor pagination orders by `idKey`. Use `filter`.
+- v3 filter shape is an **array of triples**: `[['timestampX', '>=', '...'], ['userId', '=', 5]]`. Different from v2's operator-prefixed object form.
+
+## Streamed list — `fetchList.make` (preferred for large datasets)
+
+Async generator — constant memory regardless of total size.
+
+```ts
+import { Text } from '@bitrix24/b24jssdk'
+
+interface LogItem { id: number, userId: number }
+
+const generator = $b24.actions.v3.fetchList.make<LogItem>({
+  method: 'main.eventlog.list',
+  params: {
+    filter: [['timestampX', '>=', Text.toB24Format(sixMonthAgo)]],
+    select: ['id', 'userId']
+  },
+  idKey: 'id',
+  customKeyForResult: 'items',
+  requestId: 'log-stream',
+  limit: 200
+})
+
+for await (const chunk of generator) {
+  for (const row of chunk) {
+    // process row
+  }
+}
+```
+
+Same options as `callList.make`. Errors throw `SdkError` with code `JSSDK_CORE_B24_FETCH_LIST_METHOD_API_V3` on the `for await` iteration.
+
+`fetchList.make` is **not async itself** — it returns the generator synchronously; iteration drives the calls.
+
+## Batch — `batch.make`
+
+Up to 50 commands per call. **All commands must be v3-supported** or the call throws `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`. Three input shapes:
+
+```ts
+interface TaskItem { id: number, title: string }
+
+// 1) Array of tuples
+await $b24.actions.v3.batch.make({
+  calls: [
+    ['tasks.task.get', { id: 1, select: ['id', 'title'] }],
+    ['tasks.task.get', { id: 2, select: ['id', 'title'] }]
+  ],
+  options: { isHaltOnError: true, requestId: 'tasks-pair' }
+})
+
+// 2) Array of objects
+await $b24.actions.v3.batch.make({
+  calls: [
+    { method: 'tasks.task.get', params: { id: 1, select: ['id', 'title'] } },
+    { method: 'tasks.task.get', params: { id: 2, select: ['id', 'title'] } }
+  ]
+})
+
+// 3) Named object — results keyed by name
+interface MainEventLogItem { id: number, userId: number }
+
+const response = await $b24.actions.v3.batch.make<{ task: TaskItem } | { items: MainEventLogItem[] }>({
+  calls: {
+    Task: { method: 'tasks.task.get', params: { id: 1, select: ['id', 'title'] } },
+    Log: ['main.eventlog.list', { select: ['id', 'userId'], pagination: { limit: 5 } }]
+  },
+  options: {
+    isHaltOnError: true,
+    returnAjaxResult: true,
+    requestId: 'tasks-and-log'
+  }
+})
+
+const data = response.getData() as Record<'Task' | 'Log', AjaxResult<{ task: TaskItem } | { items: MainEventLogItem[] }>>
+console.log(data.Task.getData().result)
+console.log(data.Log.getData().result)
+```
+
+`options`: same as v2 (`isHaltOnError`, `returnAjaxResult`, `requestId`).
+
+Note on `restApi:v3` batches: **all-or-nothing**. Per-command errors are not returned individually. If any one command fails the whole batch fails and `response.getErrorMessages()` carries the error. (`isHaltOnError: false` therefore has less meaning in v3 than in v2.)
+
+## Auto-chunked batch — `batchByChunk.make`
+
+Same constraints as v2: array shapes only (no named-object), `returnAjaxResult` forced to `false`.
+
+```ts
+import type { BatchCommandsArrayUniversal } from '@bitrix24/b24jssdk'
+
+const commands: BatchCommandsArrayUniversal = ids.map((id) => [
+  'tasks.task.update',
+  { id, fields: { status: '5' } }
+])
+
+const response = await $b24.actions.v3.batchByChunk.make({
+  calls: commands,
+  options: { isHaltOnError: false, requestId: 'tasks-bulk-update' }
+})
+
+const okRows = response.getData() // flat T[] of successful rows
+```
+
+## Choosing between actions
+
+| Need | Use |
+|---|---|
+| One call, one v3 method | `call.make` |
+| All rows of one v3 list method, known small | `callList.make` |
+| All rows of one v3 list method, large/unknown | `fetchList.make` |
+| Different v3 methods in one round-trip (≤ 50) | `batch.make` |
+| Mutate / read N rows where N > 50 | `batchByChunk.make` |
+| Counting elements without listing them | `aggregate` action with `count` / `countDistinct` (v3-only) |
+
+Manual paging via `AjaxResult.isMore()` / `getNext()` / `getTotal()` is **v2-only** — v3 returns no `next` / `total` envelope. If you need a total count in v3, use the `aggregate` action.
+
+## Pitfalls
+
+- **Calling a v2-only method via `v3.call.make`** — throws immediately. Move the call to `v2.call.make` or pick a v3-supported method.
+- **Missing `customKeyForResult`** — required in v3. TypeScript catches it; runtime users sometimes cast around the type.
+- **Wrong `idKey`** — default is `'id'` (lowercase) in v3. Match the field name your method actually returns.
+- **Filter shape confusion** — v3 uses array-of-triples (`[['field', 'op', value]]`), not v2's operator-prefixed-object form.
+- **Mixing v2-only and v3 methods in `v3.batch.make`** — the whole call throws. Split into two batches by version.
+- **Expecting per-command error recovery in `v3.batch.make`** — v3 is all-or-nothing; switch to `v2.batch.make` (if all methods exist in v2) when you need partial-error semantics.
+
+See [rest-api-v2](rest-api-v2.md) for the v2 mirror, [rate-limiting](../guidelines/rate-limiting.md) for tuning, and [error-handling](../guidelines/error-handling.md) for batch error semantics.

--- a/skills/b24-jssdk/references/recipes/ui-integrations.md
+++ b/skills/b24-jssdk/references/recipes/ui-integrations.md
@@ -1,0 +1,97 @@
+# UI integrations (frame-only)
+
+Sliders, dialogs, parent window control, placement bindings, and per-app/user options. **Available only on `B24Frame`** — the calls don't exist on `B24Hook` or `B24OAuth`.
+
+Assumes `$b24` is an initialized `B24Frame`. See [frame-apps](frame-apps.md) for boot.
+
+## Sliders
+
+```ts
+// Open a portal path in a slider (default Bitrix24 slider)
+const url = $b24.slider.getUrl('/crm/deal/details/1/')
+const status = await $b24.slider.openPath(url, 1640)
+if (status.isOpenAtNewWindow) {
+  // Mobile: opened in a new tab; the SDK polled until the tab closed
+}
+
+// Open *your* application page as a slider, then close it
+await $b24.slider.openSliderAppPage({ some: 'params' })
+await $b24.slider.closeSliderAppPage()
+```
+
+`openPath` automatically falls back to `window.open` on mobile and polls for close. Always check `isOpenAtNewWindow` if your flow depends on the slider being modal.
+
+## Dialogs
+
+```ts
+const user = await $b24.dialog.selectUser()        // null | { id, name, ... }
+const users = await $b24.dialog.selectUsers()      // SelectedUser[]
+```
+
+`selectAccess()` and `selectCRM()` exist but are deprecated — don't reach for them in new code.
+
+## Parent window
+
+```ts
+await $b24.parent.fitWindow()                       // size to content
+await $b24.parent.resizeWindow(1024, 768)
+await $b24.parent.resizeWindowAuto(node, 400, 600)  // measure node, clamp by min
+await $b24.parent.setTitle('My Page')
+await $b24.parent.scrollParentWindow(0)
+await $b24.parent.closeApplication()
+await $b24.parent.reloadWindow()
+
+// IM integrations (open chat, place a call)
+await $b24.parent.imCallTo(5, true)
+await $b24.parent.imOpenMessenger('chat12')
+```
+
+Call `fitWindow()` after content changes — Bitrix24 placements don't auto-resize.
+
+## Placement
+
+```ts
+console.log($b24.placement.title)
+console.log($b24.placement.options)
+console.log($b24.placement.isSliderMode)
+
+const iface = await $b24.placement.getInterface()
+await $b24.placement.bindEvent('onMessage', (...args) => console.log(args))
+await $b24.placement.call('someCommand', { foo: 'bar' })
+await $b24.placement.callCustomBind('someCommand', { opt: 1 }, (...args) => {})
+```
+
+## Options (per-app / per-user persistence)
+
+```ts
+await $b24.options.appSet('installComplete', true)
+const installed = $b24.options.appGet('installComplete')
+
+await $b24.options.userSet('theme', 'dark')
+const theme = $b24.options.userGet('theme')
+```
+
+`appSet` / `userSet` round-trip to the portal; `appGet` / `userGet` are synchronous reads from the cache that was loaded during init.
+
+For higher-level option storage (with batched saves and Pull notifications) see the helper-level `OptionsManager` in [helper-manager](helper-manager.md).
+
+## Auth & environment
+
+```ts
+const auth = $b24.auth.getAuthData()    // { access_token, refresh_token, expires_in, domain, member_id } | false
+if (!auth) {
+  await $b24.auth.refreshAuth()
+}
+const lang = $b24.getLang()              // portal UI language ('en', 'ru', …)
+const sid = $b24.getAppSid()             // app SID for the current session
+const uniq = $b24.auth.getUniq('myApp')  // stable per-member unique key
+```
+
+The frame auto-refreshes auth on `401`, so you usually don't need `refreshAuth()` explicitly — it's there for edge cases.
+
+## Anti-patterns
+
+- Calling `slider`/`dialog`/`parent` on `B24Hook` or `B24OAuth` — those managers are frame-only.
+- Forgetting `fitWindow()` after a content change — leaves an awkward scrollbar in the placement.
+- Hard-coding portal paths instead of using `slider.getUrl(path)` — the helper handles the portal domain for you.
+- Persisting transient state via `appSet` — round-trips to the portal; for ephemeral state use local component state.

--- a/skills/b24-jssdk/references/recipes/webhook-server.md
+++ b/skills/b24-jssdk/references/recipes/webhook-server.md
@@ -49,7 +49,7 @@ logger.info('companies', response.getData().result.items)
 ## Batch
 
 ```ts
-const response = await $b24.actions.v3.batch.make({
+const response = await $b24.actions.v2.batch.make({
   calls: [
     ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.company, select: ['id'] }],
     ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.contact, select: ['id'] }]
@@ -63,7 +63,7 @@ const response = await $b24.actions.v3.batch.make({
 logger.info('batch', response.getData())
 ```
 
-See [batch-calls](batch-calls.md) for halt-on-error semantics, named-object form, and chunking.
+See [batch-calls](batch-calls.md) for halt-on-error semantics and the choice between `batch.make` / `batchByChunk.make` / `call.make`, and [rest-api-v2](rest-api-v2.md) for full v2 batch reference.
 
 ## Bulk listing — preferred for large datasets
 

--- a/skills/b24-jssdk/references/recipes/webhook-server.md
+++ b/skills/b24-jssdk/references/recipes/webhook-server.md
@@ -7,82 +7,114 @@ Supported Node: `^18`, `^20`, or `>=22`.
 ## Construct from a webhook URL
 
 ```ts
-import { B24Hook, EnumCrmEntityTypeId, LoggerBrowser } from '@bitrix24/b24jssdk'
+import { B24Hook, EnumCrmEntityTypeId, LoggerBrowser, ParamsFactory } from '@bitrix24/b24jssdk'
 
 const logger = LoggerBrowser.build('Srv', true)
 
 const $b24 = B24Hook.fromWebhookUrl(
   'https://your_domain.bitrix24.com/rest/1/k32t88gf3azpmwv3'
+  // Optional: tune limits for the workload
+  // , { restrictionParams: ParamsFactory.getBatchProcessing() }
 )
 $b24.setLogger(logger)
 
 // Server-only: silence the "client-side use" warning
-$b24.offClientSideWarning?.()
+$b24.offClientSideWarning()
 ```
 
-`B24Hook.fromWebhookUrl(url)` is the preferred constructor — it parses the portal domain, user id, and secret out of the URL. The verbose form `new B24Hook({ b24Url, userId, secret })` exists for cases where you keep those parts in separate env vars.
+`B24Hook.fromWebhookUrl(url, options?)` is the preferred constructor — it parses the portal domain, user id, and secret out of the URL and supports both v2 (`/rest/{id}/{secret}`) and v3 (`/rest/api/{id}/{secret}`) URL shapes. The verbose `new B24Hook(b24HookParams, options?)` form exists when you keep parts in separate env vars.
+
+The optional `options.restrictionParams` accepts a partial override; see [rate-limiting](../guidelines/rate-limiting.md) for the presets.
 
 ## Single call
 
 ```ts
-const res = await $b24.callMethod('crm.item.list', {
-  entityTypeId: EnumCrmEntityTypeId.company,
-  order: { id: 'desc' }
+const response = await $b24.actions.v2.call.make({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.company,
+    order: { id: 'desc' }
+  },
+  requestId: 'recent-companies'
 })
-logger.info('companies', res.getData().result)
+
+if (!response.isSuccess) {
+  logger.error('list failed', response.getErrorMessages())
+  return
+}
+
+logger.info('companies', response.getData().result.items)
 ```
 
-## Batch (array form is most common server-side)
+## Batch
 
 ```ts
-import { Result } from '@bitrix24/b24jssdk'
+const response = await $b24.actions.v3.batch.make({
+  calls: [
+    ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.company, select: ['id'] }],
+    ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.contact, select: ['id'] }]
+  ],
+  options: {
+    isHaltOnError: true,
+    requestId: 'sync-step-1'
+  }
+})
 
-const batch: Result = await $b24.callBatch([
-  ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.company, select: ['id'] }],
-  ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.contact, select: ['id'] }]
-], true)
-logger.info('batch', batch.getData())
+logger.info('batch', response.getData())
 ```
 
-See [batch-calls](batch-calls.md) for halt-on-error semantics, object-keyed form, and chunking.
+See [batch-calls](batch-calls.md) for halt-on-error semantics, named-object form, and chunking.
 
-## Bulk listing
+## Bulk listing — preferred for large datasets
 
 ```ts
-// Preferred for large datasets — streams chunks
-for await (const chunk of $b24.fetchListMethod(
-  'crm.item.list',
-  { entityTypeId: EnumCrmEntityTypeId.deal, select: ['id', 'title'] },
-  'id' // idKey: use 'id' for crm.item.list (lowercase id field)
-)) {
+const generator = $b24.actions.v2.fetchList.make({
+  method: 'crm.item.list',
+  params: {
+    entityTypeId: EnumCrmEntityTypeId.deal,
+    select: ['id', 'title']
+  },
+  idKey: 'id',                  // crm.item.list returns lowercase 'id'
+  customKeyForResult: 'items',
+  requestId: 'deals-stream'
+})
+
+for await (const chunk of generator) {
   for (const row of chunk) {
-    // process each row
+    // process row
   }
 }
 ```
 
-See [list-pagination](list-pagination.md) for `callListMethod` vs `fetchListMethod` vs manual paging.
+`fetchList.make` streams chunks via async iterator — constant memory regardless of total size. See [list-pagination](list-pagination.md).
 
 ## Configuration & secrets
 
-- Read the webhook URL from an env var (`B24_HOOK`) — never hard-code in source.
+- Read the webhook URL from an env var (e.g. `B24_HOOK`). Never hard-code in source.
 - Repository tests use `.env.test` (gitignored); copy `.env.test-example` and set `B24_HOOK` for integration tests.
-- One `B24Hook` instance per portal. If you sync multiple portals, keep one instance per URL.
+- One `B24Hook` instance per portal. If you sync multiple portals, keep one instance per URL — limiter state is per-instance.
 
 ## Restriction tuning
 
-For long-running scripts on enterprise portals, pre-tune the limiter (the helper-based auto-detection isn't loaded server-side):
+For long-running scripts on enterprise portals or bulk migrations, pre-tune the limiter (the helper-based auto-detection doesn't kick in server-side):
 
 ```ts
 import { ParamsFactory } from '@bitrix24/b24jssdk'
 
-$b24.getHttpClient().setRestrictionManagerParams(ParamsFactory.getForEnterprise())
+// In-place after construction
+await $b24.setRestrictionManagerParams(ParamsFactory.getBatchProcessing())
+
+// Or at construction time
+const $b24 = B24Hook.fromWebhookUrl(url, {
+  restrictionParams: ParamsFactory.getEnterprise()
+})
 ```
 
-See [rate-limiting](../guidelines/rate-limiting.md) for when this is worth doing.
+Available presets: `getDefault()`, `getEnterprise()`, `getBatchProcessing()`, `getRealtime()`, `fromTariffPlan(plan)`. See [rate-limiting](../guidelines/rate-limiting.md) for when to use each.
 
 ## Anti-patterns
 
 - Loading a webhook URL into a frontend bundle "for convenience" — the secret leaks to every visitor.
 - Catching `QUERY_LIMIT_EXCEEDED` and retrying in a loop — the built-in limiter already retries with backoff; manual retry causes thundering herds.
 - Creating a fresh `B24Hook` per request in a long-running server — keep one instance and reuse it; the limiter state is per-instance.
+- Using the deprecated `$b24.callMethod(...)` family — switch to `$b24.actions.v{2,3}.*.make(...)`.

--- a/skills/b24-jssdk/references/recipes/webhook-server.md
+++ b/skills/b24-jssdk/references/recipes/webhook-server.md
@@ -1,0 +1,88 @@
+# Webhook server (Node)
+
+For server-side scripts, cron jobs, queue workers, or backend services. `B24Hook` authenticates via an incoming-webhook URL — the secret is part of the path. **Never use this on the client.**
+
+Supported Node: `^18`, `^20`, or `>=22`.
+
+## Construct from a webhook URL
+
+```ts
+import { B24Hook, EnumCrmEntityTypeId, LoggerBrowser } from '@bitrix24/b24jssdk'
+
+const logger = LoggerBrowser.build('Srv', true)
+
+const $b24 = B24Hook.fromWebhookUrl(
+  'https://your_domain.bitrix24.com/rest/1/k32t88gf3azpmwv3'
+)
+$b24.setLogger(logger)
+
+// Server-only: silence the "client-side use" warning
+$b24.offClientSideWarning?.()
+```
+
+`B24Hook.fromWebhookUrl(url)` is the preferred constructor — it parses the portal domain, user id, and secret out of the URL. The verbose form `new B24Hook({ b24Url, userId, secret })` exists for cases where you keep those parts in separate env vars.
+
+## Single call
+
+```ts
+const res = await $b24.callMethod('crm.item.list', {
+  entityTypeId: EnumCrmEntityTypeId.company,
+  order: { id: 'desc' }
+})
+logger.info('companies', res.getData().result)
+```
+
+## Batch (array form is most common server-side)
+
+```ts
+import { Result } from '@bitrix24/b24jssdk'
+
+const batch: Result = await $b24.callBatch([
+  ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.company, select: ['id'] }],
+  ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.contact, select: ['id'] }]
+], true)
+logger.info('batch', batch.getData())
+```
+
+See [batch-calls](batch-calls.md) for halt-on-error semantics, object-keyed form, and chunking.
+
+## Bulk listing
+
+```ts
+// Preferred for large datasets — streams chunks
+for await (const chunk of $b24.fetchListMethod(
+  'crm.item.list',
+  { entityTypeId: EnumCrmEntityTypeId.deal, select: ['id', 'title'] },
+  'id' // idKey: use 'id' for crm.item.list (lowercase id field)
+)) {
+  for (const row of chunk) {
+    // process each row
+  }
+}
+```
+
+See [list-pagination](list-pagination.md) for `callListMethod` vs `fetchListMethod` vs manual paging.
+
+## Configuration & secrets
+
+- Read the webhook URL from an env var (`B24_HOOK`) — never hard-code in source.
+- Repository tests use `.env.test` (gitignored); copy `.env.test-example` and set `B24_HOOK` for integration tests.
+- One `B24Hook` instance per portal. If you sync multiple portals, keep one instance per URL.
+
+## Restriction tuning
+
+For long-running scripts on enterprise portals, pre-tune the limiter (the helper-based auto-detection isn't loaded server-side):
+
+```ts
+import { ParamsFactory } from '@bitrix24/b24jssdk'
+
+$b24.getHttpClient().setRestrictionManagerParams(ParamsFactory.getForEnterprise())
+```
+
+See [rate-limiting](../guidelines/rate-limiting.md) for when this is worth doing.
+
+## Anti-patterns
+
+- Loading a webhook URL into a frontend bundle "for convenience" — the secret leaks to every visitor.
+- Catching `QUERY_LIMIT_EXCEEDED` and retrying in a loop — the built-in limiter already retries with backoff; manual retry causes thundering herds.
+- Creating a fresh `B24Hook` per request in a long-running server — keep one instance and reuse it; the limiter state is per-instance.

--- a/skills/index.json
+++ b/skills/index.json
@@ -11,15 +11,17 @@
         "references/guidelines/error-handling.md",
         "references/guidelines/rate-limiting.md",
         "references/guidelines/logger.md",
+        "references/recipes/rest-api-v2.md",
+        "references/recipes/rest-api-v3.md",
+        "references/recipes/batch-calls.md",
+        "references/recipes/list-pagination.md",
         "references/recipes/frame-apps.md",
         "references/recipes/webhook-server.md",
         "references/recipes/oauth-apps.md",
-        "references/recipes/batch-calls.md",
-        "references/recipes/list-pagination.md",
+        "references/recipes/nuxt-module.md",
         "references/recipes/ui-integrations.md",
         "references/recipes/helper-manager.md",
-        "references/recipes/pull-client.md",
-        "references/recipes/nuxt-module.md"
+        "references/recipes/pull-client.md"
       ]
     }
   ]

--- a/skills/index.json
+++ b/skills/index.json
@@ -1,0 +1,26 @@
+{
+  "skills": [
+    {
+      "name": "b24-jssdk",
+      "description": "Build Bitrix24 REST integrations with @bitrix24/b24jssdk — frame placements, server-side webhooks, OAuth apps, real-time Pull events, and the Nuxt module. Use when calling the Bitrix24 REST API from JS/TS code or generating SDK usage examples.",
+      "files": [
+        "SKILL.md",
+        "references/api-surface.md",
+        "references/guidelines/entry-points.md",
+        "references/guidelines/conventions.md",
+        "references/guidelines/error-handling.md",
+        "references/guidelines/rate-limiting.md",
+        "references/guidelines/logger.md",
+        "references/recipes/frame-apps.md",
+        "references/recipes/webhook-server.md",
+        "references/recipes/oauth-apps.md",
+        "references/recipes/batch-calls.md",
+        "references/recipes/list-pagination.md",
+        "references/recipes/ui-integrations.md",
+        "references/recipes/helper-manager.md",
+        "references/recipes/pull-client.md",
+        "references/recipes/nuxt-module.md"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a top-level `skills/` directory mirroring the layout used in [`bitrix24/b24ui/skills`](https://github.com/bitrix24/b24ui/tree/main/skills): `index.json` manifest + a single `b24-jssdk` skill with `SKILL.md` and `references/`.
- The skill teaches **when** to use which entry point and method (decision matrices, conventions, recipes). Detailed API references live in `packages/jssdk/README-AI.md` and the docs site — `SKILL.md` links out to them rather than duplicating.
- 17 files, ~1346 lines of markdown, English (consistent with `README-AI.md`, `AGENTS.md`, `CLAUDE.md`).

Layout:

```
skills/
├── index.json
└── b24-jssdk/
    ├── SKILL.md                      # routing table + core rules + install
    └── references/
        ├── api-surface.md            # categorized index of public exports
        ├── guidelines/  (5 files)    # entry-points, conventions, error-handling,
        │                             # rate-limiting, logger
        └── recipes/     (9 files)    # frame-apps, webhook-server, oauth-apps,
                                      # batch-calls, list-pagination, ui-integrations,
                                      # helper-manager, pull-client, nuxt-module
```

## Test plan

- [ ] Read `skills/b24-jssdk/SKILL.md` end-to-end — routing table covers expected agent tasks
- [ ] Spot-check a few references against `packages/jssdk/README-AI.md` and the source under `packages/jssdk/src/` for factual accuracy
- [ ] Verify `index.json` lists every file under `skills/b24-jssdk/` (17 entries total when including `SKILL.md` + 16 reference files)
- [ ] Confirm all relative cross-links between SKILL.md and reference files resolve

## Notes for reviewers

A few facts worth a second pair of eyes (flagged here because they were inferred from `README-AI.md` and source-tree shape rather than confirmed line-by-line):

- `references/recipes/oauth-apps.md` — the `B24OAuth` constructor signature in the example is left as a comment placeholder; if you want the exact args spelled out, please point at the canonical form and I'll fill it in.
- `references/recipes/list-pagination.md` — claims `idKey: 'id'` (lowercase) for `crm.item.list` payloads vs default `'ID'` for legacy `crm.deal.list`-style methods; worth a quick sanity check.
- `references/guidelines/rate-limiting.md` — uses `ParamsFactory.getForEnterprise()` as the enterprise preset name; confirm the actual export name.


---
_Generated by [Claude Code](https://claude.ai/code/session_019mv3r6drKPuGtotE6dmTRs)_