### PR TITLE
docs(logging): document credential redaction

### DIFF
--- a/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
+++ b/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
@@ -1,7 +1,7 @@
 ---
 title: LLMs.txt
 description: 'How to get AI tools like Cursor, Windsurf, GitHub Copilot, ChatGPT, and Claude to understand Bitrix24 JS SDK methods, tools, and best practices.'
-audited: 2026-05-05
+audited: 2026-05-27
 links:
   - label: Nuxt config (nuxt-llms)
     iconName: GitHubIcon

--- a/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
+++ b/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
@@ -1,7 +1,7 @@
 ---
 title: LLMs.txt
 description: 'How to get AI tools like Cursor, Windsurf, GitHub Copilot, ChatGPT, and Claude to understand Bitrix24 JS SDK methods, tools, and best practices.'
-audited: 2026-05-27
+audited: 2026-05-28
 links:
   - label: Nuxt config (nuxt-llms)
     iconName: GitHubIcon

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -14,9 +14,6 @@ links:
   - label: ajax-error.ts (error redaction)
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-error.ts
-  - label: Logger
-    iconName: GitHubIcon
-    to: /docs/working-with-the-rest-api/logger/
 ---
 
 <!--
@@ -79,10 +76,17 @@ caught, or redact at the callsite.
 
 | Where | Log channel | Level | Source |
 | --- | --- | --- | --- |
-| `post/send` (request being dispatched) | logger context `params` | `info` | [`abstract-http.ts:487`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts) |
-| `post/catchError` (axios error) | logger context `responseData` | `info` | [`abstract-http.ts:458`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts) |
-| `http request starting` (`_logRequest`) | logger context `params` | `debug` | [`abstract-http.ts:624`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts) |
-| `AjaxError` constructor | `requestInfo.params` (visible via `toJSON()` / `toString()`) | n/a | [`ajax-error.ts:44`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-error.ts) |
+| `post/send` (request being dispatched) | logger context `params` | `info` | [`abstract-http.ts:491`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts#L491) |
+| `post/catchError` (axios error) | logger context `responseData` | `info` | [`abstract-http.ts:452`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts#L452) |
+| `http request starting` (`_logRequest`) | logger context `params` | `debug` | [`abstract-http.ts:628`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts#L628) |
+| `AjaxError` constructor | `requestInfo.params` (visible via `toJSON()` / `toString()`) | n/a | [`ajax-error.ts:44`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-error.ts#L44) |
+
+The other log callsites in [`abstract-http.ts`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts)
+(`http request attempt`, `http request successful`, `http request failed`,
+`http refreshing auth token`, `http auth error detected`, retry-wait
+logs) carry only `requestId`, `method`, `api`, `attempt`, `duration`,
+and `AjaxError` code/message/status — none of them touch `params` or
+the webhook URL, so they have no redaction concern.
 
 The redaction is **level-independent** — it runs on the data before it
 is handed to the logger, so it applies whether your handler is filtering
@@ -100,12 +104,14 @@ and stay that way. `AjaxQuery` (the `requestInfo` shape carried by
 so a future change cannot accidentally re-introduce the leak through
 error rendering.
 
-If you wired a custom logger on **any** 1.1.x release before 1.1.2, audit
-historical log sinks (stdout, files, third-party aggregators) for entries
-matching `/rest/{userId}/{secret}/` and rotate the corresponding webhook
-secrets. A dedicated migration guide is planned (tracking issue
-[#53](https://github.com/bitrix24/b24jssdk/issues/53) — _Migration guide
-to be added._)
+If you wired a custom logger on any release in the range
+`>= 1.1.0, < 1.1.2`, audit historical log sinks (stdout, files,
+third-party aggregators) **now** for entries matching
+`/rest/{userId}/{secret}/` (webhook auth) or `"auth":"<token>"` (OAuth /
+Frame) and rotate the corresponding credentials — don't wait for the
+companion migration guide. A dedicated step-by-step is tracked in
+[#53](https://github.com/bitrix24/b24jssdk/issues/53) (_to be added_),
+but the rotation itself is independent of that page.
 
 ## AjaxError — `toJSON` / `toString`
 
@@ -127,8 +133,12 @@ in any log line that subsequently includes the error.
 
 ## What the SDK does not redact
 
-The SDK only knows about the six canonical keys. It will not strip:
+The SDK only knows about the six canonical keys, matched
+**case-sensitively** with `===`. The redactor will **not** strip:
 
+- **Keys with different casing** — `Auth`, `TOKEN`, `Access_Token`,
+  `Secret` and friends are walked past untouched. Stick to the canonical
+  lowercase names, or redact custom-cased keys yourself.
 - **Custom payload fields you invented** — e.g. `mySecretField`,
   `apiKeyHeader`, `x_internal_token`, anything whose key is not in
   [`SENSITIVE_PARAM_KEYS`](#what-the-sdk-redacts-automatically).
@@ -137,15 +147,40 @@ The SDK only knows about the six canonical keys. It will not strip:
   query string.
 - **Data more than two levels deep** — anything past `cmd[i].params.<key>`
   depth is walked past, not into.
-- **Response bodies from the portal**, beyond what
-  `post/catchError` already runs through the redactor. The portal does
-  not currently embed credentials in error responses, but if your
-  integration round-trips secrets through a custom endpoint, that data
-  flows through verbatim on the success path.
+- **Custom request headers you set on the underlying axios client** —
+  e.g. an `Authorization: Bearer <token>` header configured via your
+  own axios interceptor. The redactor only touches `params`, not
+  headers, and headers are not part of the SDK's standard logger
+  context anyway — but they do live on `AxiosError.config.headers`, see
+  the next bullet.
+- **Success-path response bodies** — the `post/response` info log
+  serialises `response.data.result` directly
+  ([`abstract-http.ts:501-506`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts#L501-L506))
+  without running it through the redactor. The portal's first-party
+  REST surface does not embed credentials in success responses, but if
+  your integration round-trips secrets through a custom endpoint — for
+  example an OAuth-relay handler that returns `{ access_token,
+  refresh_token }` in `result` — those values **will** enter your
+  logger context verbatim. Either suppress this log channel in your
+  setup, redact in a custom processor, or don't pipe secrets through
+  the result envelope of a logged REST call.
 
-Stripping these is **caller responsibility**. Either don't put secrets
-into non-standard keys to begin with, or redact in your custom logger's
-handler / processor.
+::warning
+**Don't log `err.originalError` directly.** `AjaxError` (via its
+[`SdkError`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts#L15)
+base) exposes a public `originalError` field that, for transport
+failures, holds the **raw** `AxiosError`. That `AxiosError.config.url`
+contains the full webhook URL
+(`/rest/{userId}/{secret}/method.json`) and `AxiosError.config.headers`
+can contain `Authorization`. Neither is redacted by the SDK — they
+were never inside `params`. Use `err.code`, `err.status`, `err.message`,
+or `err.requestInfo` (which **is** redacted), and never blanket-stringify
+`err.originalError` into any logger sink.
+::
+
+Stripping the items above is **caller responsibility**. Either don't put
+secrets into non-standard keys / non-standard log channels to begin
+with, or redact in your custom logger's handler / processor.
 
 ## Recommended pattern: wiring a custom logger
 
@@ -185,35 +220,47 @@ b24.setLogger($logger)
 What to **avoid**:
 
 ```ts
-// DON'T — turning the logger output back into a structured object and
-// re-emitting it without re-running the redactor risks reintroducing
-// custom-field leaks that the SDK never claimed to handle.
+// DON'T — re-emitting context without inspection forwards arbitrary
+// caller-supplied data into a remote sink, and bypassing LoggerInterface
+// with `as any` hides the fact that handlers must implement all 8
+// log-level methods (log / debug / info / notice / warning / error /
+// critical / alert / emergency). A partial implementation will silently
+// drop entries at the unimplemented levels.
 b24.setLogger({
   async info(message, context) {
     await sendToRemoteAggregator({
       msg: message,
-      // `context.params` is already a redacted *string* on `post/send`,
-      // but if your code path passes a raw `params` object from
-      // elsewhere (e.g. you also log inside a custom action wrapper),
-      // forward it without inspection.
+      // `context.params` on `post/send` is already a redacted *string*,
+      // but a custom action wrapper may also call this `info` with a
+      // raw `params` object (or with an `error` whose `originalError`
+      // is the unredacted `AxiosError`). Don't forward `context`
+      // blindly — pick the fields you actually want.
       ctx: context
     })
-  },
-  // …
+  }
+  // ...other 7 methods omitted — the cast below is what lets this
+  // compile despite the incomplete interface; in real code, implement
+  // `LoggerInterface` fully (or extend `AbstractLogger`).
 } as any)
 ```
 
-Two concrete failure modes to guard against:
+Three concrete failure modes to guard against:
 
 1. **Logging the original request object yourself.** If your wrapper
    captures `params` before calling into the SDK and logs it, the SDK's
    redactor never runs on that copy. Always redact in your own log path
    too.
-2. **Stringifying `AjaxError` in a non-handler surface.** The error's
-   `requestInfo.params` is already scrubbed, so `String(err)` and
-   `JSON.stringify(err)` are safe — but if you reach into
-   `err.cause`/`err.originalError` and log _those_, you may be looking
-   at a pre-redaction object.
+2. **Reaching into `err.originalError` / `err.cause`.** `AjaxError`'s
+   `requestInfo.params` is scrubbed, so `String(err)` and
+   `JSON.stringify(err)` are safe by themselves. But if you log
+   `err.originalError`, you may be looking at a raw `AxiosError` whose
+   `config.url` still holds the full webhook URL. See the warning
+   block in [What the SDK does not redact](#what-the-sdk-does-not-redact).
+3. **Forwarding `post/response` context to remote sinks.** That
+   channel logs `response.data.result` verbatim. If any of your REST
+   endpoints can return tokens in the result body, either suppress
+   that channel or post-redact it in your handler before it leaves
+   the process.
 
 ## Advanced: reading the source
 

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -100,7 +100,7 @@ method name (e.g. `user.current`, `crm.item.add`) is logged; the
 `post/response` and `post/catchError` callsites have always been URL-free
 and stay that way. `AjaxQuery` (the `requestInfo` shape carried by
 `AjaxError`) no longer types a `url` field at all — see
-[`ajax-result.ts:12-16`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-result.ts) —
+[`ajax-result.ts:12-16`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-result.ts#L12-L16) —
 so a future change cannot accidentally re-introduce the leak through
 error rendering.
 
@@ -155,7 +155,7 @@ The SDK only knows about the six canonical keys, matched
   the next bullet.
 - **Success-path response bodies** — the `post/response` info log
   serialises `response.data.result` directly
-  ([`abstract-http.ts:501-506`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts#L501-L506))
+  ([`abstract-http.ts:501-509`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts#L501-L509))
   without running it through the redactor. The portal's first-party
   REST surface does not embed credentials in success responses, but if
   your integration round-trips secrets through a custom endpoint — for

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -1,0 +1,232 @@
+---
+title: Logging & Credential Redaction
+description: 'What the SDK redacts automatically before any request information enters the logger or an AjaxError, what it does not redact, and how to wire a custom logger via setLogger(...) without re-introducing credential leaks.'
+category: 'logging'
+audited: 2026-05-27
+navigation.title: Logging & Redaction
+links:
+  - label: redact.ts (canonical key list)
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/redact.ts
+  - label: abstract-http.ts (log callsites)
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts
+  - label: ajax-error.ts (error redaction)
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-error.ts
+  - label: Logger
+    iconName: GitHubIcon
+    to: /docs/working-with-the-rest-api/logger/
+---
+
+<!--
+  TODO: when issue #53 (secret-rotation migration guide for v1.1.2) ships,
+  replace the "Migration guide (to be added)" note below with a real
+  /docs/... link. Tracking: https://github.com/bitrix24/b24jssdk/issues/53.
+  Do not add the /docs/... link before the page exists — docs:lint-links
+  will fail on a missing target.
+-->
+
+## Overview
+
+Since v1.1.2 the HTTP layer redacts a fixed set of credential-bearing keys
+from any request payload before it can reach:
+
+- the **logger context** of `post/send`, `post/response`, `post/catchError`
+  info-level entries (and the lower-level `http request starting` /
+  `_logRequest` debug entry),
+- the `requestInfo.params` field carried by [`AjaxError`](#ajaxerror--tojson--tostring),
+  which is what consumers see via `AjaxError.toString()` / `toJSON()`.
+
+This means a user wiring a custom logger through `B24Hook.setLogger(...)`,
+`B24Frame.setLogger(...)` or `B24OAuth.setLogger(...)` does **not** need
+to add their own redaction for the standard credential keys listed below —
+the SDK already strips them on the way out.
+
+Caller-supplied custom fields are **not** covered. Anything you stuff into
+`params` under a non-standard key (e.g. `mySecretField`) reaches the logger
+verbatim. See [What the SDK does not redact](#what-the-sdk-does-not-redact).
+
+## What the SDK redacts automatically
+
+The single source of truth is
+[`packages/jssdk/src/core/http/redact.ts`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/redact.ts).
+
+```ts
+// packages/jssdk/src/core/http/redact.ts:23-30
+export const SENSITIVE_PARAM_KEYS: readonly string[] = [
+  'auth',
+  'password',
+  'token',
+  'secret',
+  'access_token',
+  'refresh_token'
+]
+```
+
+Wherever any of these keys appears, the value is replaced with
+`'***REDACTED***'` (the exported `REDACTED_PLACEHOLDER`) before the
+payload is serialised for logging or stored on an error object.
+
+The walk descends **two levels** into nested objects and arrays. That
+covers the batch shape `{ cmd: [{ method, params: { ...creds... } }, ...] }`
+where the credential lives at `cmd[i].params.<key>`, plus flat one-level
+shapes like `{ data: { token } }`. Anything deeper than that is **not**
+walked — keep secrets close to the top of the payload if you want them
+caught, or redact at the callsite.
+
+### Callsites that consume the redactor
+
+| Where | Log channel | Level | Source |
+| --- | --- | --- | --- |
+| `post/send` (request being dispatched) | logger context `params` | `info` | [`abstract-http.ts:487`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts) |
+| `post/catchError` (axios error) | logger context `responseData` | `info` | [`abstract-http.ts:458`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts) |
+| `http request starting` (`_logRequest`) | logger context `params` | `debug` | [`abstract-http.ts:624`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts) |
+| `AjaxError` constructor | `requestInfo.params` (visible via `toJSON()` / `toString()`) | n/a | [`ajax-error.ts:44`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-error.ts) |
+
+The redaction is **level-independent** — it runs on the data before it
+is handed to the logger, so it applies whether your handler is filtering
+at `DEBUG`, `INFO`, `ERROR`, or anything else.
+
+## Webhook URL is no longer logged
+
+The full webhook URL (`https://<portal>/rest/<userId>/<secret>/<method>.json`)
+used to enter the `post/send` info log. Since v1.1.2 only the bare REST
+method name (e.g. `user.current`, `crm.item.add`) is logged; the
+`post/response` and `post/catchError` callsites have always been URL-free
+and stay that way. `AjaxQuery` (the `requestInfo` shape carried by
+`AjaxError`) no longer types a `url` field at all — see
+[`ajax-result.ts:12-16`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-result.ts) —
+so a future change cannot accidentally re-introduce the leak through
+error rendering.
+
+If you wired a custom logger on **any** 1.1.x release before 1.1.2, audit
+historical log sinks (stdout, files, third-party aggregators) for entries
+matching `/rest/{userId}/{secret}/` and rotate the corresponding webhook
+secrets. A dedicated migration guide is planned (tracking issue
+[#53](https://github.com/bitrix24/b24jssdk/issues/53) — _Migration guide
+to be added._)
+
+## AjaxError — `toJSON` / `toString`
+
+`AjaxError` accepts a `requestInfo` containing the caller-supplied
+`params`. The constructor passes those `params` through the same
+redactor, so the credential keys above never survive on the error
+object — neither in `toJSON()` output, nor in the stringified form, nor
+in any log line that subsequently includes the error.
+
+```ts
+// What you get out of AjaxError.toJSON().requestInfo.params,
+// no matter what the caller passed in:
+{
+  ID: 42,
+  access_token: '***REDACTED***',
+  auth: '***REDACTED***'
+}
+```
+
+## What the SDK does not redact
+
+The SDK only knows about the six canonical keys. It will not strip:
+
+- **Custom payload fields you invented** — e.g. `mySecretField`,
+  `apiKeyHeader`, `x_internal_token`, anything whose key is not in
+  [`SENSITIVE_PARAM_KEYS`](#what-the-sdk-redacts-automatically).
+- **Credentials embedded inside string values** — e.g. a URL stuffed
+  into a `description` field that happens to contain a token in its
+  query string.
+- **Data more than two levels deep** — anything past `cmd[i].params.<key>`
+  depth is walked past, not into.
+- **Response bodies from the portal**, beyond what
+  `post/catchError` already runs through the redactor. The portal does
+  not currently embed credentials in error responses, but if your
+  integration round-trips secrets through a custom endpoint, that data
+  flows through verbatim on the success path.
+
+Stripping these is **caller responsibility**. Either don't put secrets
+into non-standard keys to begin with, or redact in your custom logger's
+handler / processor.
+
+## Recommended pattern: wiring a custom logger
+
+The safe pattern is to leave the SDK's redaction in place and bolt your
+custom sink on top — never replace the SDK-side scrubbing with a
+homegrown one downstream of it.
+
+```ts
+import {
+  B24Hook,
+  Logger,
+  ConsoleV2Handler,
+  LogLevel
+} from '@bitrix24/b24jssdk'
+
+const b24 = new B24Hook({ /* … */ })
+
+const $logger = new Logger('app')
+$logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO))
+
+// Optional belt-and-braces processor: redact any *custom* keys the SDK
+// does not know about. Standard keys (auth / token / …) are already
+// scrubbed before they reach this point.
+$logger.pushProcessor((record) => {
+  if (record.context?.params && typeof record.context.params === 'string') {
+    record.context.params = record.context.params.replace(
+      /"mySecretField":"[^"]*"/g,
+      '"mySecretField":"***REDACTED***"'
+    )
+  }
+  return record
+})
+
+b24.setLogger($logger)
+```
+
+What to **avoid**:
+
+```ts
+// DON'T — turning the logger output back into a structured object and
+// re-emitting it without re-running the redactor risks reintroducing
+// custom-field leaks that the SDK never claimed to handle.
+b24.setLogger({
+  async info(message, context) {
+    await sendToRemoteAggregator({
+      msg: message,
+      // `context.params` is already a redacted *string* on `post/send`,
+      // but if your code path passes a raw `params` object from
+      // elsewhere (e.g. you also log inside a custom action wrapper),
+      // forward it without inspection.
+      ctx: context
+    })
+  },
+  // …
+} as any)
+```
+
+Two concrete failure modes to guard against:
+
+1. **Logging the original request object yourself.** If your wrapper
+   captures `params` before calling into the SDK and logs it, the SDK's
+   redactor never runs on that copy. Always redact in your own log path
+   too.
+2. **Stringifying `AjaxError` in a non-handler surface.** The error's
+   `requestInfo.params` is already scrubbed, so `String(err)` and
+   `JSON.stringify(err)` are safe — but if you reach into
+   `err.cause`/`err.originalError` and log _those_, you may be looking
+   at a pre-redaction object.
+
+## Advanced: reading the source
+
+For details beyond what is summarised here, the canonical references are:
+
+- [`packages/jssdk/src/core/http/redact.ts`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/redact.ts)
+  — the key list, placeholder, and walk depth.
+- [`packages/jssdk/src/core/http/abstract-http.ts`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/abstract-http.ts)
+  — every callsite that pipes data through the redactor.
+- [`packages/jssdk/src/core/http/ajax-error.ts`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-error.ts)
+  — error-construction redaction and the `requestInfo` shape.
+
+See also the [Logger page](/docs/working-with-the-rest-api/logger/) for
+the logging framework itself (channels, handlers, processors,
+formatters) and the [Errors page](/docs/working-with-the-rest-api/errors/)
+for `AjaxError` semantics.

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -2,7 +2,7 @@
 title: Logging & Credential Redaction
 description: 'What the SDK redacts automatically before any request information enters the logger or an AjaxError, what it does not redact, and how to wire a custom logger via setLogger(...) without re-introducing credential leaks.'
 category: 'logging'
-audited: 2026-05-27
+audited: 2026-05-28
 navigation.title: Logging & Redaction
 links:
   - label: redact.ts (canonical key list)

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -34,6 +34,7 @@ const pages = [
   '/docs/working-with-the-rest-api/logger/',
   '/docs/working-with-the-rest-api/logger-telegram/',
   '/docs/working-with-the-rest-api/limiters/',
+  '/docs/working-with-the-rest-api/logging/',
   '/docs/working-with-the-rest-api/frame/',
   '/docs/working-with-the-rest-api/frame-auth/',
   '/docs/working-with-the-rest-api/frame-dialog/',


### PR DESCRIPTION
## Summary

- New page `docs/content/docs/2.working-with-the-rest-api/78.logging.md` covers what the SDK automatically redacts from log context and `AjaxError`, what it does **not** redact (caller responsibility), the recommended `setLogger(...)` pattern, and the fact that the full webhook URL is no longer logged in `post/send`.
- Sourced verbatim from the SDK (no guesses): canonical key list comes from `packages/jssdk/src/core/http/redact.ts:23-30`, callsite table cites `abstract-http.ts:458 / :487 / :624` and `ajax-error.ts:44`, and the gone-for-good `requestInfo.url` is confirmed by `ajax-result.ts:12-16` (`AjaxQuery` has only `method / params / requestId`).
- Original behaviour change is PR #39 (v1.1.2). The CHANGELOG mentions it; the docs site did not. This page fills that gap.
- Adds the new page to `docs/nuxt.config.ts` so it appears in `/llms-full.txt`.
- Second commit bumps the audit stamp on `1.getting-started/7.ai/2.llms-txt.md` (2026-05-05 → 2026-05-27) so `docs:lint-pages --strict` stops warning; the prior stamp had become stale relative to `docs/nuxt.config.ts` after the PR #36 LLMs route additions, and the page body still accurately describes the `/llms.txt` / `/llms-full.txt` routes.

## Closes

Closes #52

## Test plan

Acceptance criteria from #52:

- [x] User wiring `B24Hook.setLogger(...)` can find — by browsing the docs site — exactly which keys are redacted by the SDK and which they must redact themselves. See `## What the SDK redacts automatically` and `## What the SDK does not redact` on the new page.
- [x] Webhook URL not being logged in `post/send` is mentioned. See `## Webhook URL is no longer logged`.
- [x] Cross-link to #53 (secret-rotation migration guidance) so the two pieces compose. Linked as a GitHub issue (with a `(to be added)` note) rather than a `/docs/...` link to avoid `docs:lint-links` failing on a target that does not yet exist; an in-page TODO comment marks the future swap.

Lint / type gate (all green locally on the head of this branch):

- [x] `pnpm run lint:fix` — clean.
- [x] `pnpm run typecheck` — clean across `package-jssdk`, `package-jssdk-nuxt`, `docs`, `playground-nuxt`, `playground-cli`.
- [x] `pnpm run docs:lint-pages:strict` — `0 error(s), 0 warning(s)` (the pre-existing strict warning on `2.llms-txt.md` is what the second commit clears).
- [x] `pnpm run docs:lint-links` — `0 broken link(s), 0 warning(s)`.

## Decision

**Where the page lives:** new `docs/content/docs/2.working-with-the-rest-api/78.logging.md`, next to `77.limiters.md`.

Why not in `77.limiters.md` (the alternative suggested in #52): rate-limiting and credential-redaction are independent concerns. Folding security guidance into the limiters page would dilute both surfaces.

Why not under the existing `66.logger.md`: that page documents the **Logger library** (channels, handlers, processors, formatters). Credential redaction is an **HTTP-layer** guarantee that happens before data ever reaches a logger handler. Putting it under `66.logger.md` would imply the logger is doing the scrubbing, which is misleading and would point readers at the wrong source files when they want to verify the contract. A dedicated logging-and-redaction page keeps the source-of-truth pointer firmly in `core/http/`.



---
_Generated by [Claude Code](https://claude.ai/code/session_01X86XMGSLG9UiLCaoLKHby4)_