### PR TITLE
fix(http): stop logging full webhook URL in post/send (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## [1.1.2](https://github.com/bitrix24/b24jssdk/compare/v1.1.1...v1.1.2) (2026-05-18)
 
-### Bug Fixes
+### Security
 
-* **http\security:** stop logging the full webhook URL in the `post/send` info-level log — only the bare REST method name (e.g. `user.current`) enters the logger context, preventing webhook-secret disclosure to user-supplied loggers wired via `B24Hook.setLogger(...)`. The `post/response` and `post/catchError` callsites stay URL-free as well. (#39)
-* **http\AjaxError:** drop the unused `url` field from `requestInfo` typing, `toString()`, and `formatErrorMessage()` so a future change cannot accidentally re-introduce the same leak through error rendering (#39)
+* **http:** stop logging the full webhook URL in the `post/send` info-level log — only the bare REST method name (e.g. `user.current`) enters the logger context, preventing webhook-secret disclosure to user-supplied loggers wired via `B24Hook.setLogger(...)`. The `post/response` and `post/catchError` callsites stay URL-free as well. (#39)
+* **http:** redact credential-bearing keys (`auth`, `password`, `token`, `secret`, `access_token`, `refresh_token`) from the serialised `params` blob that enters the `post/send` info log. Closes a smear path for `B24OAuth`/`B24Frame` where `_prepareParams` injects `auth = access_token` into the request body on every call. (#39)
+* **http\AjaxError:** redact the same credential-bearing keys from `requestInfo.params` at error-construction time so they do not leak via `AjaxError.toJSON()` / `toString()` if the caller passed sensitive fields directly in their REST payload. (#39)
+* **http\AjaxError:** drop the unused `url` field from `requestInfo` typing, `toString()`, and `formatErrorMessage()` so a future change cannot accidentally re-introduce the original webhook-URL leak through error rendering. (#39)
 
-### Tests
-
-* **http:** add `http-logger-redaction.unit.spec.ts` — mocks the axios client with a synthetic webhook URL whose secret is a recognisable sentinel and asserts that no captured logger entry contains the sentinel on success, error, and `AjaxError.toString()` paths (v2 + v3)
+**Migration note:** update to 1.1.2 and, if you wired a custom logger via `setLogger(...)` on any 1.1.x release, audit historical log sinks (stdout, files, third-party aggregators) for entries matching `/rest/{userId}/{secret}/` (webhook) or `"auth":"<token>"` (OAuth) and rotate the corresponding credentials. Downstream redaction shims (e.g. `templates-mcp`'s `logger-redactor`) remain useful as defence in depth.
 
 ## [1.1.1](https://github.com/bitrix24/b24jssdk/compare/v1.1.0...v1.1.1) (2026-05-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.1.2](https://github.com/bitrix24/b24jssdk/compare/v1.1.1...v1.1.2) (2026-05-18)
+
+### Bug Fixes
+
+* **http\security:** stop logging the full webhook URL in the `post/send` info-level log — only the bare REST method name (e.g. `user.current`) enters the logger context, preventing webhook-secret disclosure to user-supplied loggers wired via `B24Hook.setLogger(...)`. The `post/response` and `post/catchError` callsites stay URL-free as well. (#39)
+* **http\AjaxError:** drop the unused `url` field from `requestInfo` typing, `toString()`, and `formatErrorMessage()` so a future change cannot accidentally re-introduce the same leak through error rendering (#39)
+
+### Tests
+
+* **http:** add `http-logger-redaction.unit.spec.ts` — mocks the axios client with a synthetic webhook URL whose secret is a recognisable sentinel and asserts that no captured logger entry contains the sentinel on success, error, and `AjaxError.toString()` paths (v2 + v3)
+
 ## [1.1.1](https://github.com/bitrix24/b24jssdk/compare/v1.1.0...v1.1.1) (2026-05-15)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@
 * **http\AjaxError:** redact the same credential-bearing keys from `requestInfo.params` at error-construction time so they do not leak via `AjaxError.toJSON()` / `toString()` if the caller passed sensitive fields directly in their REST payload. (#39)
 * **http\AjaxError:** drop the unused `url` field from `requestInfo` typing, `toString()`, and `formatErrorMessage()` so a future change cannot accidentally re-introduce the original webhook-URL leak through error rendering. (#39)
 
-**Migration note:** update to 1.1.2 and, if you wired a custom logger via `setLogger(...)` on any 1.1.x release, audit historical log sinks (stdout, files, third-party aggregators) for entries matching `/rest/{userId}/{secret}/` (webhook) or `"auth":"<token>"` (OAuth) and rotate the corresponding credentials. Downstream redaction shims (e.g. `templates-mcp`'s `logger-redactor`) remain useful as defence in depth.
+### Migration (affects `>= 1.1.0, < 1.1.2`)
+
+* Update to 1.1.2.
+* If you wired a custom logger via `setLogger(...)` on any 1.1.x release, audit historical log sinks (stdout, files, third-party aggregators) for entries matching `/rest/{userId}/{secret}/` (webhook auth) or `"auth":"<token>"` (OAuth / Frame) and rotate the corresponding credentials.
+* Downstream redaction shims (e.g. `templates-mcp`'s `logger-redactor`) remain useful as defence in depth — keep them in place.
 
 ## [1.1.1](https://github.com/bitrix24/b24jssdk/compare/v1.1.0...v1.1.1) (2026-05-15)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@ Single test by name from the root: `pnpm vitest run --project jsSdk:integration 
 
 **Tests hit real Bitrix24 REST endpoints — never mock responses.** They validate API contracts, so a passing mocked test would defeat the suite's purpose.
 
+**Exception — `*.unit.spec.ts` files inside `test/integration/`.** A small number of regression specs (`batch-null-result.unit.spec.ts`, `http-logger-redaction.unit.spec.ts`, …) exercise pure-logic invariants that have nothing to verify against a live portal — batch response parsing, logger-context redaction, etc. They live in the `jsSdk:integration` project but mock the axios client / construct SDK primitives in isolation, so they run without `.env.test` / `B24_HOOK`. Use this naming when the test is **about the SDK's internal behaviour**, not about the REST contract. For anything that touches a REST method's request/response shape — no mocks.
+
 ## Architecture
 
 The core SDK is organised around one abstract base + three concrete entry points:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitrix24/b24jssdk-main",
   "description": "Bitrix24 REST API JS SDK",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Bitrix",
   "packageManager": "pnpm@10.33.2",
   "repository": {

--- a/packages/jssdk-nuxt/package.json
+++ b/packages/jssdk-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitrix24/b24jssdk-nuxt",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "packageManager": "pnpm@10.33.2",
   "author": "Bitrix",
   "license": "MIT",

--- a/packages/jssdk/package.json
+++ b/packages/jssdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitrix24/b24jssdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Bitrix",
   "license": "MIT",
   "description": "Bitrix24 REST API JavaScript SDK",

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -20,6 +20,7 @@ import { ParamsFactory } from './limiters/params-factory'
 import { RestrictionManager } from './limiters/manager'
 import { AjaxError } from './ajax-error'
 import { AjaxResult } from './ajax-result'
+import { redactSensitiveParams } from './redact'
 import { Type } from '../../tools/type'
 import { Environment, getEnvironment } from '../../tools/environment'
 import { ApiVersion } from '../../types/b24'
@@ -478,7 +479,10 @@ export abstract class AbstractHttp implements TypeHttp {
     const methodFormatted = this._prepareMethod(requestId, method, this.getBaseUrl())
 
     const paramsFormatted = this._prepareParams(authData, params)
-    const paramsFormattedForLog = JSON.stringify(paramsFormatted, null, 0)
+    // `paramsFormatted` carries the OAuth `auth` (access_token) for non-hook flows;
+    // log a redacted copy so the secret never enters logger context, while axios
+    // still receives the original below. (#39)
+    const paramsFormattedForLog = JSON.stringify(redactSensitiveParams(paramsFormatted), null, 0)
 
     const maxLogLength = 300
     const sliceLogLength = 100
@@ -615,16 +619,7 @@ export abstract class AbstractHttp implements TypeHttp {
 
   // region Log ////
   protected _sanitizeParams(params: TypeCallParams): Record<string, unknown> {
-    const sanitized = { ...params }
-    const sensitiveKeys = ['auth', 'password', 'token', 'secret', 'access_token', 'refresh_token']
-
-    sensitiveKeys.forEach((key) => {
-      if (key in sanitized && sanitized[key]) {
-        sanitized[key] = '***REDACTED***'
-      }
-    })
-
-    return sanitized
+    return redactSensitiveParams(params)
   }
 
   protected _logRequest(requestId: string, method: string, params: TypeCallParams): void {

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -485,7 +485,7 @@ export abstract class AbstractHttp implements TypeHttp {
     this.getLogger().info(
       `post/send`, {
         requestId,
-        method: methodFormatted,
+        method,
         params: paramsFormattedForLog.length > maxLogLength ? paramsFormattedForLog.slice(0, sliceLogLength) + '...' : paramsFormattedForLog
       }
     )

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -453,7 +453,9 @@ export abstract class AbstractHttp implements TypeHttp {
           `post/catchError`, {
             requestId,
             status: error.status,
-            responseData: JSON.stringify(error?.response?.data, null, 0)
+            // Redact in case a future portal response embeds credentials in
+            // the error body (today it doesn't, but the channel is open). (#39)
+            responseData: JSON.stringify(redactSensitiveParams(error?.response?.data), null, 0)
           }
         )
       }

--- a/packages/jssdk/src/core/http/ajax-error.ts
+++ b/packages/jssdk/src/core/http/ajax-error.ts
@@ -1,6 +1,7 @@
 import type { AjaxQuery } from './ajax-result'
 import type { SdkErrorDetails } from '../sdk-error'
 import { SdkError } from '../sdk-error'
+import { redactSensitiveParams } from './redact'
 
 export type AnswerError = {
   error: string
@@ -34,7 +35,16 @@ export class AjaxError extends SdkError {
     super(params)
 
     this.name = 'AjaxError' as const
+    // Redact credential-bearing keys from caller-supplied params so they never
+    // leak via `toJSON()` / `toString()` consumers (#39).
     this.requestInfo = params.requestInfo
+      ? {
+          ...params.requestInfo,
+          ...(params.requestInfo.params !== undefined
+            ? { params: redactSensitiveParams(params.requestInfo.params) }
+            : {})
+        }
+      : undefined
 
     this.cleanErrorStack()
   }

--- a/packages/jssdk/src/core/http/ajax-error.ts
+++ b/packages/jssdk/src/core/http/ajax-error.ts
@@ -14,7 +14,7 @@ export type AjaxErrorParams = {
 }
 
 type AjaxErrorDetails = SdkErrorDetails & {
-  requestInfo?: Partial<AjaxQuery> & { url?: string }
+  requestInfo?: Partial<AjaxQuery>
 }
 
 /**
@@ -97,7 +97,7 @@ export class AjaxError extends SdkError {
     let output = `[${this.name}] ${this.code} (${this._status}): ${this.message}`
 
     if (this.requestInfo) {
-      output += `\nRequest: ${this.requestInfo?.requestId ? `[${this.requestInfo.requestId}] ` : ''}${this.requestInfo.method} ${this.requestInfo.url}`
+      output += `\nRequest: ${this.requestInfo?.requestId ? `[${this.requestInfo.requestId}] ` : ''}${this.requestInfo.method}`
     }
 
     if (this.stack) {
@@ -112,11 +112,8 @@ export class AjaxError extends SdkError {
    */
   protected static override formatErrorMessage(params: AjaxErrorDetails): string {
     if (!params?.description) {
-      if (
-        params.requestInfo?.method
-        && params.requestInfo.url
-      ) {
-        return `${params.code} (on ${params.requestInfo.method}${params.requestInfo?.url ? ' ' + params.requestInfo.url : ''})`
+      if (params.requestInfo?.method) {
+        return `${params.code} (on ${params.requestInfo.method})`
       } else {
         return `Internal ajax error`
       }

--- a/packages/jssdk/src/core/http/redact.ts
+++ b/packages/jssdk/src/core/http/redact.ts
@@ -1,0 +1,43 @@
+/**
+ * Shallow redact for params that may contain credentials before they enter
+ * any logger or error-rendering surface.
+ *
+ * Two callers today: `Http._sanitizeParams` (logger context) and
+ * `AjaxError` constructor (stores `requestInfo.params` exposed by
+ * `toJSON()` / `toString()`). Keeping a single source of truth means the
+ * redaction list stays consistent across both.
+ *
+ * The walk is intentionally shallow — the SDK's REST payloads are flat
+ * (`auth`, `password`, `token`, …) at the top level. Deep walking
+ * arbitrary user payloads would be expensive and brittle; if a deeper
+ * redact is ever needed, do it at the callsite.
+ */
+
+export const SENSITIVE_PARAM_KEYS: readonly string[] = [
+  'auth',
+  'password',
+  'token',
+  'secret',
+  'access_token',
+  'refresh_token'
+]
+
+export const REDACTED_PLACEHOLDER = '***REDACTED***'
+
+/**
+ * Returns a shallow copy of `params` with any known credential-bearing
+ * key replaced by `REDACTED_PLACEHOLDER`. Non-object / null inputs are
+ * returned as-is so callers don't have to pre-check.
+ */
+export function redactSensitiveParams<T>(params: T): T {
+  if (params === null || typeof params !== 'object' || Array.isArray(params)) {
+    return params
+  }
+  const sanitized: Record<string, unknown> = { ...(params as Record<string, unknown>) }
+  for (const key of SENSITIVE_PARAM_KEYS) {
+    if (key in sanitized && sanitized[key]) {
+      sanitized[key] = REDACTED_PLACEHOLDER
+    }
+  }
+  return sanitized as T
+}

--- a/packages/jssdk/src/core/http/redact.ts
+++ b/packages/jssdk/src/core/http/redact.ts
@@ -1,16 +1,23 @@
 /**
- * Shallow redact for params that may contain credentials before they enter
- * any logger or error-rendering surface.
+ * Bounded-depth redact for params that may contain credentials before they
+ * enter any logger or error-rendering surface.
  *
- * Two callers today: `Http._sanitizeParams` (logger context) and
- * `AjaxError` constructor (stores `requestInfo.params` exposed by
- * `toJSON()` / `toString()`). Keeping a single source of truth means the
- * redaction list stays consistent across both.
+ * Callers: `Http._sanitizeParams` (logger context), `_makeAxiosRequest`
+ * (`post/send` and `post/catchError` info logs), `AjaxError` constructor
+ * (stores `requestInfo.params` exposed by `toJSON()` / `toString()`).
+ * Keeping a single source of truth means the redaction list stays
+ * consistent across all of them.
  *
- * The walk is intentionally shallow — the SDK's REST payloads are flat
- * (`auth`, `password`, `token`, …) at the top level. Deep walking
- * arbitrary user payloads would be expensive and brittle; if a deeper
- * redact is ever needed, do it at the callsite.
+ * The walk descends two levels into nested objects and arrays. That is
+ * the minimum that covers batch payloads (`{ cmd: [{ method, params:
+ * { ...credentials... } }, ...] }`) where the credential lives at
+ * `cmd[i].params.<key>`, as well as flat one-level-nested payloads like
+ * `{ data: { token } }`. Deeper walks risk arbitrary cost on
+ * user-supplied trees and brittle false positives; two levels is the
+ * documented contract — beyond that, redact at the callsite.
+ *
+ * Empty / nullish values are still considered sensitive — an empty
+ * `access_token` is unusual but not safe to leave un-redacted.
  */
 
 export const SENSITIVE_PARAM_KEYS: readonly string[] = [
@@ -24,20 +31,47 @@ export const SENSITIVE_PARAM_KEYS: readonly string[] = [
 
 export const REDACTED_PLACEHOLDER = '***REDACTED***'
 
-/**
- * Returns a shallow copy of `params` with any known credential-bearing
- * key replaced by `REDACTED_PLACEHOLDER`. Non-object / null inputs are
- * returned as-is so callers don't have to pre-check.
- */
-export function redactSensitiveParams<T>(params: T): T {
-  if (params === null || typeof params !== 'object' || Array.isArray(params)) {
-    return params
-  }
-  const sanitized: Record<string, unknown> = { ...(params as Record<string, unknown>) }
-  for (const key of SENSITIVE_PARAM_KEYS) {
-    if (key in sanitized && sanitized[key]) {
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function redactObject(
+  source: Record<string, unknown>,
+  depth: number
+): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = { ...source }
+  for (const key of Object.keys(sanitized)) {
+    if (SENSITIVE_PARAM_KEYS.includes(key)) {
       sanitized[key] = REDACTED_PLACEHOLDER
+      continue
+    }
+    if (depth <= 0) continue
+    const child = sanitized[key]
+    if (isPlainObject(child)) {
+      sanitized[key] = redactObject(child, depth - 1)
+    } else if (Array.isArray(child)) {
+      sanitized[key] = child.map(item =>
+        isPlainObject(item) ? redactObject(item, depth - 1) : item
+      )
     }
   }
-  return sanitized as T
+  return sanitized
+}
+
+const DEFAULT_REDACT_DEPTH = 2
+
+/**
+ * Returns a copy of `params` with any known credential-bearing key
+ * replaced by `REDACTED_PLACEHOLDER`. Walks up to two levels into nested
+ * objects/arrays so batch-shaped payloads (`cmd[i].params.<key>`) are
+ * covered. Non-object inputs are returned as-is so callers don't have
+ * to pre-check.
+ */
+export function redactSensitiveParams(
+  params: Record<string, unknown>
+): Record<string, unknown>
+export function redactSensitiveParams<T>(params: T): T
+export function redactSensitiveParams(params: unknown): unknown {
+  if (!isPlainObject(params)) return params
+  return redactObject(params, DEFAULT_REDACT_DEPTH)
 }

--- a/test/integration/core/http-logger-redaction.unit.spec.ts
+++ b/test/integration/core/http-logger-redaction.unit.spec.ts
@@ -85,12 +85,22 @@ function mockSuccessfulPost(b24: B24Hook, version: ApiVersion): void {
   })
 }
 
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    // Cycle / non-serialisable: fall back to a string coercion so the assertion
+    // can still scan for the sentinel without crashing the whole test run.
+    return String(value)
+  }
+}
+
 function assertNoSecretLeak(
   captured: CapturedLog[],
   pathFragment: string
 ): void {
   for (const entry of captured) {
-    const blob = `${entry.message} ${JSON.stringify(entry.context ?? {})}`
+    const blob = `${entry.message} ${safeStringify(entry.context ?? {})}`
     expect(blob, `secret leaked in log entry "${entry.message}"`).not.toContain(FAKE_SECRET)
     expect(blob, `webhook path leaked in log entry "${entry.message}"`).not.toContain(pathFragment)
   }
@@ -137,6 +147,10 @@ describe('core.http logger redaction @issue-39', () => {
     const postSend = captured.find(e => e.message === 'post/send')
     expect(postSend).toBeDefined()
     expect(postSend!.context!.method).toBe('tasks.task.get')
+
+    const postResponse = captured.find(e => e.message === 'post/response')
+    expect(postResponse, 'post/response must fire on a successful v3 call').toBeDefined()
+    expect(postResponse!.context).not.toHaveProperty('method')
   })
 
   it('v2 error: post/catchError logs requestId/status only, never the URL/secret', async () => {
@@ -174,7 +188,6 @@ describe('core.http logger redaction @issue-39', () => {
   })
 
   it('AjaxError.toString() never embeds the webhook URL', () => {
-    b24 = buildClient('v2')
     // Mirrors the shape `_convertAxiosErrorToAjaxError` produces internally.
     const err = new AjaxError({
       code: 'INTERNAL_SERVER_ERROR',
@@ -189,5 +202,114 @@ describe('core.http logger redaction @issue-39', () => {
     const rendered = err.toString() + ' ' + JSON.stringify(err.toJSON())
     expect(rendered).not.toContain(FAKE_SECRET)
     expect(rendered).not.toContain(V2_PATH_FRAGMENT)
+  })
+
+  it('post/send redacts credential-bearing keys from params (OAuth `auth` access_token, user-supplied `password`/`token`)', async () => {
+    b24 = buildClient('v2')
+    mockSuccessfulPost(b24, ApiVersion.v2)
+    const captured: CapturedLog[] = []
+    b24.setLogger(buildCapturingLogger(captured))
+
+    // The values below stand in for credentials that would otherwise enter the
+    // info-level `post/send` log via `JSON.stringify(paramsFormatted)`:
+    //  - `auth` is the field `_prepareParams` injects for OAuth flows
+    //    (`result.auth = authData.access_token`) — webhook auth skips it, but
+    //    OAuth/Frame leak it on every call without this redaction.
+    //  - `password` / `token` model a caller passing sensitive business fields
+    //    directly inside params (e.g. a CRM custom field).
+    await b24.actions.v2.call.make({
+      method: 'crm.deal.add',
+      params: {
+        fields: { TITLE: 'safe' },
+        auth: 'OAUTH_ACCESS_TOKEN_LEAK_PROBE_aaa',
+        password: 'USER_PASSWORD_LEAK_PROBE_bbb',
+        token: 'USER_TOKEN_LEAK_PROBE_ccc'
+      } as Record<string, any>
+    })
+
+    const postSend = captured.find(e => e.message === 'post/send')
+    expect(postSend, 'post/send must fire').toBeDefined()
+    const serialized = JSON.stringify(postSend!.context)
+    expect(serialized).not.toContain('OAUTH_ACCESS_TOKEN_LEAK_PROBE_aaa')
+    expect(serialized).not.toContain('USER_PASSWORD_LEAK_PROBE_bbb')
+    expect(serialized).not.toContain('USER_TOKEN_LEAK_PROBE_ccc')
+    expect(serialized).toContain('***REDACTED***')
+  })
+
+  it('AjaxError.toJSON()/toString() redacts credential-bearing keys in requestInfo.params', () => {
+    const err = new AjaxError({
+      code: 'JSSDK_INTERNAL_AJAX_ERROR',
+      status: 500,
+      requestInfo: {
+        method: 'crm.deal.add',
+        params: {
+          fields: { TITLE: 'safe' },
+          auth: 'OAUTH_TOKEN_PROBE_xxx',
+          password: 'USER_PASSWORD_PROBE_yyy'
+        } as Record<string, any>,
+        requestId: 'test-request-id'
+      }
+    })
+
+    const jsonBlob = JSON.stringify(err.toJSON())
+    expect(jsonBlob).not.toContain('OAUTH_TOKEN_PROBE_xxx')
+    expect(jsonBlob).not.toContain('USER_PASSWORD_PROBE_yyy')
+    expect(jsonBlob).toContain('***REDACTED***')
+    // Non-sensitive payload survives so error stays diagnosable.
+    expect(jsonBlob).toContain('TITLE')
+
+    const stringBlob = err.toString()
+    expect(stringBlob).not.toContain('OAUTH_TOKEN_PROBE_xxx')
+    expect(stringBlob).not.toContain('USER_PASSWORD_PROBE_yyy')
+  })
+
+  it('retry path does not leak the secret across multiple attempts', async () => {
+    b24 = buildClient('v2')
+    const httpClient = b24.getHttpClient(ApiVersion.v2)
+    // First attempt rejects, second succeeds — exercises the `http request
+    // attempt` / `http wait` debug logs and `post/catchError` in one flow.
+    const successResponse = {
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as never,
+      data: {
+        result: { ok: true },
+        time: {
+          start: 0, finish: 0, duration: 0, processing: 0,
+          date_start: '1970-01-01T00:00:00+00:00',
+          date_finish: '1970-01-01T00:00:00+00:00',
+          operating_reset_at: 1, operating: 0
+        }
+      }
+    }
+    vi.spyOn(httpClient.ajaxClient, 'post')
+      .mockRejectedValueOnce(new AxiosError(
+        'Request failed with status code 503',
+        'ERR_BAD_RESPONSE',
+        undefined,
+        undefined,
+        {
+          status: 503,
+          statusText: 'Service Unavailable',
+          headers: {},
+          config: {} as never,
+          data: { error: 'QUERY_LIMIT_EXCEEDED', error_description: 'transient' }
+        }
+      ))
+      .mockResolvedValue(successResponse)
+    await b24.setRestrictionManagerParams({
+      ...ParamsFactory.getDefault(),
+      retryDelay: 1
+    })
+    const captured: CapturedLog[] = []
+    b24.setLogger(buildCapturingLogger(captured))
+
+    await b24.actions.v2.call.make({ method: 'user.current', params: {} })
+
+    assertNoSecretLeak(captured, V2_PATH_FRAGMENT)
+    // Sanity: both attempts left a trace.
+    expect(captured.some(e => e.message === 'post/catchError')).toBe(true)
+    expect(captured.filter(e => e.message === 'post/send').length).toBeGreaterThanOrEqual(2)
   })
 })

--- a/test/integration/core/http-logger-redaction.unit.spec.ts
+++ b/test/integration/core/http-logger-redaction.unit.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Regression for https://github.com/bitrix24/b24jssdk/issues/39
+ *
+ * The HTTP layer used to log the full request URL — including the webhook
+ * secret path segment — at INFO level on every REST call. When a consumer
+ * wired their own logger via `B24Hook.setLogger(...)`, the secret leaked to
+ * every sink that logger ships to (stdout, files, third-party aggregators).
+ *
+ * This spec exercises the SDK with a synthetic webhook URL whose secret is
+ * a recognisable sentinel, mocks the axios client so no network traffic
+ * leaves the machine, and asserts that the captured logger context never
+ * contains the sentinel — regardless of which path (success/error) ran and
+ * how many retries fired.
+ *
+ * `*.unit.spec.ts` keeps this file in the `jsSdk:integration` Vitest
+ * project but signals (alongside `batch-null-result.unit.spec.ts`) that the
+ * spec does not need a real Bitrix24 portal — `.env.test` / `B24_HOOK` are
+ * not required.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { AxiosError } from 'axios'
+import {
+  ApiVersion,
+  B24Hook,
+  ParamsFactory
+} from '../../../packages/jssdk/src/'
+import { AjaxError } from '../../../packages/jssdk/src/core/http/ajax-error'
+import type { LoggerInterface } from '../../../packages/jssdk/src/types/logger'
+
+const FAKE_SECRET = 'SECRET_TOKEN_REDACTION_SENTINEL_xyz123'
+const V2_PATH_FRAGMENT = '/rest/1/'
+const V3_PATH_FRAGMENT = '/rest/api/1/'
+
+type CapturedLog = { level: string, message: string, context?: Record<string, any> }
+
+function buildCapturingLogger(captured: CapturedLog[]): LoggerInterface {
+  const sink = (level: string) =>
+    async (message: string, context?: Record<string, any>) => {
+      captured.push({ level, message, context })
+    }
+  return {
+    log: async (level: any, message: string, context?: Record<string, any>) => {
+      captured.push({ level: String(level), message, context })
+    },
+    debug: sink('debug'),
+    info: sink('info'),
+    notice: sink('notice'),
+    warning: sink('warning'),
+    error: sink('error'),
+    critical: sink('critical'),
+    alert: sink('alert'),
+    emergency: sink('emergency')
+  }
+}
+
+function buildClient(version: 'v2' | 'v3'): B24Hook {
+  const url = version === 'v2'
+    ? `https://example.bitrix24.com/rest/1/${FAKE_SECRET}`
+    : `https://example.bitrix24.com/rest/api/1/${FAKE_SECRET}`
+  return B24Hook.fromWebhookUrl(url, {
+    restrictionParams: { ...ParamsFactory.getDefault(), retryDelay: 1 }
+  })
+}
+
+function mockSuccessfulPost(b24: B24Hook, version: ApiVersion): void {
+  const httpClient = b24.getHttpClient(version)
+  vi.spyOn(httpClient.ajaxClient, 'post').mockResolvedValue({
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as never,
+    data: {
+      result: { ID: 1 },
+      time: {
+        start: 0,
+        finish: 0,
+        duration: 0,
+        processing: 0,
+        date_start: '1970-01-01T00:00:00+00:00',
+        date_finish: '1970-01-01T00:00:00+00:00',
+        operating_reset_at: 1,
+        operating: 0
+      }
+    }
+  })
+}
+
+function assertNoSecretLeak(
+  captured: CapturedLog[],
+  pathFragment: string
+): void {
+  for (const entry of captured) {
+    const blob = `${entry.message} ${JSON.stringify(entry.context ?? {})}`
+    expect(blob, `secret leaked in log entry "${entry.message}"`).not.toContain(FAKE_SECRET)
+    expect(blob, `webhook path leaked in log entry "${entry.message}"`).not.toContain(pathFragment)
+  }
+}
+
+describe('core.http logger redaction @issue-39', () => {
+  let b24: B24Hook | null = null
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    b24?.destroy()
+    b24 = null
+  })
+
+  it('v2 success: post/send context contains bare method name, never the URL/secret', async () => {
+    b24 = buildClient('v2')
+    mockSuccessfulPost(b24, ApiVersion.v2)
+    const captured: CapturedLog[] = []
+    b24.setLogger(buildCapturingLogger(captured))
+
+    await b24.actions.v2.call.make({ method: 'user.current', params: {} })
+
+    assertNoSecretLeak(captured, V2_PATH_FRAGMENT)
+
+    const postSend = captured.find(e => e.message === 'post/send')
+    expect(postSend, 'post/send must fire on a successful call').toBeDefined()
+    expect(postSend!.context!.method).toBe('user.current')
+
+    const postResponse = captured.find(e => e.message === 'post/response')
+    expect(postResponse, 'post/response must fire on a successful call').toBeDefined()
+    expect(postResponse!.context).not.toHaveProperty('method')
+  })
+
+  it('v3 success: post/send context contains bare method name, never the URL/secret', async () => {
+    b24 = buildClient('v3')
+    mockSuccessfulPost(b24, ApiVersion.v3)
+    const captured: CapturedLog[] = []
+    b24.setLogger(buildCapturingLogger(captured))
+
+    await b24.actions.v3.call.make({ method: 'tasks.task.get', params: { taskId: 1 } })
+
+    assertNoSecretLeak(captured, V3_PATH_FRAGMENT)
+
+    const postSend = captured.find(e => e.message === 'post/send')
+    expect(postSend).toBeDefined()
+    expect(postSend!.context!.method).toBe('tasks.task.get')
+  })
+
+  it('v2 error: post/catchError logs requestId/status only, never the URL/secret', async () => {
+    b24 = buildClient('v2')
+    const httpClient = b24.getHttpClient(ApiVersion.v2)
+    vi.spyOn(httpClient.ajaxClient, 'post').mockRejectedValue(
+      new AxiosError(
+        'Request failed with status code 500',
+        'ERR_BAD_RESPONSE',
+        undefined,
+        undefined,
+        {
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: {},
+          config: {} as never,
+          data: { error: 'INTERNAL_SERVER_ERROR', error_description: 'simulated failure' }
+        }
+      )
+    )
+    const captured: CapturedLog[] = []
+    b24.setLogger(buildCapturingLogger(captured))
+
+    await expect(
+      b24.actions.v2.call.make({ method: 'user.current', params: {} })
+    ).rejects.toBeDefined()
+
+    assertNoSecretLeak(captured, V2_PATH_FRAGMENT)
+
+    const postCatch = captured.find(e => e.message === 'post/catchError')
+    expect(postCatch, 'post/catchError must fire on an axios rejection').toBeDefined()
+    expect(postCatch!.context!.requestId).toBeTruthy()
+    expect(postCatch!.context).not.toHaveProperty('url')
+    expect(postCatch!.context).not.toHaveProperty('method')
+  })
+
+  it('AjaxError.toString() never embeds the webhook URL', () => {
+    b24 = buildClient('v2')
+    // Mirrors the shape `_convertAxiosErrorToAjaxError` produces internally.
+    const err = new AjaxError({
+      code: 'INTERNAL_SERVER_ERROR',
+      status: 500,
+      requestInfo: {
+        method: 'user.current',
+        params: {},
+        requestId: 'test-request-id'
+      }
+    })
+
+    const rendered = err.toString() + ' ' + JSON.stringify(err.toJSON())
+    expect(rendered).not.toContain(FAKE_SECRET)
+    expect(rendered).not.toContain(V2_PATH_FRAGMENT)
+  })
+})

--- a/test/integration/core/http-logger-redaction.unit.spec.ts
+++ b/test/integration/core/http-logger-redaction.unit.spec.ts
@@ -25,6 +25,7 @@ import {
   ParamsFactory
 } from '../../../packages/jssdk/src/'
 import { AjaxError } from '../../../packages/jssdk/src/core/http/ajax-error'
+import { redactSensitiveParams } from '../../../packages/jssdk/src/core/http/redact'
 import type { LoggerInterface } from '../../../packages/jssdk/src/types/logger'
 
 const FAKE_SECRET = 'SECRET_TOKEN_REDACTION_SENTINEL_xyz123'
@@ -311,5 +312,109 @@ describe('core.http logger redaction @issue-39', () => {
     // Sanity: both attempts left a trace.
     expect(captured.some(e => e.message === 'post/catchError')).toBe(true)
     expect(captured.filter(e => e.message === 'post/send').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('v3 error path: post/catchError does not leak the secret', async () => {
+    b24 = buildClient('v3')
+    const httpClient = b24.getHttpClient(ApiVersion.v3)
+    vi.spyOn(httpClient.ajaxClient, 'post').mockRejectedValue(
+      new AxiosError(
+        'Request failed with status code 500',
+        'ERR_BAD_RESPONSE',
+        undefined,
+        undefined,
+        {
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: {},
+          config: {} as never,
+          data: { error: 'INTERNAL_SERVER_ERROR', error_description: 'boom' }
+        }
+      )
+    )
+    const captured: CapturedLog[] = []
+    b24.setLogger(buildCapturingLogger(captured))
+
+    await expect(
+      b24.actions.v3.call.make({ method: 'tasks.task.get', params: { taskId: 1 } })
+    ).rejects.toBeDefined()
+
+    assertNoSecretLeak(captured, V3_PATH_FRAGMENT)
+  })
+
+  it('redacts credential keys even when the value is an empty string (token = "")', async () => {
+    b24 = buildClient('v2')
+    mockSuccessfulPost(b24, ApiVersion.v2)
+    const captured: CapturedLog[] = []
+    b24.setLogger(buildCapturingLogger(captured))
+
+    // An empty token is unusual but should still be redacted — leaving an
+    // empty `access_token: ""` visible would advertise that the field
+    // exists and how the SDK names it, which a falsy-guard would skip.
+    await b24.actions.v2.call.make({
+      method: 'user.current',
+      params: { access_token: '', auth: '', token: '' } as Record<string, any>
+    })
+
+    const postSend = captured.find(e => e.message === 'post/send')
+    expect(postSend).toBeDefined()
+    const serialized = JSON.stringify(postSend!.context)
+    expect(serialized).not.toMatch(/"access_token"\s*:\s*""/)
+    expect(serialized).not.toMatch(/"auth"\s*:\s*""/)
+    expect(serialized).not.toMatch(/"token"\s*:\s*""/)
+    expect(serialized).toContain('***REDACTED***')
+  })
+
+  it('redacts credentials nested one level deep in params (e.g. data.access_token)', async () => {
+    b24 = buildClient('v2')
+    mockSuccessfulPost(b24, ApiVersion.v2)
+    const captured: CapturedLog[] = []
+    b24.setLogger(buildCapturingLogger(captured))
+
+    // A caller might tunnel a credential under a nested object (`data`,
+    // `fields`, or a batch entry); the helper walks one level so this is
+    // still masked. Goes via a regular call so the mock path stays valid.
+    await b24.actions.v2.call.make({
+      method: 'crm.deal.add',
+      params: {
+        fields: { TITLE: 'safe', access_token: 'NESTED_ACCESS_TOKEN_PROBE_qqq' },
+        data: { token: 'NESTED_TOKEN_PROBE_rrr' }
+      } as Record<string, any>
+    })
+
+    const postSend = captured.find(e => e.message === 'post/send')
+    expect(postSend).toBeDefined()
+    const serialized = JSON.stringify(postSend!.context)
+    expect(serialized).not.toContain('NESTED_ACCESS_TOKEN_PROBE_qqq')
+    expect(serialized).not.toContain('NESTED_TOKEN_PROBE_rrr')
+    expect(serialized).toContain('***REDACTED***')
+    expect(serialized).toContain('TITLE') // non-sensitive sibling survives
+  })
+
+  it('redactSensitiveParams: directly exercises depth-1 walk through arrays and objects', () => {
+    // Direct helper test so the contract is pinned independent of the
+    // SDK call chain — `cmd[i].params.<key>` (batch shape) is the
+    // motivating example.
+    const out = redactSensitiveParams({
+      halt: 0,
+      cmd: [
+        { method: 'user.current', params: { access_token: 'A' } },
+        { method: 'profile', params: { token: 'B' } }
+      ],
+      top_secret: { token: 'C' },
+      auth: 'D',
+      access_token: ''
+    } as Record<string, unknown>)
+
+    // Top-level credential key — masked.
+    expect(out.auth).toBe('***REDACTED***')
+    // Empty string is still masked (not skipped by a falsy guard).
+    expect(out.access_token).toBe('***REDACTED***')
+    // Array contents are walked one level.
+    const cmd = out.cmd as Array<{ params: Record<string, unknown> }>
+    expect(cmd[0].params.access_token).toBe('***REDACTED***')
+    expect(cmd[1].params.token).toBe('***REDACTED***')
+    // Nested object one level deep — credential key inside is masked.
+    expect((out.top_secret as Record<string, unknown>).token).toBe('***REDACTED***')
   })
 })


### PR DESCRIPTION
Closes #39.

## Summary

- The HTTP layer wrote `method: methodFormatted` — i.e. the full URL with the webhook secret embedded — into the `post/send` info-level log on every REST call. When a consumer wired their own logger via `B24Hook.setLogger(...)` for observability, the secret leaked to every sink that logger ships to (stdout, files, third-party aggregators). A webhook secret is API-key-equivalent.
- Switch the `post/send` log context to the bare REST method name (e.g. `user.current`). `requestId` is still sufficient for correlation; the URL adds nothing the consumer doesn't already know from their own configuration. Applies issue #39's recommended **Option A**.
- `post/response` and `post/catchError` were already URL-free — the new regression test pins that.
- Drop the unused `url` field from `AjaxError.requestInfo` typing, `toString()`, and `formatErrorMessage()`. The field was declared but never populated at runtime, making it a dormant second leak path through error rendering.

## Files

- `packages/jssdk/src/core/http/abstract-http.ts` — `_makeAxiosRequest` `post/send` callsite now logs bare `method`, not `methodFormatted`.
- `packages/jssdk/src/core/http/ajax-error.ts` — remove `url` from `AjaxErrorDetails['requestInfo']`, `toString()`, `formatErrorMessage()`.
- `test/integration/core/http-logger-redaction.unit.spec.ts` — new regression spec (4 tests, v2 + v3 success/error paths + `AjaxError.toString()`). Pattern follows `batch-null-result.unit.spec.ts` — mocks the axios client, no `B24_HOOK` required.
- `CHANGELOG.md` — entry for 1.1.2.

## Test plan

- [x] `pnpm run lint` — clean.
- [x] `pnpm run typecheck` — clean (all workspaces).
- [x] `pnpm vitest run --project jsSdk:integration test/integration/core/http-logger-redaction.unit.spec.ts` — 4/4 passing.
- [x] `pnpm vitest run --project jsSdk:integration test/integration/core/batch-null-result.unit.spec.ts` — 4/4 passing (regression check on the existing unit-style spec).
- [x] **Manual smoke** with real `LoggerBrowser.build('smoke', true)` wired via `setLogger(...)` and a synthetic webhook URL `https://example.bitrix24.com/rest/1/MANUAL_SMOKE_SECRET_zzz999` (axios mocked, no network traffic). Verdict: neither the secret nor the `/rest/1/` path fragment appears anywhere in the console output. Captured `post/send` fragment:

  ```
  '0': 'post/send',
  '1': {
    requestId: '396f52ee-d7c2-7afe-a063-03a10dd2e6b5',
    method: 'user.current',
    params: '{}'
  }
  ```

  And `post/response`:

  ```
  '0': 'post/response',
  '1': {
    requestId: '396f52ee-d7c2-7afe-a063-03a10dd2e6b5',
    result: '{"ID":42,"NAME":"Smoke User"}',
    time: '{"start":0,"finish":0,"duration":0,...}'
  }
  ```

## Acceptance criteria from #39

- [x] `post/send` no longer logs the full URL — uses the bare REST method name.
- [x] `post/response` and `post/catchError` stay URL-free — pinned by tests.
- [x] Regression test spies on the logger, runs an API call against a mocked HTTP client, asserts the captured context never contains the secret.
- [x] Release note in `CHANGELOG.md` under 1.1.2 calls out the security implication so downstream consumers can decide whether to keep their own redaction shim as defence in depth.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQDAWbJx9fudzMUXew9wy4)_