### PR TITLE
fix(http): stop retrying HTTP 4xx client errors

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
+++ b/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
@@ -163,16 +163,22 @@ If operating of current method > (limitMs × thresholdPercent / 100):
 
 ```ts
 // Determining error type
-#isRateLimitError(error): boolean     // 503 or QUERY_LIMIT_EXCEEDED
-#isOperatingLimitError(error): boolean // 429 or OPERATION_TIME_LIMIT
-#isNeedThrowError(error): boolean     // Critical errors (no point in retrying)
+#isRateLimitError(error): boolean          // 503 or QUERY_LIMIT_EXCEEDED
+#isOperatingLimitError(error): boolean     // 429 or OPERATION_TIME_LIMIT
+#isNonRetryableClientError(error): boolean // HTTP 4xx (except 429 / 408)
+#isNeedThrowError(error): boolean          // Critical errors (no point in retrying)
 ```
 
 #### Retry Strategy
 
 1. **For limit errors**: Exponential delay considering the attempt number
-2. **For other errors**: Basic backoff with jitter (±10%)
-3. **Critical errors**: No retries
+2. **For client errors (HTTP 4xx, except 429 / 408)**: No retries — a `4xx`
+   response is deterministic, so retrying cannot change the outcome. The error
+   is surfaced on the first attempt (thrown, or returned in `AjaxResult` for
+   soft codes). `429` is retried as a rate/operating limit; `408` (request
+   timeout) stays transient.
+3. **For other errors**: Basic backoff with jitter (±10%)
+4. **Critical errors**: No retries
 
 ## Default Configurations
 
@@ -412,13 +418,17 @@ The SDK groups REST error codes into three categories:
 2. **Soft errors** — returned inside `AjaxResult` as an error payload, **not**
    thrown. Used for codes that callers typically inspect as part of normal
    control flow (e.g. `ENTITY_NOT_FOUND`, v3 validation errors).
-3. **Everything else** — treated as transient and retried up to `maxRetries`
-   times with backoff and jitter.
+3. **Everything else** — retryability is decided by HTTP status. Client errors
+   (HTTP `4xx`, except `429` and `408`) are **never retried** — they are
+   deterministic, so the SDK fails fast on the first attempt regardless of
+   whether the error code is enumerated. Transient conditions (`5xx`, `429`,
+   `408`, network errors) are retried up to `maxRetries` times with backoff and
+   jitter.
 
 The built-in lists cover Bitrix24's standard REST surface. If your application
 uses custom REST endpoints (e.g. from a local app or a placement handler) that
-return their own error codes, those codes will be **retried by default** —
-which is wrong for non-idempotent business errors.
+return their own error codes with a non-`4xx` status, those codes will be
+**retried by default** — which is wrong for non-idempotent business errors.
 
 Extend the classification via `hardErrorCodes` and `softErrorCodes`:
 

--- a/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
+++ b/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
@@ -57,7 +57,7 @@ interface RestrictionParams {
   adaptiveConfig?: AdaptiveConfig  // Adaptive delay settings
   maxRetries?: number              // Maximum number of request retries (default: 3). Except for `batch` requests
   retryDelay?: number              // Base delay between retries in ms (default: 1000)
-  retryOnNetworkError?: boolean    // Retry on `NETWORK_ERROR` / `REQUEST_TIMEOUT` (default: true).
+  retryOnNetworkError?: boolean    // Retry on `NETWORK_ERROR` / `REQUEST_TIMEOUT` (HTTP 408) (default: true).
                                    // Set to `false` for non-idempotent calls — see "Non-idempotent calls" below.
   hardErrorCodes?: string[]        // Extra codes to throw immediately (merged with built-in hard list).
   softErrorCodes?: string[]        // Extra codes to return as AjaxResult with error (merged with built-in soft list).
@@ -174,9 +174,10 @@ If operating of current method > (limitMs × thresholdPercent / 100):
 1. **For limit errors**: Exponential delay considering the attempt number
 2. **For client errors (HTTP 4xx, except 429 / 408)**: No retries — a `4xx`
    response is deterministic, so retrying cannot change the outcome. The error
-   is surfaced on the first attempt (thrown, or returned in `AjaxResult` for
-   soft codes). `429` is retried as a rate/operating limit; `408` (request
-   timeout) stays transient.
+   exits the retry loop on the first attempt; the usual hard/soft classification
+   then applies (thrown as `AjaxError`, or returned inside `AjaxResult` for soft
+   codes). `429` is retried as a rate/operating limit; `408` (request timeout)
+   stays transient.
 3. **For other errors**: Basic backoff with jitter (±10%)
 4. **Critical errors**: No retries
 

--- a/packages/jssdk/src/core/http/limiters/manager.ts
+++ b/packages/jssdk/src/core/http/limiters/manager.ts
@@ -119,6 +119,13 @@ export class RestrictionManager {
       return wait
     }
 
+    // Client errors (HTTP 4xx) are deterministic — retrying cannot change the
+    // outcome, so fail fast regardless of whether the error code is enumerated.
+    // 429 (rate/operating limit) is handled above; 408 (timeout) stays retryable.
+    if (this.#isNonRetryableClientError(error)) {
+      return 0 // We don't repeat
+    }
+
     // Other exceptions
     if (!this.#isNeedThrowError(error)) {
       // Since this is error handling, we take into account the number of attempts
@@ -172,6 +179,18 @@ export class RestrictionManager {
    */
   async #handleOperatingLimitError(requestId: string, method: string, params?: any, _error?: any): Promise<number> {
     return this.#operatingLimiter.getTimeToFree(requestId, method, params, _error)
+  }
+
+  /**
+   * Checks if the error is a non-retryable client error (HTTP 4xx).
+   *
+   * `429` is excluded — it is handled as a rate/operating limit and is retried
+   * with backoff. `408` (request timeout) is excluded — it is transient and is
+   * governed by `retryOnNetworkError`.
+   */
+  #isNonRetryableClientError(error: any): boolean {
+    const status = Number(error?.status ?? 0)
+    return status >= 400 && status < 500 && status !== 408 && status !== 429
   }
 
   /**

--- a/packages/jssdk/src/core/http/limiters/manager.ts
+++ b/packages/jssdk/src/core/http/limiters/manager.ts
@@ -123,7 +123,8 @@ export class RestrictionManager {
     // outcome, so fail fast regardless of whether the error code is enumerated.
     // 429 (rate/operating limit) is handled above; 408 (timeout) stays retryable.
     if (this.#isNonRetryableClientError(error)) {
-      return 0 // We don't repeat
+      this.#logNonRetryableClientError(requestId, error?.code ? `${error.code}` : '?', error?.message ?? '', method, Number(error?.status ?? 0))
+      return 0
     }
 
     // Other exceptions
@@ -190,6 +191,9 @@ export class RestrictionManager {
    */
   #isNonRetryableClientError(error: any): boolean {
     const status = Number(error?.status ?? 0)
+    if (Number.isNaN(status)) {
+      return false
+    }
     return status >= 400 && status < 500 && status !== 408 && status !== 429
   }
 
@@ -405,6 +409,18 @@ export class RestrictionManager {
       requestId,
       method,
       wait,
+      error: {
+        code,
+        message
+      }
+    })
+  }
+
+  #logNonRetryableClientError(requestId: string, code: string, message: string, method: string, status: number) {
+    this.getLogger().error(`client error ${status} (${code}) for the ${method} method is not retryable`, {
+      requestId,
+      method,
+      status,
       error: {
         code,
         message

--- a/playgrounds/cli/README.md
+++ b/playgrounds/cli/README.md
@@ -271,6 +271,84 @@ pnpm run dev make deals --total=50 --categoryId=3 --maxProducts=5 --assignedById
 pnpm run dev make deals --total=150
 ```
 
+## Smoke tests: retry policy
+
+> Manual end-to-end checks for the retry-policy fix (PR #45, issues #44 / #46).
+> The unit suite (`pnpm run package-jssdk:test:run`) covers the same regressions
+> deterministically; this script exists to confirm the behaviour against a real
+> portal. Source: [`src/commands/smoke-retry.ts`](./src/commands/smoke-retry.ts).
+
+### What the file does
+
+| | Scenario | Tests | Main PASS condition |
+|---|---|---|---|
+| **A** | #44 — v3 validation 400 | Regression for issue #44: the fix fires on v3 | `attempts=1`, `not-retryable=1`, `[THROWN]` < 2s |
+| **B** | #46 — `tasks.task.pause` code `1048582` | Regression for issue #46: the fix fires on unlisted 4xx codes | `attempts=1`, `not-retryable=1` (or `[OK]`), < 1.5s |
+| **D** | Timeout (HTTP 408) still retries | Negative control: 408 is not caught by the fix | `attempts=3`, `not-retryable=0` |
+| **E** | 500 parallel requests | Negative control: the rate limiter still kicks in | `ok=TOTAL`, `attempts ≥ TOTAL`, `rateLimitHits > 0`, `not-retryable=0` |
+
+### `.env`
+
+Required in `playgrounds/cli/.env`:
+
+```
+B24_HOOK=https://<portal>/rest/<userId>/<secret>/
+```
+
+Optional:
+
+```
+SMOKE_TASK_ID=2016               # for B — a real task id you can (or cannot) pause
+SMOKE_E_TOTAL=500                # for E — number of parallel calls (default: 500)
+SMOKE_LOG_FILE=./my-trace.log    # full-trace log path (default: playgrounds/cli/smoke-retry.log)
+```
+
+### How to run
+
+```bash
+# one scenario at a time (recommended — cleaner output):
+pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts A
+pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts B
+pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts D
+pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts E
+
+# or back-to-back:
+pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts all
+```
+
+### What you see in the console
+
+Each scenario prints a compact summary from an in-process `MemoryHandler` — no
+manual `grep` needed:
+
+```
+===== A. issue #44 — v3 validation 400 (bad payload) =====
+[THROWN] 612ms | attempts=1 | not-retryable=1 | exhausted=0
+       code=BITRIX_REST_V3_EXCEPTION_VALIDATION_REQUESTVALIDATIONEXCEPTION status=400 msg=...
+```
+
+That summary line is the PASS criterion. If you see `attempts=3 | exhausted=1`
+instead, it is a regression.
+
+### Analysing the log file
+
+The full trace (every `post/send`, `post/catchError`, limiter state event, …)
+is written to the path printed at the end of the run. The script also prints
+the most useful `grep` recipes itself:
+
+```bash
+grep -c 'http request attempt'         playgrounds/cli/smoke-retry.log   # total attempts across the run
+grep -c 'is not retryable'             playgrounds/cli/smoke-retry.log   # 4xx fast-fail hits (PR #45)
+grep -c 'all retry attempts exhausted' playgrounds/cli/smoke-retry.log   # must be 0 for scenarios A and B
+grep -c 'blocked method'               playgrounds/cli/smoke-retry.log   # limiter pre-throttle hits (E)
+```
+
+To extract the trace of a single request by its `requestId`:
+
+```bash
+grep '538a952b-1e87' playgrounds/cli/smoke-retry.log
+```
+
 ## Running from Different Directories
 
 ### From the monorepo root:

--- a/playgrounds/cli/README.md
+++ b/playgrounds/cli/README.md
@@ -302,7 +302,7 @@ B24_HOOK=https://<portal>/rest/<userId>/<secret>/
 | `--scenario` | `all` | Scenario key: `A`, `B`, `D`, `E`, or `all`. |
 | `--taskId` | `0` | Real task id used in scenario **B** (`tasks.task.pause`). Scenario B is skipped when `0`. |
 | `--total` | `500` | Number of parallel `user.current` calls in scenario **E**. |
-| `--logFile` | `playgrounds/cli/smoke-retry.log` | Path of the full-trace log file. |
+| `--logFile` | `smoke-retry.log` | Path of the full-trace log file. Relative paths resolve against the process cwd, which is `playgrounds/cli/` when invoked via `pnpm --filter`. |
 
 ### How to run
 

--- a/playgrounds/cli/README.md
+++ b/playgrounds/cli/README.md
@@ -295,25 +295,26 @@ Required in `playgrounds/cli/.env`:
 B24_HOOK=https://<portal>/rest/<userId>/<secret>/
 ```
 
-Optional:
+### CLI arguments
 
-```
-SMOKE_TASK_ID=2016               # for B — a real task id you can (or cannot) pause
-SMOKE_E_TOTAL=500                # for E — number of parallel calls (default: 500)
-SMOKE_LOG_FILE=./my-trace.log    # full-trace log path (default: playgrounds/cli/smoke-retry.log)
-```
+| Argument | Default | Description |
+|---|---|---|
+| `--scenario` | `all` | Scenario key: `A`, `B`, `D`, `E`, or `all`. |
+| `--taskId` | `0` | Real task id used in scenario **B** (`tasks.task.pause`). Scenario B is skipped when `0`. |
+| `--total` | `500` | Number of parallel `user.current` calls in scenario **E**. |
+| `--logFile` | `playgrounds/cli/smoke-retry.log` | Path of the full-trace log file. |
 
 ### How to run
 
 ```bash
 # one scenario at a time (recommended — cleaner output):
-pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts A
-pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts B
-pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts D
-pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts E
+pnpm --filter @bitrix24/b24jssdk-cli dev smoke-retry --scenario=A
+pnpm --filter @bitrix24/b24jssdk-cli dev smoke-retry --scenario=B --taskId=2016
+pnpm --filter @bitrix24/b24jssdk-cli dev smoke-retry --scenario=D
+pnpm --filter @bitrix24/b24jssdk-cli dev smoke-retry --scenario=E --total=500
 
-# or back-to-back:
-pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts all
+# or all of them back-to-back:
+pnpm --filter @bitrix24/b24jssdk-cli dev smoke-retry --scenario=all --taskId=2016
 ```
 
 ### What you see in the console

--- a/playgrounds/cli/src/commands/smoke-retry.ts
+++ b/playgrounds/cli/src/commands/smoke-retry.ts
@@ -58,8 +58,17 @@ export default defineCommand({
     logFile: { description: 'Full-trace log file path (relative paths resolve against cwd)', default: 'smoke-retry.log' }
   },
   async setup({ args }) {
+    const SCENARIO_KEYS = ['A', 'B', 'D', 'E', 'ALL'] as const
+    type ScenarioKey = typeof SCENARIO_KEYS[number]
     const scenario = String(args.scenario).toUpperCase()
-    const want = (key: string): boolean => scenario === key || scenario === 'ALL'
+    if (!(SCENARIO_KEYS as readonly string[]).includes(scenario)) {
+      console.error(
+        `Unknown --scenario=${args.scenario}. Allowed: ${SCENARIO_KEYS.join(' | ')} (Latin letters, case-insensitive).`
+      )
+      process.exit(2)
+    }
+    const want = (key: Exclude<ScenarioKey, 'ALL'>): boolean =>
+      scenario === key || scenario === 'ALL'
     const taskIdArg = Number(args.taskId)
     const totalArg = Number(args.total)
     const logPath = resolve(process.cwd(), String(args.logFile))
@@ -283,13 +292,17 @@ export default defineCommand({
     }
     // endregion ////
 
-    await new Promise<void>(resolveFlush => fileStream.end(() => resolveFlush()))
+    // Trailing summary MUST run before fileStream.end(): logger.notice
+    // fans out to the StreamHandler too, and writing after end() crashes
+    // with ERR_STREAM_WRITE_AFTER_END. Each notice() is awaited so the
+    // StreamHandler.handle() write resolves before we close the stream.
+    await logger.notice(`full trace -> ${logPath}`)
+    await logger.notice('analyse with:')
+    await logger.notice(`  grep -c 'http request attempt'         ${logPath}   # total attempts across the run`)
+    await logger.notice(`  grep -c 'is not retryable'             ${logPath}   # 4xx fast-fail hits (PR #45)`)
+    await logger.notice(`  grep -c 'all retry attempts exhausted' ${logPath}   # exhausted retries — should be 0 for A/B`)
+    await logger.notice(`  grep -c 'blocked method'               ${logPath}   # limiter pre-throttle hits (E)`)
 
-    logger.notice(`full trace -> ${logPath}`)
-    logger.notice('analyse with:')
-    logger.notice(`  grep -c 'http request attempt'         ${logPath}   # total attempts across the run`)
-    logger.notice(`  grep -c 'is not retryable'             ${logPath}   # 4xx fast-fail hits (PR #45)`)
-    logger.notice(`  grep -c 'all retry attempts exhausted' ${logPath}   # exhausted retries — should be 0 for A/B`)
-    logger.notice(`  grep -c 'blocked method'               ${logPath}   # limiter pre-throttle hits (E)`)
+    await new Promise<void>(resolveFlush => fileStream.end(() => resolveFlush()))
   }
 })

--- a/playgrounds/cli/src/commands/smoke-retry.ts
+++ b/playgrounds/cli/src/commands/smoke-retry.ts
@@ -1,0 +1,309 @@
+/**
+ * Manual smoke tests for the retry-policy fix (PR #45 / issues #44, #46).
+ *
+ * Each scenario is annotated with: purpose, what it does, PASS markers,
+ * FAIL (regression) markers. The script attaches a `Logger` with two
+ * handlers:
+ *   - `ConsoleV2Handler` at INFO  — surfaces just the useful lines in the
+ *     terminal so you can eyeball each scenario.
+ *   - `StreamHandler` at DEBUG    — writes the full trace (every attempt,
+ *     request/response, limiter state) to a file for post-hoc analysis.
+ *   - `MemoryHandler` at DEBUG    — used by the script itself to print a
+ *     short PASS/FAIL summary after each scenario.
+ *
+ * Required env (in `playgrounds/cli/.env`):
+ *
+ *   B24_HOOK=https://<portal>/rest/<userId>/<secret>/
+ *
+ * Optional env:
+ *
+ *   SMOKE_TASK_ID=<id>          # real task id you may pause for scenario B
+ *   SMOKE_E_TOTAL=500           # number of parallel calls for scenario E
+ *   SMOKE_LOG_FILE=./smoke.log  # log path (default: playgrounds/cli/smoke-retry.log)
+ *
+ * Run a single scenario (recommended — clearer output):
+ *
+ *   pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts A
+ *   pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts B
+ *   pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts D
+ *   pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts E
+ *
+ * Or run them all back-to-back:
+ *
+ *   pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts all
+ *
+ * After the run, the script prints the log file path and a few grep
+ * recipes you can use to dig into the trace.
+ */
+
+import 'dotenv/config'
+import { createWriteStream } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  ApiVersion,
+  B24Hook,
+  ConsoleV2Handler,
+  Logger,
+  LogLevel,
+  MemoryHandler,
+  StreamHandler
+} from '@bitrix24/b24jssdk'
+
+// region ---- env + logger ----------------------------------------------
+
+const HOOK_URL = process.env.B24_HOOK
+if (!HOOK_URL || !HOOK_URL.trim()) {
+  throw new Error('Set B24_HOOK in playgrounds/cli/.env')
+}
+
+const LOG_PATH = resolve(
+  process.cwd(),
+  process.env.SMOKE_LOG_FILE ?? 'playgrounds/cli/smoke-retry.log'
+)
+
+const fileStream = createWriteStream(LOG_PATH, { flags: 'w' })
+const memHandler = new MemoryHandler(LogLevel.DEBUG, { limit: 50_000 })
+
+const logger = new Logger('smoke-retry')
+logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO))
+logger.pushHandler(new StreamHandler(LogLevel.DEBUG, { stream: fileStream }))
+logger.pushHandler(memHandler)
+
+const b24 = B24Hook.fromWebhookUrl(HOOK_URL)
+b24.setLogger(logger)
+
+// endregion ---------------------------------------------------------------
+
+// region ---- helpers ----------------------------------------------------
+
+/**
+ * Stringify the entire LogRecord and check for a substring marker.
+ * Robust against the exact record shape — covers `message`, level name
+ * and any context fields the SDK puts under `params`.
+ */
+function countInMemory(marker: string): number {
+  const rec = memHandler.getRecords()
+  let n = 0
+  for (const r of rec) {
+    if (JSON.stringify(r).includes(marker)) n++
+  }
+  return n
+}
+
+async function run(label: string, fn: () => Promise<unknown>): Promise<void> {
+  memHandler.clear()
+  const t0 = Date.now()
+  console.log(`\n===== ${label} =====`)
+  let outcome: 'OK' | 'THROWN' = 'OK'
+  let summary = ''
+  try {
+    const res = await fn()
+    summary = (res && typeof res === 'object' && '_status' in (res as any))
+      ? `status=${(res as any)._status}`
+      : String(res ?? '')
+  } catch (e: any) {
+    outcome = 'THROWN'
+    summary = `code=${e?.code} status=${e?.status} msg=${e?.message}`
+  }
+  const elapsed = Date.now() - t0
+  const attempts = countInMemory('http request attempt')
+  const notRetryable = countInMemory('is not retryable')
+  const exhausted = countInMemory('all retry attempts exhausted')
+  console.log(
+    `[${outcome}] ${elapsed}ms | attempts=${attempts} | not-retryable=${notRetryable} | exhausted=${exhausted}`
+  )
+  if (summary) console.log(`       ${summary}`)
+}
+
+const scenario = (process.argv[2] ?? 'all').toUpperCase()
+const want = (key: string) => scenario === key || scenario === 'ALL'
+
+// endregion ---------------------------------------------------------------
+
+// region ---- A. issue #44 — v3 validation 400 ---------------------------
+/**
+ * **Why:** This is the exact scenario from issue #44 — a v3 method called
+ * with a malformed payload returns HTTP 400 with the validation error
+ * `BITRIX_REST_V3_EXCEPTION_VALIDATION_REQUESTVALIDATIONEXCEPTION`. Before
+ * PR #45 the SDK retried it 3 times (~7s) because that code was not in
+ * the hard/soft allowlist.
+ *
+ * **What it does:** Calls `tasks.task.update` via the v3 endpoint with a
+ * wrong-shape body. The server replies `400` immediately. With the fix,
+ * `handleError()` short-circuits on the 4xx status and the loop exits on
+ * the first attempt.
+ *
+ * **PASS markers (console summary):**
+ *   - `attempts=1`
+ *   - `not-retryable=1` (the new fast-fail log line fires once)
+ *   - `exhausted=0`
+ *   - outcome `[THROWN]` with `code=BITRIX_REST_V3_EXCEPTION_VALIDATION_...`
+ *   - elapsed `< 2_000`ms
+ *
+ * **FAIL markers (regression):** `attempts=3`, `exhausted=1`, elapsed `> 5_000`ms.
+ */
+if (want('A')) {
+  await run('A. issue #44 — v3 validation 400 (bad payload)', () =>
+    b24.actions.v3.call.make({
+      method: 'tasks.task.update',
+      params: { wrong: 'shape' }
+    })
+  )
+}
+
+// endregion ---------------------------------------------------------------
+
+// region ---- B. issue #46 — tasks code 1048582 -------------------------
+/**
+ * **Why:** Issue #46. Calling `tasks.task.pause` on a task that is not in
+ * a pauseable state (e.g. already paused / completed / not assigned to
+ * the webhook user) returns HTTP 400 with a numeric Bitrix code
+ * `1048582` (`"Действие не доступно"`). The code is not in any built-in
+ * allowlist, so before PR #45 the SDK retried 3 times (~7s).
+ *
+ * **What it does:** Calls `tasks.task.pause` twice in a row on
+ * `SMOKE_TASK_ID`. At least one of the two calls is expected to hit the
+ * "action not available" condition.
+ *
+ * **PASS markers (per call):**
+ *   - `attempts=1`
+ *   - if it errors: `not-retryable=1` with `code=1048582 status=400`
+ *   - elapsed `< 1_500`ms
+ *
+ * **FAIL markers (regression):** `attempts=3`, multiple `post/catchError`
+ * entries in the log for the same requestId, elapsed `> 5_000`ms.
+ *
+ * If `SMOKE_TASK_ID` is unset, the scenario is skipped.
+ */
+if (want('B')) {
+  const taskId = Number(process.env.SMOKE_TASK_ID ?? 0)
+  if (taskId > 0) {
+    await run('B1. issue #46 — pause once', () =>
+      b24.actions.v2.call.make({ method: 'tasks.task.pause', params: { taskId } })
+    )
+    await run('B2. issue #46 — pause again (expect 400 / code 1048582)', () =>
+      b24.actions.v2.call.make({ method: 'tasks.task.pause', params: { taskId } })
+    )
+  } else {
+    console.log('\nB. skipped — set SMOKE_TASK_ID=<id> in playgrounds/cli/.env')
+  }
+}
+
+// endregion ---------------------------------------------------------------
+
+// region ---- D. transient errors still retry (negative control) --------
+/**
+ * **Why:** PR #45 must not have broken the retry path for genuinely
+ * transient failures. A client-side timeout falls under HTTP `408`
+ * (`REQUEST_TIMEOUT`) — explicitly excluded from the 4xx fast-fail gate,
+ * still governed by `retryOnNetworkError` (default `true`).
+ *
+ * **What it does:** Lowers the underlying axios timeout to **1 ms** on
+ * the v2 HTTP client, then makes a normal `user.current` call. Every
+ * attempt aborts before any response can arrive, so the SDK enters the
+ * retry loop and burns all `maxRetries` (3) attempts.
+ *
+ * **PASS markers:** `attempts=3`, outcome `[THROWN]`, `code=REQUEST_TIMEOUT`
+ * or `NETWORK_ERROR`, `not-retryable=0`.
+ *
+ * **FAIL markers (regression):** `attempts=1` (i.e. we accidentally
+ * turned 408 into a fast-fail).
+ *
+ * Note: we restore the timeout right after to keep later scenarios sane.
+ */
+if (want('D')) {
+  const v2 = b24.getHttpClient(ApiVersion.v2).ajaxClient
+  const restore = v2.defaults.timeout
+  v2.defaults.timeout = 1
+  try {
+    await run('D. transient — timeout still retries (axios timeout=1ms)', () =>
+      b24.actions.v2.call.make({ method: 'user.current' })
+    )
+  } finally {
+    v2.defaults.timeout = restore
+  }
+}
+
+// endregion ---------------------------------------------------------------
+
+// region ---- E. rate-limit still retries (load — log to file) -----------
+/**
+ * **Why:** Same intent as D — confirm the limiter stack still kicks in
+ * for real transient signals (`429` / `503` / `QUERY_LIMIT_EXCEEDED` /
+ * `OPERATION_TIME_LIMIT`). PR #45 must not bypass these.
+ *
+ * **What it does:** Fires `SMOKE_E_TOTAL` (default 500) parallel
+ * `user.current` calls. The SDK's internal `RateLimiter` /
+ * `AdaptiveDelayer` should pre-throttle (`blocked method`), and if the
+ * portal returns `503` / `429`, `RestrictionManager.handleError()`
+ * should issue retries with backoff.
+ *
+ * The console flood is suppressed by the INFO handler — full trace
+ * lives in the log file; the summary line shows what matters.
+ *
+ * **PASS markers:**
+ *   - `ok = total` (or close to it)
+ *   - `attempts >= total` (≥ means at least one retry happened — that
+ *     is the limiter doing its job)
+ *   - `rateLimitHits > 0` (some calls were pre-throttled or got 503)
+ *   - `not-retryable = 0` (no 4xx leaked through this path)
+ *   - `exhausted = 0`
+ *
+ * **FAIL markers (regression):** `not-retryable > 0` (we zapped 429),
+ * or large `failed` count with `code=QUERY_LIMIT_EXCEEDED` (limiter
+ * not handling 503).
+ */
+if (want('E')) {
+  const TOTAL = Number(process.env.SMOKE_E_TOTAL ?? 500)
+  memHandler.clear()
+  const t0 = Date.now()
+  console.log(`\n===== E. rate-limit — ${TOTAL} parallel user.current =====`)
+  const results = await Promise.allSettled(
+    Array.from({ length: TOTAL }, () =>
+      b24.actions.v2.call.make({ method: 'user.current' })
+    )
+  )
+  const elapsed = Date.now() - t0
+  const ok = results.filter(r => r.status === 'fulfilled').length
+  const failed = results.filter(r => r.status === 'rejected') as PromiseRejectedResult[]
+  const byCode: Record<string, number> = {}
+  for (const f of failed) {
+    const c = (f.reason as any)?.code ?? 'unknown'
+    byCode[c] = (byCode[c] ?? 0) + 1
+  }
+  const attempts = countInMemory('http request attempt')
+  const rateLimitHits =
+    countInMemory('QUERY_LIMIT_EXCEEDED')
+    + countInMemory('OPERATION_TIME_LIMIT')
+    + countInMemory('blocked method')
+  const notRetryable = countInMemory('is not retryable')
+  const exhausted = countInMemory('all retry attempts exhausted')
+
+  console.log(
+    `[${ok === TOTAL ? 'OK' : 'PARTIAL'}] ${elapsed}ms (avg ${(elapsed / TOTAL).toFixed(1)}ms) | `
+    + `ok=${ok}/${TOTAL} | attempts=${attempts} | rateLimitHits=${rateLimitHits} | `
+    + `not-retryable=${notRetryable} | exhausted=${exhausted}`
+  )
+  if (failed.length > 0) {
+    console.log('       failures by code:')
+    for (const [code, n] of Object.entries(byCode)) {
+      console.log(`         ${code}: ${n}`)
+    }
+  }
+}
+
+// endregion ---------------------------------------------------------------
+
+// region ---- final block — flush log + grep recipes --------------------
+
+await new Promise<void>(resolveFlush => fileStream.end(() => resolveFlush()))
+
+console.log(`\nfull trace -> ${LOG_PATH}`)
+console.log('analyse with:')
+console.log(`  grep -c 'http request attempt'      ${LOG_PATH}    # total attempts across the run`)
+console.log(`  grep -c 'is not retryable'          ${LOG_PATH}    # 4xx fast-fail hits (PR #45)`)
+console.log(`  grep -c 'all retry attempts exhausted' ${LOG_PATH} # exhausted retries — should be 0 for A/B`)
+console.log(`  grep -c 'blocked method'            ${LOG_PATH}    # limiter pre-throttle hits (E)`)
+console.log(`  grep    'requestId' ${LOG_PATH} | awk -F'requestId' '{print $2}' | head -5`)
+
+// endregion ---------------------------------------------------------------

--- a/playgrounds/cli/src/commands/smoke-retry.ts
+++ b/playgrounds/cli/src/commands/smoke-retry.ts
@@ -1,308 +1,293 @@
-/**
- * Manual smoke tests for the retry-policy fix (PR #45 / issues #44, #46).
- *
- * Each scenario is annotated with: purpose, what it does, PASS markers,
- * FAIL (regression) markers. The script attaches a `Logger` with two
- * handlers (NO `ConsoleV2Handler` — the SDK emits deprecation/migration
- * warnings on every call that would otherwise drown out the test verdict;
- * the per-scenario summary printed via `console.log` is the PASS/FAIL line
- * you actually want to read):
- *   - `StreamHandler` at DEBUG    — writes the full trace (every attempt,
- *     request/response, limiter state) to a file for post-hoc analysis.
- *   - `MemoryHandler` at DEBUG    — used by the script itself to print a
- *     short PASS/FAIL summary after each scenario.
- *
- * Required env (in `playgrounds/cli/.env`):
- *
- *   B24_HOOK=https://<portal>/rest/<userId>/<secret>/
- *
- * Optional env:
- *
- *   SMOKE_TASK_ID=<id>          # real task id you may pause for scenario B
- *   SMOKE_E_TOTAL=500           # number of parallel calls for scenario E
- *   SMOKE_LOG_FILE=./smoke.log  # log path (default: playgrounds/cli/smoke-retry.log)
- *
- * Run a single scenario (recommended — clearer output):
- *
- *   pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts A
- *   pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts B
- *   pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts D
- *   pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts E
- *
- * Or run them all back-to-back:
- *
- *   pnpm --filter @bitrix24/b24jssdk-cli exec tsx src/commands/smoke-retry.ts all
- *
- * After the run, the script prints the log file path and a few grep
- * recipes you can use to dig into the trace.
- */
-
-import 'dotenv/config'
 import { createWriteStream } from 'node:fs'
 import { resolve } from 'node:path'
+import { defineCommand } from 'citty'
+import 'dotenv/config'
 import {
   ApiVersion,
   B24Hook,
+  ConsoleV2Handler,
   Logger,
   LogLevel,
   MemoryHandler,
   StreamHandler
 } from '@bitrix24/b24jssdk'
 
-// region ---- env + logger ----------------------------------------------
-
-const HOOK_URL = process.env.B24_HOOK
-if (!HOOK_URL || !HOOK_URL.trim()) {
-  throw new Error('Set B24_HOOK in playgrounds/cli/.env')
-}
-
-const LOG_PATH = resolve(
-  process.cwd(),
-  process.env.SMOKE_LOG_FILE ?? 'playgrounds/cli/smoke-retry.log'
-)
-
-const fileStream = createWriteStream(LOG_PATH, { flags: 'w' })
-const memHandler = new MemoryHandler(LogLevel.DEBUG, { limit: 50_000 })
-
-const logger = new Logger('smoke-retry')
-logger.pushHandler(new StreamHandler(LogLevel.DEBUG, { stream: fileStream }))
-logger.pushHandler(memHandler)
-
-const b24 = B24Hook.fromWebhookUrl(HOOK_URL)
-b24.setLogger(logger)
-
-// endregion ---------------------------------------------------------------
-
-// region ---- helpers ----------------------------------------------------
-
 /**
- * Stringify the entire LogRecord and check for a substring marker.
- * Robust against the exact record shape — covers `message`, level name
- * and any context fields the SDK puts under `params`.
+ * CLI command — manual smoke tests for the retry-policy fix
+ * (PR #45 / issues #44 and #46).
+ *
+ * Each scenario is annotated with: purpose, what it does, PASS markers,
+ * FAIL (regression) markers. Two loggers are attached:
+ *
+ *   - `smoke-retry` (user-facing, ConsoleV2Handler at INFO + StreamHandler
+ *     at DEBUG to the log file + MemoryHandler at DEBUG for in-process
+ *     analysis) — used to print scenario headers and the PASS/FAIL line.
+ *
+ *   - `b24` (SDK-facing, ConsoleV2Handler at ERROR only) — passed to
+ *     `b24.setLogger(...)`. Keeps actual SDK errors visible while
+ *     filtering out the deprecation/migration warning chatter on every
+ *     call. Full DEBUG trace still goes to the log file via the shared
+ *     stream below.
+ *
+ * Required env (in `playgrounds/cli/.env`):
+ *
+ *   B24_HOOK=https://<portal>/rest/<userId>/<secret>/
+ *
+ * Optional args (citty flags — see `args` block below):
+ *
+ *   --scenario=<A|B|D|E|all>  which scenario to run (default: all)
+ *   --taskId=<id>             real task id for scenario B
+ *   --total=<n>               number of parallel calls for scenario E
+ *                             (default: 500)
+ *   --logFile=<path>          log path (default: playgrounds/cli/smoke-retry.log)
+ *
+ * @usage pnpm --filter @bitrix24/b24jssdk-cli dev smoke-retry --scenario=A
  */
-function countInMemory(marker: string): number {
-  const rec = memHandler.getRecords()
-  let n = 0
-  for (const r of rec) {
-    if (JSON.stringify(r).includes(marker)) n++
-  }
-  return n
-}
 
-async function run(label: string, fn: () => Promise<unknown>): Promise<void> {
-  memHandler.clear()
-  const t0 = Date.now()
-  console.log(`\n===== ${label} =====`)
-  let outcome: 'OK' | 'THROWN' = 'OK'
-  let summary = ''
-  try {
-    const res = await fn()
-    summary = (res && typeof res === 'object' && '_status' in (res as any))
-      ? `status=${(res as any)._status}`
-      : String(res ?? '')
-  } catch (e: any) {
-    outcome = 'THROWN'
-    summary = `code=${e?.code} status=${e?.status} msg=${e?.message}`
-  }
-  const elapsed = Date.now() - t0
-  const attempts = countInMemory('http request attempt')
-  const notRetryable = countInMemory('is not retryable')
-  const exhausted = countInMemory('all retry attempts exhausted')
-  console.log(
-    `[${outcome}] ${elapsed}ms | attempts=${attempts} | not-retryable=${notRetryable} | exhausted=${exhausted}`
-  )
-  if (summary) console.log(`       ${summary}`)
-}
+export default defineCommand({
+  meta: {
+    name: 'smoke-retry',
+    description: 'Manual smoke tests for the retry-policy fix (PR #45)'
+  },
+  args: {
+    scenario: { description: 'Scenario key: A | B | D | E | all', default: 'all' },
+    taskId: { description: 'Real task id to use in scenario B', default: '0' },
+    total: { description: 'Number of parallel calls in scenario E', default: '500' },
+    logFile: { description: 'Full-trace log file path', default: 'playgrounds/cli/smoke-retry.log' }
+  },
+  async setup({ args }) {
+    const scenario = String(args.scenario).toUpperCase()
+    const want = (key: string): boolean => scenario === key || scenario === 'ALL'
+    const taskIdArg = Number(args.taskId)
+    const totalArg = Number(args.total)
+    const logPath = resolve(process.cwd(), String(args.logFile))
 
-const scenario = (process.argv[2] ?? 'all').toUpperCase()
-const want = (key: string) => scenario === key || scenario === 'ALL'
+    // region Loggers ////
+    const fileStream = createWriteStream(logPath, { flags: 'w' })
+    const memHandler = new MemoryHandler(LogLevel.DEBUG, { limit: 50_000 })
 
-// endregion ---------------------------------------------------------------
+    const logger = Logger.create('smoke-retry')
+    logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO, { useStyles: false }))
+    logger.pushHandler(new StreamHandler(LogLevel.DEBUG, { stream: fileStream }))
+    logger.pushHandler(memHandler)
 
-// region ---- A. issue #44 — v3 validation 400 ---------------------------
-/**
- * **Why:** This is the exact scenario from issue #44 — a v3 method called
- * with a malformed payload returns HTTP 400 with the validation error
- * `BITRIX_REST_V3_EXCEPTION_VALIDATION_REQUESTVALIDATIONEXCEPTION`. Before
- * PR #45 the SDK retried it 3 times (~7s) because that code was not in
- * the hard/soft allowlist.
- *
- * **What it does:** Calls `tasks.task.update` via the v3 endpoint with a
- * wrong-shape body. The server replies `400` immediately. With the fix,
- * `handleError()` short-circuits on the 4xx status and the loop exits on
- * the first attempt.
- *
- * **PASS markers (console summary):**
- *   - `attempts=1`
- *   - `not-retryable=1` (the new fast-fail log line fires once)
- *   - `exhausted=0`
- *   - outcome `[THROWN]` with `code=BITRIX_REST_V3_EXCEPTION_VALIDATION_...`
- *   - elapsed `< 2_000`ms
- *
- * **FAIL markers (regression):** `attempts=3`, `exhausted=1`, elapsed `> 5_000`ms.
- */
-if (want('A')) {
-  await run('A. issue #44 — v3 validation 400 (bad payload)', () =>
-    b24.actions.v3.call.make({
-      method: 'tasks.task.update',
-      params: { wrong: 'shape' }
-    })
-  )
-}
+    const loggerForDebugB24 = Logger.create('b24')
+    loggerForDebugB24.pushHandler(new ConsoleV2Handler(LogLevel.ERROR, { useStyles: false }))
+    loggerForDebugB24.pushHandler(new StreamHandler(LogLevel.DEBUG, { stream: fileStream }))
+    loggerForDebugB24.pushHandler(memHandler)
+    // endregion Loggers ////
 
-// endregion ---------------------------------------------------------------
-
-// region ---- B. issue #46 — tasks code 1048582 -------------------------
-/**
- * **Why:** Issue #46. Calling `tasks.task.pause` on a task that is not in
- * a pauseable state (e.g. already paused / completed / not assigned to
- * the webhook user) returns HTTP 400 with a numeric Bitrix code
- * `1048582` (`"Действие не доступно"`). The code is not in any built-in
- * allowlist, so before PR #45 the SDK retried 3 times (~7s).
- *
- * **What it does:** Calls `tasks.task.pause` twice in a row on
- * `SMOKE_TASK_ID`. At least one of the two calls is expected to hit the
- * "action not available" condition.
- *
- * **PASS markers (per call):**
- *   - `attempts=1`
- *   - if it errors: `not-retryable=1` with `code=1048582 status=400`
- *   - elapsed `< 1_500`ms
- *
- * **FAIL markers (regression):** `attempts=3`, multiple `post/catchError`
- * entries in the log for the same requestId, elapsed `> 5_000`ms.
- *
- * If `SMOKE_TASK_ID` is unset, the scenario is skipped.
- */
-if (want('B')) {
-  const taskId = Number(process.env.SMOKE_TASK_ID ?? 0)
-  if (taskId > 0) {
-    await run('B1. issue #46 — pause once', () =>
-      b24.actions.v2.call.make({ method: 'tasks.task.pause', params: { taskId } })
-    )
-    await run('B2. issue #46 — pause again (expect 400 / code 1048582)', () =>
-      b24.actions.v2.call.make({ method: 'tasks.task.pause', params: { taskId } })
-    )
-  } else {
-    console.log('\nB. skipped — set SMOKE_TASK_ID=<id> in playgrounds/cli/.env')
-  }
-}
-
-// endregion ---------------------------------------------------------------
-
-// region ---- D. transient errors still retry (negative control) --------
-/**
- * **Why:** PR #45 must not have broken the retry path for genuinely
- * transient failures. A client-side timeout falls under HTTP `408`
- * (`REQUEST_TIMEOUT`) — explicitly excluded from the 4xx fast-fail gate,
- * still governed by `retryOnNetworkError` (default `true`).
- *
- * **What it does:** Lowers the underlying axios timeout to **1 ms** on
- * the v2 HTTP client, then makes a normal `user.current` call. Every
- * attempt aborts before any response can arrive, so the SDK enters the
- * retry loop and burns all `maxRetries` (3) attempts.
- *
- * **PASS markers:** `attempts=3`, outcome `[THROWN]`, `code=REQUEST_TIMEOUT`
- * or `NETWORK_ERROR`, `not-retryable=0`.
- *
- * **FAIL markers (regression):** `attempts=1` (i.e. we accidentally
- * turned 408 into a fast-fail).
- *
- * Note: we restore the timeout right after to keep later scenarios sane.
- */
-if (want('D')) {
-  const v2 = b24.getHttpClient(ApiVersion.v2).ajaxClient
-  const restore = v2.defaults.timeout
-  v2.defaults.timeout = 1
-  try {
-    await run('D. transient — timeout still retries (axios timeout=1ms)', () =>
-      b24.actions.v2.call.make({ method: 'user.current' })
-    )
-  } finally {
-    v2.defaults.timeout = restore
-  }
-}
-
-// endregion ---------------------------------------------------------------
-
-// region ---- E. rate-limit still retries (load — log to file) -----------
-/**
- * **Why:** Same intent as D — confirm the limiter stack still kicks in
- * for real transient signals (`429` / `503` / `QUERY_LIMIT_EXCEEDED` /
- * `OPERATION_TIME_LIMIT`). PR #45 must not bypass these.
- *
- * **What it does:** Fires `SMOKE_E_TOTAL` (default 500) parallel
- * `user.current` calls. The SDK's internal `RateLimiter` /
- * `AdaptiveDelayer` should pre-throttle (`blocked method`), and if the
- * portal returns `503` / `429`, `RestrictionManager.handleError()`
- * should issue retries with backoff.
- *
- * The console flood is suppressed by the INFO handler — full trace
- * lives in the log file; the summary line shows what matters.
- *
- * **PASS markers:**
- *   - `ok = total` (or close to it)
- *   - `attempts >= total` (≥ means at least one retry happened — that
- *     is the limiter doing its job)
- *   - `rateLimitHits > 0` (some calls were pre-throttled or got 503)
- *   - `not-retryable = 0` (no 4xx leaked through this path)
- *   - `exhausted = 0`
- *
- * **FAIL markers (regression):** `not-retryable > 0` (we zapped 429),
- * or large `failed` count with `code=QUERY_LIMIT_EXCEEDED` (limiter
- * not handling 503).
- */
-if (want('E')) {
-  const TOTAL = Number(process.env.SMOKE_E_TOTAL ?? 500)
-  memHandler.clear()
-  const t0 = Date.now()
-  console.log(`\n===== E. rate-limit — ${TOTAL} parallel user.current =====`)
-  const results = await Promise.allSettled(
-    Array.from({ length: TOTAL }, () =>
-      b24.actions.v2.call.make({ method: 'user.current' })
-    )
-  )
-  const elapsed = Date.now() - t0
-  const ok = results.filter(r => r.status === 'fulfilled').length
-  const failed = results.filter(r => r.status === 'rejected') as PromiseRejectedResult[]
-  const byCode: Record<string, number> = {}
-  for (const f of failed) {
-    const c = (f.reason as any)?.code ?? 'unknown'
-    byCode[c] = (byCode[c] ?? 0) + 1
-  }
-  const attempts = countInMemory('http request attempt')
-  const rateLimitHits =
-    countInMemory('QUERY_LIMIT_EXCEEDED')
-    + countInMemory('OPERATION_TIME_LIMIT')
-    + countInMemory('blocked method')
-  const notRetryable = countInMemory('is not retryable')
-  const exhausted = countInMemory('all retry attempts exhausted')
-
-  console.log(
-    `[${ok === TOTAL ? 'OK' : 'PARTIAL'}] ${elapsed}ms (avg ${(elapsed / TOTAL).toFixed(1)}ms) | `
-    + `ok=${ok}/${TOTAL} | attempts=${attempts} | rateLimitHits=${rateLimitHits} | `
-    + `not-retryable=${notRetryable} | exhausted=${exhausted}`
-  )
-  if (failed.length > 0) {
-    console.log('       failures by code:')
-    for (const [code, n] of Object.entries(byCode)) {
-      console.log(`         ${code}: ${n}`)
+    const hookPath = process.env.B24_HOOK ?? ''
+    if (!hookPath.trim()) {
+      logger.emergency('B24_HOOK environment variable is not set. Configure it in playgrounds/cli/.env')
+      process.exit(1)
     }
+
+    const b24 = B24Hook.fromWebhookUrl(hookPath)
+    b24.setLogger(loggerForDebugB24)
+
+    logger.notice(`Connected to Bitrix24: ${b24.getTargetOrigin()}`)
+    logger.notice(`Scenario: ${scenario} | log file: ${logPath}`)
+
+    /**
+     * Stringify the entire LogRecord and check for a substring marker.
+     * Robust against the exact record shape — covers `message`, level
+     * name and any context fields.
+     */
+    function countInMemory(marker: string): number {
+      const records = memHandler.getRecords()
+      let n = 0
+      for (const r of records) {
+        if (JSON.stringify(r).includes(marker)) n++
+      }
+      return n
+    }
+
+    async function run(label: string, fn: () => Promise<unknown>): Promise<void> {
+      memHandler.clear()
+      const t0 = Date.now()
+      logger.notice(`===== ${label} =====`)
+      let outcome: 'OK' | 'THROWN' = 'OK'
+      let summary = ''
+      try {
+        const res = await fn()
+        summary = (res && typeof res === 'object' && '_status' in (res as any))
+          ? `status=${(res as any)._status}`
+          : String(res ?? '')
+      } catch (e: any) {
+        outcome = 'THROWN'
+        summary = `code=${e?.code} status=${e?.status} msg=${e?.message}`
+      }
+      const elapsed = Date.now() - t0
+      const attempts = countInMemory('http request attempt')
+      const notRetryable = countInMemory('is not retryable')
+      const exhausted = countInMemory('all retry attempts exhausted')
+      logger.notice(
+        `[${outcome}] ${elapsed}ms | attempts=${attempts} | not-retryable=${notRetryable} | exhausted=${exhausted}`
+      )
+      if (summary) logger.notice(`       ${summary}`)
+    }
+
+    // region A. issue #44 — v3 validation 400 ////
+    /**
+     * **Why:** Exact scenario from issue #44 — a v3 method called with a
+     * malformed payload returns HTTP 400 with the validation error
+     * `BITRIX_REST_V3_EXCEPTION_VALIDATION_REQUESTVALIDATIONEXCEPTION`.
+     * Before PR #45 the SDK retried it 3 times (~7s) because that code
+     * was not in the hard/soft allowlist.
+     *
+     * **What it does:** Calls `tasks.task.update` via the v3 endpoint
+     * with a wrong-shape body. The server replies `400` immediately. With
+     * the fix, `handleError()` short-circuits on the 4xx status and the
+     * loop exits on the first attempt.
+     *
+     * **PASS markers:** `attempts=1`, `not-retryable=1`, `exhausted=0`,
+     * outcome `[THROWN]` with `code=BITRIX_REST_V3_EXCEPTION_VALIDATION_...`,
+     * elapsed `< 2_000`ms.
+     *
+     * **FAIL markers:** `attempts=3`, `exhausted=1`, elapsed `> 5_000`ms.
+     */
+    if (want('A')) {
+      await run('A. issue #44 — v3 validation 400 (bad payload)', () =>
+        b24.actions.v3.call.make({
+          method: 'tasks.task.update',
+          params: { wrong: 'shape' }
+        })
+      )
+    }
+    // endregion ////
+
+    // region B. issue #46 — tasks code 1048582 ////
+    /**
+     * **Why:** Issue #46. Calling `tasks.task.pause` on a task that is
+     * not in a pauseable state (already paused / completed / not assigned
+     * to the webhook user) returns HTTP 400 with a numeric Bitrix code
+     * `1048582` (`"Действие не доступно"`). The code is not in any
+     * built-in allowlist, so before PR #45 the SDK retried 3 times (~7s).
+     *
+     * **What it does:** Calls `tasks.task.pause` twice in a row on
+     * `--taskId`. At least one of the two calls is expected to hit the
+     * "action not available" condition.
+     *
+     * **PASS markers (per call):** `attempts=1`, on error
+     * `not-retryable=1` with `code=1048582 status=400`, elapsed `< 1_500`ms.
+     *
+     * **FAIL markers:** `attempts=3`, multiple `post/catchError` entries
+     * for the same requestId, elapsed `> 5_000`ms.
+     *
+     * If `--taskId` is unset (default `0`), the scenario is skipped.
+     */
+    if (want('B')) {
+      if (taskIdArg > 0) {
+        await run('B1. issue #46 — pause once', () =>
+          b24.actions.v2.call.make({ method: 'tasks.task.pause', params: { taskId: taskIdArg } })
+        )
+        await run('B2. issue #46 — pause again (expect 400 / code 1048582)', () =>
+          b24.actions.v2.call.make({ method: 'tasks.task.pause', params: { taskId: taskIdArg } })
+        )
+      } else {
+        logger.notice('B. skipped — pass --taskId=<id> to run')
+      }
+    }
+    // endregion ////
+
+    // region D. transient errors still retry (negative control) ////
+    /**
+     * **Why:** PR #45 must not have broken the retry path for genuinely
+     * transient failures. A client-side timeout falls under HTTP `408`
+     * (`REQUEST_TIMEOUT`) — explicitly excluded from the 4xx fast-fail
+     * gate, still governed by `retryOnNetworkError` (default `true`).
+     *
+     * **What it does:** Lowers the underlying axios timeout to **1 ms**
+     * on the v2 HTTP client, then makes a normal `user.current` call.
+     * Every attempt aborts before any response can arrive, so the SDK
+     * enters the retry loop and burns all `maxRetries` (3) attempts.
+     *
+     * **PASS markers:** `attempts=3`, outcome `[THROWN]`,
+     * `code=REQUEST_TIMEOUT` or `NETWORK_ERROR`, `not-retryable=0`.
+     *
+     * **FAIL markers:** `attempts=1` (i.e. we accidentally turned 408
+     * into a fast-fail).
+     */
+    if (want('D')) {
+      const v2 = b24.getHttpClient(ApiVersion.v2).ajaxClient
+      const restore = v2.defaults.timeout
+      v2.defaults.timeout = 1
+      try {
+        await run('D. transient — timeout still retries (axios timeout=1ms)', () =>
+          b24.actions.v2.call.make({ method: 'user.current' })
+        )
+      } finally {
+        v2.defaults.timeout = restore
+      }
+    }
+    // endregion ////
+
+    // region E. rate-limit still retries (load — log to file) ////
+    /**
+     * **Why:** Same intent as D — confirm the limiter stack still kicks
+     * in for real transient signals (`429` / `503` /
+     * `QUERY_LIMIT_EXCEEDED` / `OPERATION_TIME_LIMIT`). PR #45 must not
+     * bypass these.
+     *
+     * **What it does:** Fires `--total` (default 500) parallel
+     * `user.current` calls. The SDK's `RateLimiter` / `AdaptiveDelayer`
+     * should pre-throttle (`blocked method`), and on `503` / `429` the
+     * `RestrictionManager.handleError()` should issue retries with
+     * backoff.
+     *
+     * **PASS markers:** `ok = total` (or close to it),
+     * `attempts >= total` (≥ means at least one retry — the limiter
+     * doing its job), `rateLimitHits > 0`, `not-retryable = 0`,
+     * `exhausted = 0`.
+     *
+     * **FAIL markers:** `not-retryable > 0` (we zapped 429), or large
+     * `failed` count with `code=QUERY_LIMIT_EXCEEDED` (limiter not
+     * handling 503).
+     */
+    if (want('E')) {
+      memHandler.clear()
+      const t0 = Date.now()
+      logger.notice(`===== E. rate-limit — ${totalArg} parallel user.current =====`)
+      const results = await Promise.allSettled(
+        Array.from({ length: totalArg }, () =>
+          b24.actions.v2.call.make({ method: 'user.current' })
+        )
+      )
+      const elapsed = Date.now() - t0
+      const ok = results.filter(r => r.status === 'fulfilled').length
+      const failed = results.filter(r => r.status === 'rejected') as PromiseRejectedResult[]
+      const byCode: Record<string, number> = {}
+      for (const f of failed) {
+        const c = (f.reason as any)?.code ?? 'unknown'
+        byCode[c] = (byCode[c] ?? 0) + 1
+      }
+      const attempts = countInMemory('http request attempt')
+      const rateLimitHits
+        = countInMemory('QUERY_LIMIT_EXCEEDED')
+          + countInMemory('OPERATION_TIME_LIMIT')
+          + countInMemory('blocked method')
+      const notRetryable = countInMemory('is not retryable')
+      const exhausted = countInMemory('all retry attempts exhausted')
+
+      logger.notice(
+        `[${ok === totalArg ? 'OK' : 'PARTIAL'}] ${elapsed}ms (avg ${(elapsed / totalArg).toFixed(1)}ms) | `
+        + `ok=${ok}/${totalArg} | attempts=${attempts} | rateLimitHits=${rateLimitHits} | `
+        + `not-retryable=${notRetryable} | exhausted=${exhausted}`
+      )
+      if (failed.length > 0) {
+        logger.notice('       failures by code:', byCode)
+      }
+    }
+    // endregion ////
+
+    await new Promise<void>(resolveFlush => fileStream.end(() => resolveFlush()))
+
+    logger.notice(`full trace -> ${logPath}`)
+    logger.notice('analyse with:')
+    logger.notice(`  grep -c 'http request attempt'         ${logPath}   # total attempts across the run`)
+    logger.notice(`  grep -c 'is not retryable'             ${logPath}   # 4xx fast-fail hits (PR #45)`)
+    logger.notice(`  grep -c 'all retry attempts exhausted' ${logPath}   # exhausted retries — should be 0 for A/B`)
+    logger.notice(`  grep -c 'blocked method'               ${logPath}   # limiter pre-throttle hits (E)`)
   }
-}
-
-// endregion ---------------------------------------------------------------
-
-// region ---- final block — flush log + grep recipes --------------------
-
-await new Promise<void>(resolveFlush => fileStream.end(() => resolveFlush()))
-
-console.log(`\nfull trace -> ${LOG_PATH}`)
-console.log('analyse with:')
-console.log(`  grep -c 'http request attempt'      ${LOG_PATH}    # total attempts across the run`)
-console.log(`  grep -c 'is not retryable'          ${LOG_PATH}    # 4xx fast-fail hits (PR #45)`)
-console.log(`  grep -c 'all retry attempts exhausted' ${LOG_PATH} # exhausted retries — should be 0 for A/B`)
-console.log(`  grep -c 'blocked method'            ${LOG_PATH}    # limiter pre-throttle hits (E)`)
-console.log(`  grep    'requestId' ${LOG_PATH} | awk -F'requestId' '{print $2}' | head -5`)
-
-// endregion ---------------------------------------------------------------
+})

--- a/playgrounds/cli/src/commands/smoke-retry.ts
+++ b/playgrounds/cli/src/commands/smoke-retry.ts
@@ -39,7 +39,9 @@ import {
  *   --taskId=<id>             real task id for scenario B
  *   --total=<n>               number of parallel calls for scenario E
  *                             (default: 500)
- *   --logFile=<path>          log path (default: playgrounds/cli/smoke-retry.log)
+ *   --logFile=<path>          log path (default: smoke-retry.log,
+ *                             resolved against cwd — `playgrounds/cli/`
+ *                             when invoked via `pnpm --filter`)
  *
  * @usage pnpm --filter @bitrix24/b24jssdk-cli dev smoke-retry --scenario=A
  */
@@ -53,7 +55,7 @@ export default defineCommand({
     scenario: { description: 'Scenario key: A | B | D | E | all', default: 'all' },
     taskId: { description: 'Real task id to use in scenario B', default: '0' },
     total: { description: 'Number of parallel calls in scenario E', default: '500' },
-    logFile: { description: 'Full-trace log file path', default: 'playgrounds/cli/smoke-retry.log' }
+    logFile: { description: 'Full-trace log file path (relative paths resolve against cwd)', default: 'smoke-retry.log' }
   },
   async setup({ args }) {
     const scenario = String(args.scenario).toUpperCase()

--- a/playgrounds/cli/src/commands/smoke-retry.ts
+++ b/playgrounds/cli/src/commands/smoke-retry.ts
@@ -3,9 +3,10 @@
  *
  * Each scenario is annotated with: purpose, what it does, PASS markers,
  * FAIL (regression) markers. The script attaches a `Logger` with two
- * handlers:
- *   - `ConsoleV2Handler` at INFO  — surfaces just the useful lines in the
- *     terminal so you can eyeball each scenario.
+ * handlers (NO `ConsoleV2Handler` — the SDK emits deprecation/migration
+ * warnings on every call that would otherwise drown out the test verdict;
+ * the per-scenario summary printed via `console.log` is the PASS/FAIL line
+ * you actually want to read):
  *   - `StreamHandler` at DEBUG    — writes the full trace (every attempt,
  *     request/response, limiter state) to a file for post-hoc analysis.
  *   - `MemoryHandler` at DEBUG    — used by the script itself to print a
@@ -42,7 +43,6 @@ import { resolve } from 'node:path'
 import {
   ApiVersion,
   B24Hook,
-  ConsoleV2Handler,
   Logger,
   LogLevel,
   MemoryHandler,
@@ -65,7 +65,6 @@ const fileStream = createWriteStream(LOG_PATH, { flags: 'w' })
 const memHandler = new MemoryHandler(LogLevel.DEBUG, { limit: 50_000 })
 
 const logger = new Logger('smoke-retry')
-logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO))
 logger.pushHandler(new StreamHandler(LogLevel.DEBUG, { stream: fileStream }))
 logger.pushHandler(memHandler)
 

--- a/playgrounds/cli/src/index.ts
+++ b/playgrounds/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { defineCommand, runMain } from 'citty'
 import make from './commands/make'
+import smokeRetry from './commands/smoke-retry'
 
 const main = defineCommand({
   meta: {
@@ -8,7 +9,8 @@ const main = defineCommand({
     description: 'Bitrix24 JS SDK CLI'
   },
   subCommands: {
-    make
+    make,
+    'smoke-retry': smokeRetry
   }
 })
 

--- a/test/integration/core/retry-client-error.unit.spec.ts
+++ b/test/integration/core/retry-client-error.unit.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit-style tests for the retry decision in `RestrictionManager.handleError`.
+ *
+ * Regression for issue #44: a v3 client validation error (HTTP 400) must fail
+ * fast instead of being retried `maxRetries` times. Retryability is decided by
+ * HTTP status — any 4xx (except 429/408) is deterministic and not retried,
+ * regardless of whether its error code is enumerated in the hard/soft lists.
+ *
+ * `handleError` returns the wait time before the next attempt: `0` means "do
+ * not retry", a positive value means "retry after this delay".
+ */
+import { describe, it, expect } from 'vitest'
+import { RestrictionManager } from '../../../packages/jssdk/src/core/http/limiters/manager'
+import { ParamsFactory } from '../../../packages/jssdk/src/core/http/limiters/params-factory'
+
+function buildManager(): RestrictionManager {
+  return new RestrictionManager(ParamsFactory.getDefault())
+}
+
+function callHandleError(manager: RestrictionManager, error: { code: string, message?: string, status: number }) {
+  return manager.handleError('unit-test', 'tasks.task.update', {}, { message: '', ...error }, 0)
+}
+
+describe('retry decision: client errors are not retried (issue #44)', () => {
+  it('does not retry the v3 validation error from the report (HTTP 400)', async () => {
+    const wait = await callHandleError(buildManager(), {
+      code: 'BITRIX_REST_V3_EXCEPTION_VALIDATION_REQUESTVALIDATIONEXCEPTION',
+      status: 400
+    })
+    expect(wait).toBe(0)
+  })
+
+  it('does not retry an unlisted 4xx error code (status-driven, not allowlist-driven)', async () => {
+    const wait = await callHandleError(buildManager(), {
+      code: 'BITRIX_REST_V3_EXCEPTION_SOME_BRAND_NEW_CODE',
+      status: 400
+    })
+    expect(wait).toBe(0)
+  })
+
+  it.each([401, 403, 404, 422])('does not retry HTTP %i', async (status) => {
+    const wait = await callHandleError(buildManager(), { code: 'CLIENT_ERROR', status })
+    expect(wait).toBe(0)
+  })
+
+  it('still retries 408 (request timeout) — transient', async () => {
+    const wait = await callHandleError(buildManager(), { code: 'REQUEST_TIMEOUT', status: 408 })
+    expect(wait).toBeGreaterThan(0)
+  })
+
+  it('still retries 429 (operating limit)', async () => {
+    const wait = await callHandleError(buildManager(), { code: 'OPERATION_TIME_LIMIT', status: 429 })
+    expect(wait).toBeGreaterThan(0)
+  })
+
+  it('still retries 503 (rate limit)', async () => {
+    const wait = await callHandleError(buildManager(), { code: 'QUERY_LIMIT_EXCEEDED', status: 503 })
+    expect(wait).toBeGreaterThan(0)
+  })
+
+  it('still retries a network error (status 0)', async () => {
+    const wait = await callHandleError(buildManager(), { code: 'NETWORK_ERROR', status: 0 })
+    expect(wait).toBeGreaterThan(0)
+  })
+})

--- a/test/integration/core/retry-client-error.unit.spec.ts
+++ b/test/integration/core/retry-client-error.unit.spec.ts
@@ -17,8 +17,12 @@ function buildManager(): RestrictionManager {
   return new RestrictionManager(ParamsFactory.getDefault())
 }
 
-function callHandleError(manager: RestrictionManager, error: { code: string, message?: string, status: number }) {
-  return manager.handleError('unit-test', 'tasks.task.update', {}, { message: '', ...error }, 0)
+function callHandleError(
+  manager: RestrictionManager,
+  error: { code: string, message?: string, status: number },
+  attempt = 0
+) {
+  return manager.handleError('unit-test', 'tasks.task.update', {}, { message: '', ...error }, attempt)
 }
 
 describe('retry decision: client errors are not retried (issue #44)', () => {
@@ -38,8 +42,23 @@ describe('retry decision: client errors are not retried (issue #44)', () => {
     expect(wait).toBe(0)
   })
 
-  it.each([401, 403, 404, 422])('does not retry HTTP %i', async (status) => {
+  it.each([400, 401, 403, 404, 422, 451, 499])('does not retry HTTP %i', async (status) => {
     const wait = await callHandleError(buildManager(), { code: 'CLIENT_ERROR', status })
+    expect(wait).toBe(0)
+  })
+
+  it('does not retry a 4xx error even on a later attempt (the issue #44 scenario)', async () => {
+    const wait = await callHandleError(buildManager(), {
+      code: 'BITRIX_REST_V3_EXCEPTION_VALIDATION_REQUESTVALIDATIONEXCEPTION',
+      status: 400
+    }, 2)
+    expect(wait).toBe(0)
+  })
+
+  it('does not retry a hard error code carried on a 4xx status', async () => {
+    // ACCESS_DENIED is in BUILT_IN_HARD_ERROR_CODES; with a 4xx status the
+    // status gate fires first, but the outcome must still be "no retry".
+    const wait = await callHandleError(buildManager(), { code: 'ACCESS_DENIED', status: 403 })
     expect(wait).toBe(0)
   })
 
@@ -50,7 +69,7 @@ describe('retry decision: client errors are not retried (issue #44)', () => {
 
   it('still retries 429 (operating limit)', async () => {
     const wait = await callHandleError(buildManager(), { code: 'OPERATION_TIME_LIMIT', status: 429 })
-    expect(wait).toBeGreaterThan(0)
+    expect(wait).toBeGreaterThanOrEqual(10_000)
   })
 
   it('still retries 503 (rate limit)', async () => {
@@ -58,8 +77,22 @@ describe('retry decision: client errors are not retried (issue #44)', () => {
     expect(wait).toBeGreaterThan(0)
   })
 
+  it.each([500, 502, 504])('still retries server error HTTP %i', async (status) => {
+    const wait = await callHandleError(buildManager(), { code: 'SERVER_ERROR', status })
+    expect(wait).toBeGreaterThan(0)
+  })
+
   it('still retries a network error (status 0)', async () => {
     const wait = await callHandleError(buildManager(), { code: 'NETWORK_ERROR', status: 0 })
     expect(wait).toBeGreaterThan(0)
+  })
+
+  it('grows the backoff with the attempt number for a server error', async () => {
+    const manager = buildManager()
+    const wait0 = await callHandleError(manager, { code: 'SERVER_ERROR', status: 500 }, 0)
+    const wait2 = await callHandleError(manager, { code: 'SERVER_ERROR', status: 500 }, 2)
+    // Backoff is delay * 2^attempt with ±10% jitter — the gap is large enough
+    // that the upper jitter bound of attempt 0 stays below attempt 2.
+    expect(wait2).toBeGreaterThan(wait0)
   })
 })

--- a/test/integration/core/retry-client-error.unit.spec.ts
+++ b/test/integration/core/retry-client-error.unit.spec.ts
@@ -42,6 +42,15 @@ describe('retry decision: client errors are not retried (issue #44)', () => {
     expect(wait).toBe(0)
   })
 
+  it('does not retry the tasks "action not available" code 1048582 (issue #46)', async () => {
+    // tasks.task.pause / .defer on an already-applied state returns HTTP 400
+    // with {"error":"1048582","error_description":"Действие не доступно"}.
+    // The code is not in any built-in list, but the 4xx status alone must
+    // stop the retry — no per-code allowlist patching required.
+    const wait = await callHandleError(buildManager(), { code: '1048582', status: 400 })
+    expect(wait).toBe(0)
+  })
+
   it.each([400, 401, 403, 404, 422, 451, 499])('does not retry HTTP %i', async (status) => {
     const wait = await callHandleError(buildManager(), { code: 'CLIENT_ERROR', status })
     expect(wait).toBe(0)


### PR DESCRIPTION
## Summary

Fixes #44 **and #46** (same root cause, same fix). A REST **v3** call that fails with a deterministic client error (HTTP `4xx`) was retried up to `maxRetries` (3) times before giving up — wasting round-trips and emitting a misleading `all retry attempts exhausted` warning for an error that was never transient.

**Root cause:** retryability was decided by a hardcoded error-code allowlist (`BUILT_IN_HARD/SOFT_ERROR_CODES`), not the HTTP status. `RestrictionManager.handleError()` only returned `0` (no retry) when the error **code** was enumerated; any `4xx` whose code was missing fell through to the backoff branch and got retried. This was fragile by design:
- #44 — v3 `tasks.task.update` with `BITRIX_REST_V3_EXCEPTION_VALIDATION_REQUESTVALIDATIONEXCEPTION`
- #46 — tasks `tasks.task.pause` / `.defer` with numeric Bitrix code `1048582` ("Действие не доступно"); inconsistent with `tasks.task.start` which returns code `"0"` → axios `ERR_BAD_REQUEST` (hard-listed → already fail-fast)

Both are HTTP `400` with codes outside the allowlist; both are now handled uniformly.

## Change

`RestrictionManager.handleError()` now gates retries on **HTTP status** (`packages/jssdk/src/core/http/limiters/manager.ts`):

- HTTP `4xx` ⇒ **no retry** (deterministic client error), surfaced on the first attempt.
- `429` is still retried as a rate/operating limit (handled earlier in the method).
- `408` (request timeout) stays transient/retryable, governed by `retryOnNetworkError`.
- `5xx`, network errors, timeouts ⇒ unchanged (still retried with backoff + jitter).
- Logs the fast-fail decision for parity with the other `handleError` branches.
- `NaN`-guard on `error.status` for an explicit contract.

Soft-code handling is unaffected: a `4xx` soft code (e.g. v3 validation) still returns `0` here and is then surfaced via `AjaxResult` by `call()` in `abstract-http.ts` — it just no longer burns the extra attempts first.

## Tests

New unit-style regression spec `test/integration/core/retry-client-error.unit.spec.ts` (no live portal needed), 20 cases:

- the exact v3 validation code from #44 ⇒ not retried
- the tasks code `1048582` from #46 ⇒ not retried
- an **unlisted** `4xx` code ⇒ not retried (status-driven, not allowlist-driven)
- boundary `400/401/403/404/422/451/499` ⇒ not retried
- fast-fail on a later attempt (`attempt=2`) ⇒ still `0`
- hard-code on a `4xx` status ⇒ `0`
- `408`, `429`, `503`, `500/502/504`, network error ⇒ still retried
- backoff grows with the attempt number

## Docs

Updated `docs/content/docs/2.working-with-the-rest-api/77.limiters.md` (Error Handling, Retry Strategy, Error Classification, the `retryOnNetworkError` row in the parameter table) to describe the status-based gating.

## Verification

- `pnpm run package-jssdk:typecheck` — pass
- `eslint` on changed files — clean
- `vitest --project jsSdk:integration` unit specs — 34 passed (20 new + 14 existing)

## Test plan

- [ ] Confirm a v3 `tasks.task.update` with a malformed payload fails on the first attempt (no `attempt 3/3` / `all retry attempts exhausted` in logs)
- [ ] Confirm `tasks.task.pause` on an already-paused task fails fast (no retries, no `1048582` allowlist patching needed)
- [ ] Confirm rate-limited (`429/503`) and transient (network/`408`) calls still retry

Closes #44
Closes #46

https://claude.ai/code/session_01DrGTzw139WbMeShEvwACSo