### PR TITLE
docs: align example code with v1.1.0 / v1.1.1 type changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@
 * **limiters\RestrictionParams:** add `retryOnNetworkError` flag — set to `false` to throw immediately on `NETWORK_ERROR` / `REQUEST_TIMEOUT` instead of retrying. Important for non-idempotent calls (e.g. `crm.documentgenerator.document.add`) where retries can create duplicates
 * **limiters\RestrictionParams:** add `hardErrorCodes` and `softErrorCodes` — merge custom REST error codes into the built-in hard/soft lists so business-specific codes can opt out of automatic retry or be returned as soft errors via `AjaxResult` (#24)
 * **limiters\RestrictionManager:** expose `BUILT_IN_HARD_ERROR_CODES` / `BUILT_IN_SOFT_ERROR_CODES` as readonly static fields so callers can introspect the defaults
-* **limiters\ParamsFactory:** `realtime` preset now ships with `retryOnNetworkError: false` so realtime callers don't accidentally retry non-idempotent writes
 
 ### Bug Fixes
 

--- a/docs/content/docs/1.getting-started/1.index.md
+++ b/docs/content/docs/1.getting-started/1.index.md
@@ -27,6 +27,7 @@ If you are developing an application that will run inside the Bitrix24 interface
 
 ```ts
 // In an application embedded in Bitrix24
+import { B24Frame, initializeB24Frame } from '@bitrix24/b24jssdk'
 
 let $b24: undefined | B24Frame
 
@@ -35,13 +36,13 @@ async function getCurrentUser() {
     return
   }
   try {
-    const response = await B24Frame.actions.v2.call.make({
+    const response = await $b24.actions.v2.call.make({
       method: 'user.current',
       requestId: 'get-current-user'
     })
 
     if (response.isSuccess) {
-      const user = response.getData()
+      const user = response.getData()?.result
       console.log('Current user:', user)
       return user
     } else {
@@ -57,7 +58,7 @@ async function getContacts() {
   if (!$b24) {
     return
   }
-  const response = await B24Frame.actions.v2.callList.make({
+  const response = await $b24.actions.v2.callList.make({
     method: 'crm.contact.list',
     params: {
       filter: { '>ID': 0 },
@@ -68,16 +69,16 @@ async function getContacts() {
   })
 
   if (response.isSuccess) {
-    return response.getData()
+    return response.getData() ?? []
   }
   return []
 }
 
-async init() {
+async function init() {
   $b24 = await initializeB24Frame()
 }
 
-await init() 
+await init()
 ```
 
 ### For Server Applications with Webhook (B24Hook)
@@ -105,7 +106,7 @@ async function getCompany(companyId: number) {
   })
 
   if (response.isSuccess) {
-    return response.getData()
+    return response.getData()?.result
   } else {
     throw new Error(`Error getting company: ${response.getErrorMessages().join(', ')}`)
   }
@@ -208,7 +209,7 @@ async function testConnection() {
   })
   
   if (userResponse.isSuccess) {
-    console.log('Current user:', userResponse.getData())
+    console.log('Current user:', userResponse.getData()?.result)
   }
   
   return true
@@ -353,7 +354,7 @@ if (!response.isSuccess) {
 }
 
 // Only after successful check, work with the data
-const data = response.getData()!
+const data = response.getData()!.result
 ```
 
 ### 3. Choose the Right Method for Working with Lists

--- a/docs/content/docs/1.getting-started/1.index.md
+++ b/docs/content/docs/1.getting-started/1.index.md
@@ -43,6 +43,8 @@ async function getCurrentUser() {
 
     if (response.isSuccess) {
       const user = response.getData()?.result
+      // in production: use a structured logger (e.g. LoggerFactory.createForBrowser)
+      // and redact PII before sending logs to third-party sinks
       console.log('Current user:', user)
       return user
     } else {
@@ -92,10 +94,10 @@ import { B24Hook } from '@bitrix24/b24jssdk'
 //    - Go to Bitrix24
 //    - Settings → Developers → Webhooks
 //    - Create a new webhook with the required permissions
-//    - Copy the URL in the format: https://your-domain.bitrix24.com/rest/1/your-token/
+//    - Copy the URL in the format: https://your_domain.bitrix24.com/rest/1/webhook_code/
 
 // 2. Initialize B24Hook
-const $b24 = B24Hook.fromWebhookUrl('https://your-domain.bitrix24.com/rest/1/your-token/')
+const $b24 = B24Hook.fromWebhookUrl('https://your_domain.bitrix24.com/rest/1/webhook_code/')
 
 // 3. Use API methods
 async function getCompany(companyId: number) {
@@ -151,7 +153,7 @@ import { B24OAuth } from '@bitrix24/b24jssdk'
 
 // 2. Initialize B24OAuth
 const $b24 = B24OAuth.fromConfig({
-  domain: 'your-domain.bitrix24.com',
+  domain: 'your_domain.bitrix24.com',
   clientId: 'your_client_id',
   clientSecret: 'your_client_secret',
   accessToken: 'current_access_token',
@@ -183,7 +185,7 @@ async function getTasks() {
 // Test API availability
 async function testConnection() {
   // For B24Hook or B24OAuth
-  const $b24 = B24Hook.fromWebhookUrl('https://your-domain.bitrix24.com/rest/1/your-token/')
+  const $b24 = B24Hook.fromWebhookUrl('https://your_domain.bitrix24.com/rest/1/webhook_code/')
   
   // 1. Check availability
   const isHealthy = await $b24.tools.healthCheck.make({
@@ -209,6 +211,7 @@ async function testConnection() {
   })
   
   if (userResponse.isSuccess) {
+    // in production: use a structured logger and redact PII (email, phone, etc.)
     console.log('Current user:', userResponse.getData()?.result)
   }
   

--- a/docs/content/docs/1.getting-started/3.migration/1.v1.md
+++ b/docs/content/docs/1.getting-started/3.migration/1.v1.md
@@ -175,7 +175,7 @@ This method is deprecated and will be removed in version `2.0.0`.
 
 :::tabs-item{label="restApi:v2"}
 
-For `restApi:v2`, you must use the [`b24.actions.v2.call.callList(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-list-rest-api-ver2/) method.
+For `restApi:v2`, you must use the [`b24.actions.v2.callList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-list-rest-api-ver2/) method.
 
 ```diff
 - await b24.callListMethod('some.method', { filter: { '>id': 123 } }, null, 'items')
@@ -192,7 +192,7 @@ For `restApi:v2`, you must use the [`b24.actions.v2.call.callList(options)`{lang
 
 :::tabs-item{label="restApi:v3"}
 
-For `restApi:v3`, you must use the [`b24.actions.v3.call.callList(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-list-rest-api-ver3/) method.
+For `restApi:v3`, you must use the [`b24.actions.v3.callList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-list-rest-api-ver3/) method.
 
 ```diff
 - await b24.callListMethod('some.method', { filter: { '>id': 123 } }, null, 'items')

--- a/docs/content/docs/2.working-with-the-rest-api/0.index.md
+++ b/docs/content/docs/2.working-with-the-rest-api/0.index.md
@@ -111,25 +111,21 @@ Use `B24Frame` — it's available in [Bitrix24 application iframes](/docs/gettin
 #rest-api-ver2
 ```ts
 // In an application embedded in Bitrix24
-async () => {
-  $b24 = await initializeB24Frame()
-  const response = await B24Frame.actions.v2.call.make({
-    method: 'crm.contact.get',
-    params: { id: 123 }
-  })
-}
+const $b24 = await initializeB24Frame()
+const response = await $b24.actions.v2.call.make({
+  method: 'crm.contact.get',
+  params: { id: 123 }
+})
 ```
 
 #rest-api-ver3
 ```ts
 // In an application embedded in Bitrix24
-async () => {
-  $b24 = await initializeB24Frame()
-  const response = await B24Frame.actions.v3.call.make({
-    method: 'tasks.task.get',
-    params: { id: 123 }
-  })
-}
+const $b24 = await initializeB24Frame()
+const response = await $b24.actions.v3.call.make({
+  method: 'tasks.task.get',
+  params: { id: 123 }
+})
 ```
 ::
 

--- a/docs/content/docs/2.working-with-the-rest-api/0.index.md
+++ b/docs/content/docs/2.working-with-the-rest-api/0.index.md
@@ -273,7 +273,7 @@ if (!response.isSuccess) {
 }
 
 // Working with successful result
-const data = response.getData()
+const data = response.getData()?.result
 ```
 
 #rest-api-ver3
@@ -291,7 +291,7 @@ if (!response.isSuccess) {
 }
 
 // Working with successful result
-const data = response.getData()
+const data = response.getData()?.result
 ```
 ::
 

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
@@ -108,7 +108,7 @@ if (!response.isSuccess) {
 }
 
 // Working with a successful result
-const data = response.getData()
+const data = response.getData()?.result
 ```
 
 ## Examples

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
@@ -86,7 +86,7 @@ if (!response.isSuccess) {
 }
 
 // Working with a successful result
-const data = response.getData()
+const data = response.getData()?.result
 ```
 
 ## Examples

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
@@ -186,13 +186,13 @@ async function getCrmItemList(requestId: string): Promise<Company[]> {
 
   if (!response.isSuccess) {
     throw new SdkError({
-      code: 'MY_APP_GET_PROBLEM'
+      code: 'MY_APP_GET_PROBLEM',
       description: `Problem ${response.getErrorMessages().join('; ')}`,
       status: 404
     })
   }
 
-  return response.getData()
+  return response.getData() ?? []
 }
 
 // Usage

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
@@ -176,13 +176,13 @@ async function getMainEventLogItemList(requestId: string): Promise<MainEventLogI
 
   if (!response.isSuccess) {
     throw new SdkError({
-      code: 'MY_APP_GET_PROBLEM'
+      code: 'MY_APP_GET_PROBLEM',
       description: `Problem ${response.getErrorMessages().join('; ')}`,
       status: 404
     })
   }
 
-  return response.getData()
+  return response.getData() ?? []
 }
 
 // Usage

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
@@ -165,8 +165,8 @@ const data = response.getData()
 ### Getting Some Tasks
 
 ```ts [BatchTasks.ts]
-import type { AjaxResult } from '@bitrix24/b24jssdk'
-import { B24Hook, EnumCrmEntityTypeId, LoggerFactory, SdkError } from '@bitrix24/b24jssdk'
+import type { AjaxResult, Result } from '@bitrix24/b24jssdk'
+import { AjaxError, B24Hook, LoggerFactory, SdkError } from '@bitrix24/b24jssdk'
 
 type TaskItem = {
   id: number
@@ -178,9 +178,9 @@ const $logger = LoggerFactory.createForBrowser('Example:batchTasks', devMode)
 const $b24 = B24Hook.fromWebhookUrl('https://your_domain.bitrix24.com/rest/1/webhook_code/')
 
 async function getMultipleItems(itemIds: number[], requestId: string): Promise<TaskItem[]> {
-  if (itemId.length < 1 || itemId.length > 50) {
+  if (itemIds.length < 1 || itemIds.length > 50) {
     throw new SdkError({
-      code: 'MY_APP_GET_PROBLEM'
+      code: 'MY_APP_GET_PROBLEM',
       description: `The number of elements must be between 1 and 50`,
       status: 404
     })
@@ -193,7 +193,7 @@ async function getMultipleItems(itemIds: number[], requestId: string): Promise<T
       select: ['id', 'title']
     }
   ])
-  
+
   const response = await $b24.actions.v3.batch.make<{ item: TaskItem }>({
     calls,
     options: {
@@ -202,16 +202,19 @@ async function getMultipleItems(itemIds: number[], requestId: string): Promise<T
       requestId
     }
   })
-  
+
   if (!response.isSuccess) {
     throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
   }
-  
-  const resultData = (response as Result<AjaxResult<{ item: TaskItem }>[]>).getData()
+
+  const resultData = (response as Result<AjaxResult<{ item: TaskItem }>[]>).getData() ?? []
   const results: TaskItem[] = []
-  resultData.forEach((resultRow, index) => {
+  resultData.forEach((resultRow) => {
     if (resultRow.isSuccess) {
-      results.push(resultRow.getData()!.result.item)
+      const item = resultRow.getData()?.result.item
+      if (item) {
+        results.push(item)
+      }
     }
   })
 

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
@@ -150,8 +150,7 @@ const data = response.getData()
 ### Bulk CRM deal creation
 
 ```ts [BatchByChunkCrmItems.ts]
-import type { AjaxResult } from '@bitrix24/b24jssdk'
-import { B24Hook, EnumCrmEntityTypeId, LoggerFactory } from '@bitrix24/b24jssdk'
+import { AjaxError, B24Hook, EnumCrmEntityTypeId, LoggerFactory } from '@bitrix24/b24jssdk'
 
 type Deal = {
   id: number
@@ -176,7 +175,7 @@ async function addMultipleItems(needAdd: number, requestId: string): Promise<num
       }
     }
   ])
-  
+
   const response = await $b24.actions.v2.batchByChunk.make<{ item: Deal }>({
     calls,
     options: {
@@ -184,18 +183,13 @@ async function addMultipleItems(needAdd: number, requestId: string): Promise<num
       requestId
     }
   })
-  
+
   if (!response.isSuccess) {
     throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
   }
-  
-  const resultData = (response as Result<AjaxResult<{ item: Deal }>[]>).getData()!
-  const results: number[] = []
-  resultData.forEach((resultRow, index) => {
-    if (resultRow.isSuccess) {
-      results.push(resultRow.item.id)
-    }
-  })
+
+  const resultData = response.getData() ?? []
+  const results: number[] = resultData.map(chunkRow => chunkRow.item.id)
 
   return results
 }

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
@@ -150,8 +150,7 @@ const data = response.getData()
 ### Bulk Task Creation
 
 ```ts [BatchByChunkTask.ts]
-import type { AjaxResult } from '@bitrix24/b24jssdk'
-import { B24Hook, LoggerFactory } from '@bitrix24/b24jssdk'
+import { AjaxError, B24Hook, LoggerFactory } from '@bitrix24/b24jssdk'
 
 type TaskItem = {
   id: number
@@ -173,7 +172,7 @@ async function addMultipleItems(needAdd: number, requestId: string): Promise<num
       }
     }
   ])
-  
+
   const response = await $b24.actions.v3.batchByChunk.make<{ item: TaskItem }>({
     calls,
     options: {
@@ -181,18 +180,13 @@ async function addMultipleItems(needAdd: number, requestId: string): Promise<num
       requestId
     }
   })
-  
+
   if (!response.isSuccess) {
     throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
   }
-  
-  const resultData = (response as Result<AjaxResult<{ item: TaskItem }>[]>).getData()!
-  const results: number[] = []
-  resultData.forEach((resultRow, index) => {
-    if (resultRow.isSuccess) {
-      results.push(resultRow.item.id)
-    }
-  })
+
+  const resultData = response.getData() ?? []
+  const results: number[] = resultData.map(chunkRow => chunkRow.item.id)
 
   return results
 }

--- a/packages/jssdk/src/core/actions/v2/batch.ts
+++ b/packages/jssdk/src/core/actions/v2/batch.ts
@@ -66,7 +66,7 @@ export class BatchV2 extends AbstractBatch {
    * const resultData = (response as Result<AjaxResult<{ item: Contact }>[]>).getData()
    * resultData.forEach((resultRow, index) => {
    *   if (resultRow.isSuccess) {
-   *    console.log(`Item ${index + 1}:`, resultRow.getData().result.item)
+   *    console.log(`Item ${index + 1}:`, resultRow.getData()!.result.item)
    *   }
    * })
    *
@@ -109,8 +109,8 @@ export class BatchV2 extends AbstractBatch {
    * }
    *
    * const results = response.getData() as Record<string, AjaxResult<{ item: Contact } | { item: Deal }>>
-   * console.log('Contact:', results.Contact.getData().result.item as Contact)
-   * console.log('Deal:', results.Deal.getData().result.item as Deal)
+   * console.log('Contact:', results.Contact.getData()?.result.item as Contact)
+   * console.log('Deal:', results.Deal.getData()?.result.item as Deal)
    *
    * @warning The maximum number of commands in one batch request is 50.
    * @note A batch request executes faster than sequential single calls,

--- a/packages/jssdk/src/core/actions/v3/batch.ts
+++ b/packages/jssdk/src/core/actions/v3/batch.ts
@@ -66,7 +66,7 @@ export class BatchV3 extends AbstractBatch {
    * const resultData = (response as Result<AjaxResult<{ item: TaskItem }>[]>).getData()
    * resultData.forEach((resultRow, index) => {
    *   if (resultRow.isSuccess) {
-   *    console.log(`Item ${index + 1}:`, resultRow.getData().result.item)
+   *    console.log(`Item ${index + 1}:`, resultRow.getData()!.result.item)
    *   }
    * })
    *
@@ -105,8 +105,8 @@ export class BatchV3 extends AbstractBatch {
    * }
    *
    * const results = response.getData() as Record<string, AjaxResult<{ item: TaskItem } | { items: MainEventLogItem[] }>>
-   * console.log('Task:', results.Task.getData().result.item as TaskItem)
-   * console.log('MainEventLog:', results.MainEventLog.getData().result.items as MainEventLogItem[])
+   * console.log('Task:', results.Task.getData()?.result.item as TaskItem)
+   * console.log('MainEventLog:', results.MainEventLog.getData()?.result.items as MainEventLogItem[])
    *
    * @warning The maximum number of commands in one batch request is 50.
    * @note A batch request executes faster than sequential single calls,


### PR DESCRIPTION
## Summary

Audit of the TS examples in `docs/content/docs/**` (and JSDoc `@example` blocks in `packages/jssdk/src/core/actions/v{2,3}/batch.ts`) against the public API after v1.1.0 (`AjaxResult.getData()` narrowed to `{ result, time }`, paging/legacy helpers deprecated) and v1.1.1 (limiter knobs).

Driven by two rounds of multi-agent review — see follow-ups section for what each round surfaced and which findings are tracked separately.

### Doc fixes

- **`1.getting-started/1.index.md`** — `B24Frame.actions.*` → `$b24.actions.*` (`actions` is an instance getter, not a static). Single-call examples now unwrap the envelope via `response.getData()?.result` since `AjaxResult.getData()` returns `{ result, time } | undefined` after #22. Fixed `async init()` → `async function init()`, added missing `B24Frame` / `initializeB24Frame` imports, aligned webhook URL placeholder with the rest of the docs (`your_domain` / `webhook_code`), and added a one-line hint at each `console.log(user)` site pointing readers to `LoggerFactory` and PII redaction.
- **`2.working-with-the-rest-api/0.index.md`** — same `B24Frame.actions.*` → `$b24.actions.*` for the v2 and v3 snippets; fixed two remaining `const data = response.getData()` occurrences in the "Best Practices > Error Handling" section.
- **`2.call-rest-api-ver{2,3}.md`** — `const data = response.getData()` → `?.result` in the Error Handling examples (found in round 2).
- **`2.call-list-rest-api-ver{2,3}.md`** — missing comma in `new SdkError({ code: '…', description: … })` (TS syntax error); `return response.getData() ?? []` since `Result<T[]>.getData()` is `T[] | null | undefined`.
- **`3.batch-rest-api-ver3.md`** — `itemId.length` → `itemIds.length`; same `SdkError` comma; added missing `Result` / `AjaxError` imports; dropped unused `EnumCrmEntityTypeId`; replaced `.getData()!` with a null-safe access.
- **`4.batch-by-chunk-rest-api-ver{2,3}.md`** — dropped the bogus `as Result<AjaxResult<…>[]>` cast and the `resultRow.isSuccess` gate. `batchByChunk` forces `returnAjaxResult: false` (`abstract-batch.ts:80-97` unwraps via `_extractBatchSimpleData`), so `getData()` is already `T[]` — the example now maps `chunkRow.item.id` directly, matching the JSDoc in `src/core/actions/v{2,3}/batch-by-chunk.ts`.
- **`1.getting-started/3.migration/1.v1.md`** — fixed `b24.actions.v{2,3}.call.callList(options)` → `b24.actions.v{2,3}.callList.make(options)` (stray `.call.` in the prose links).

### JSDoc fixes (`packages/jssdk/src/core/actions/v{2,3}/batch.ts`)

- `resultRow.getData().result.item` inside `if (resultRow.isSuccess) { … }` → `resultRow.getData()!.result.item` (assertion is sound after the guard).
- `results.<Named>.getData().result.item` in the named-batch example (no surrounding guard) → `?.result.item` (defensive). Both forms were strict-TS errors before — `getData()` returns `SuccessPayload<T> | undefined`.

### CHANGELOG correction

- Removed the v1.1.1 entry claiming `ParamsFactory.getRealtime()` ships `retryOnNetworkError: false`. That change was reverted in `a21eab7` before release; the released `getRealtime()` only sets `maxRetries: 1` and inherits `retryOnNetworkError: true` from `getDefault()`.

## Follow-ups (out of scope, tracked separately)

Surfaced by two rounds of multi-agent re-review of this PR. All listed issues are open; release-blockers must close before the next version tag.

**Release blockers (next release gated on these):**

- **#51** — `docs: audit remaining docs/content/docs/** for v1.1.0 getData() envelope breakage` — full sweep beyond what PR #37 covered; now also includes verifying `7.ai/2.llms-txt.md` and the rendered `/llms-full.txt` route.
- **#52** — `docs/limiters: backport v1.1.2 logging-security guidance to 77.limiters.md`.
- **#53** — `docs/getting-started: surface v1.1.2 secret-rotation migration guidance` — now with an explicit AC that the page state the affected version range (`>= 1.1.0, < 1.1.2`).

**Tech debt / process (non-blocking):**

- **#50** — `ci: type-check TS code blocks in docs/content/docs/**` — close the systemic gap that let these examples rot in the first place.
- **#55** — `docs: add @deprecated banner to packages/jssdk/README-AI.md` — surface deprecation status at the top of the file. Team agreed to remove the file progressively; this issue is the lightweight first step.
- **#56** — `test: assert chunkRow.item shape in batchByChunk integration specs` — the existing `js-docs/*.spec.ts` don't pin the shape, which is why the broken example sat undetected.
- **#57** — `test: cover selectCRM array shape (v1.1.0 BC) in frame integration specs` — no spec asserts the v1.1.0 array-shape contract.
- **#58** — `chore: add grep-docs rule to CLAUDE.md for public-API changes` — written checklist until #50 lands.

`packages/jssdk/README-AI.md` is intentionally untouched here — team decision to deprecate and remove progressively. See #55 for the next concrete step.

## Test plan

- [ ] Read each modified doc page on the rendered docs site and confirm the snippets parse as TS (no missing commas, no undefined symbols).
- [ ] Spot-check `1.getting-started/1.index.md` Quick-start snippet against a real `$b24.actions.v2.call.make({ method: 'user.current' })` call — `response.getData()?.result` returns the user object as expected; placeholder webhook URL is consistent with other pages.
- [ ] Spot-check the `batchByChunk` examples — `chunkRow.item.id` resolves against the actual response shape (no `isSuccess` layer).
- [ ] Sanity-read `CHANGELOG.md` for the v1.1.1 section.
- [ ] Build the SDK locally — JSDoc in `packages/jssdk/src/core/actions/v{2,3}/batch.ts` must `tsc --noEmit` clean.