### PR TITLE
docs(migration): v1.1.2 security migration guidance

### DIFF
--- a/docs/content/docs/1.getting-started/1.index.md
+++ b/docs/content/docs/1.getting-started/1.index.md
@@ -12,6 +12,10 @@ links:
 We are still updating this page. Some data may be missing here — we will complete it shortly.
 ::
 
+::note
+Used a custom logger on v1.1.0 or v1.1.1? See [Migration: v1.1.2 security](/docs/getting-started/migration/v1-1-2-security/) for credential-rotation steps.
+::
+
 ## Overview
 
 The SDK for working with Bitrix24 REST API provides a unified interface for interacting with the Bitrix24 API from JavaScript/TypeScript applications. This page will help you quickly get started with the library.

--- a/docs/content/docs/1.getting-started/3.migration/2.v1-1-2-security.md
+++ b/docs/content/docs/1.getting-started/3.migration/2.v1-1-2-security.md
@@ -1,0 +1,100 @@
+---
+title: Migration to v1.1.2 (Security)
+description: 'Credential-rotation guide for users on >= 1.1.0, < 1.1.2: what leaked into logs, how to find it, and how to rotate affected webhook secrets and OAuth tokens.'
+navigation.title: v1.1.x security
+audited: 2026-05-28
+links:
+  - label: v1.1.2 release notes
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/releases/tag/v1.1.2
+  - label: CHANGELOG.md
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/CHANGELOG.md
+---
+
+**Affects versions: >= 1.1.0, < 1.1.2**
+
+## What happened
+
+Between v1.1.0 and v1.1.1 (inclusive), the HTTP layer logged the full
+webhook URL — including the secret segment — and serialised OAuth/Frame
+access tokens into an `auth` key that appeared verbatim in log context.
+Any application that wired a custom logger via `B24Hook.setLogger(...)`,
+`B24Frame.setLogger(...)`, or `B24OAuth.setLogger(...)` on those versions
+may have written live credentials into log sinks readable by server
+admins, ops teams, CI runners, and any third-party log aggregator
+(Datadog, Logtail, Splunk, etc.) receiving that process output.
+
+A webhook URL takes the form `/rest/{userId}/{secret}/`, where `{secret}`
+gives its holder full API access to your Bitrix24 portal with the
+permissions granted to that webhook. An OAuth or Frame token in
+`"auth":"..."` in a serialised params blob is equivalent: anyone who
+captures it can make REST calls as the authenticated user until the token
+expires or is revoked.
+
+v1.1.2 fixes both leaks. **You still need to rotate any credentials that
+were present in your logs before you upgraded.**
+
+## Finding exposed credentials in your logs
+
+Search your log archives — stdout captures, log files, aggregator
+indices — for these two patterns.
+
+**Webhook URL** — grep / ripgrep:
+
+```bash
+grep -rE '/rest/[0-9]+/[a-z0-9]+/' /var/log/myapp/
+rg '/rest/\d+/[a-z0-9]+/' /var/log/myapp/
+```
+
+**OAuth / Frame auth token in serialised params** — grep / ripgrep:
+
+```bash
+grep -rE '"auth":"[^"]+"' /var/log/myapp/
+rg '"auth":"[^"]+"' /var/log/myapp/
+```
+
+Replace `/var/log/myapp/` with the actual path(s) for your setup.
+
+**Typical sinks to check:**
+
+- stdout/stderr from your server process (Docker logs, systemd journal, PM2 logs)
+- Application log files (`/var/log/`, `logs/`, any path you configured for `StreamHandler`)
+- CI build logs (GitHub Actions, GitLab CI — run output may be retained for days)
+- Third-party aggregators: Datadog, Logtail, Splunk, Papertrail, Seq, etc.
+
+## Migration steps
+
+1. **Update to v1.1.2.** The security fixes are only available in this
+   release and later.
+
+2. **Locate all historical log sinks.** Check every destination listed
+   above: on-disk log files, remote aggregator indices, CI build
+   artefacts.
+
+3. **Run the patterns above** against each sink. A match means credentials
+   from that sink are compromised.
+
+4. **Rotate affected credentials immediately if any match is found.**
+   - **Webhook secret:** go to Bitrix24 → Settings → Developers →
+     Webhooks, delete the exposed webhook and create a new one with a
+     fresh secret.
+   - **OAuth / Frame access token:** revoke the access token. If a
+     refresh token was also captured in your logs (under a `refresh_token`
+     key), revoke that as well.
+
+5. **Keep downstream redaction shims in place** if you have them (for
+   example `templates-mcp`'s `logger-redactor`). They remain useful as
+   defence in depth even after upgrading.
+
+## After upgrading
+
+v1.1.2 redacts the standard credential keys (`auth`, `password`, `token`,
+`secret`, `access_token`, `refresh_token`) before any data reaches your
+logger, and no longer logs the full webhook URL in `post/send` at all.
+See [Logging & Credential Redaction](/docs/working-with-the-rest-api/logging/)
+for the full list of what the SDK now protects automatically and what
+remains caller responsibility.
+
+The [v1.1.2 release on GitHub](https://github.com/bitrix24/b24jssdk/releases/tag/v1.1.2)
+is the authoritative source for this change.

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -16,14 +16,6 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-error.ts
 ---
 
-<!--
-  TODO: when issue #53 (secret-rotation migration guide for v1.1.2) ships,
-  replace the "Migration guide (to be added)" note below with a real
-  /docs/... link. Tracking: https://github.com/bitrix24/b24jssdk/issues/53.
-  Do not add the /docs/... link before the page exists — docs:lint-links
-  will fail on a missing target.
--->
-
 ## Overview
 
 Since v1.1.2 the HTTP layer redacts a fixed set of credential-bearing keys
@@ -109,9 +101,8 @@ If you wired a custom logger on any release in the range
 third-party aggregators) **now** for entries matching
 `/rest/{userId}/{secret}/` (webhook auth) or `"auth":"<token>"` (OAuth /
 Frame) and rotate the corresponding credentials — don't wait for the
-companion migration guide. A dedicated step-by-step is tracked in
-[#53](https://github.com/bitrix24/b24jssdk/issues/53) (_to be added_),
-but the rotation itself is independent of that page.
+companion migration guide. See [Migration: v1.1.2 security](/docs/getting-started/migration/v1-1-2-security/)
+for a step-by-step credential-rotation guide.
 
 ## AjaxError — `toJSON` / `toString`
 

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -13,6 +13,7 @@ const pages = [
   '/docs/getting-started/installation/nodejs/',
   '/docs/getting-started/installation/umd/',
   '/docs/getting-started/migration/v1/',
+  '/docs/getting-started/migration/v1-1-2-security/',
   '/docs/getting-started/ai/llms-txt/',
   // endregion ////
   // region examples ////


### PR DESCRIPTION
## Summary

- New migration page for users on 1.1.0/1.1.1: `docs/content/docs/1.getting-started/3.migration/2.v1-1-2-security.md`
- Explicit affected version range (`>= 1.1.0, < 1.1.2`) stated on the first line
- Plain-English threat model: webhook URL secret and OAuth/Frame `auth` token in serialised params; what an attacker can do with either
- grep / ripgrep patterns for auditing log archives
- Numbered migration steps (upgrade → locate sinks → grep → rotate → keep shims)

## Closes

Closes #53

## Test plan (AC from #53)

- [x] Affected version range stated as explicit string (`>= 1.1.0, < 1.1.2`) — first line of page body
- [x] Threat model in plain English (not just regex patterns) — "What happened" section
- [x] Cross-link to v1.1.2 release on GitHub — frontmatter `links:` + "After upgrading" section
- [x] Cross-link from `getting-started/index.md` — `::note` callout added after warning block
- [x] Cross-link to logging page from #52 (`78.logging.md`) — "After upgrading" links to `/docs/working-with-the-rest-api/logging/`; `78.logging.md` TODO comment replaced with real link
- [x] `pnpm run docs:lint-pages` — `0 error(s), 0 warning(s)`
- [x] `pnpm run docs:lint-links` — `0 broken link(s), 0 warning(s)`
- [x] `pnpm run lint:fix` — clean
- [x] `pnpm run typecheck` — clean (exit 0)

## Related

- Logically paired page: #52 (logging redaction guidance, `78.logging.md`)