### PR TITLE
test(some-code-from-docs): compile-check canonical contributing snippets

### DIFF
--- a/.github/contributing/package-structure.md
+++ b/.github/contributing/package-structure.md
@@ -91,6 +91,8 @@ export class MyManager {
 }
 ```
 
+> Compile-checked example: [`test/some-code-from-docs/contributing/package-structure-manager.ts`](../../test/some-code-from-docs/contributing/package-structure-manager.ts)
+
 For transport-layer actions (under `src/core/actions/v2/` and `v3/`) extend `AbstractAction` (`packages/jssdk/src/core/actions/abstract-action.ts`) instead — see [packages/jssdk/src/core/actions/v3/call.ts](../../packages/jssdk/src/core/actions/v3/call.ts) for the canonical example.
 
 ## Adding to the Public Surface

--- a/.github/contributing/transports-and-results.md
+++ b/.github/contributing/transports-and-results.md
@@ -64,7 +64,7 @@ import { ApiVersion } from '@bitrix24/b24jssdk'
 
 const result = await b24.actions.v2.call.make({
   method: 'crm.deal.list',
-  params: { filter: {}, select: ['ID', 'TITLE'] },
+  params: { filter: {}, select: ['ID', 'TITLE'] }, // filter: {} — replace with any valid filter object
   requestId: 'app/crm.deal.list'
 })
 
@@ -108,7 +108,8 @@ const result = await b24.actions.v3.call.make({
 })
 const [err] = result.getErrors()
 if (err instanceof AjaxError) {
-  // err.code (string), err.status (number), err.message (string)
+  // AjaxError exposes .code (string), .status (number), .message (string).
+  // Note: getCode(), getStatus(), getDescription() do not exist on AjaxError.
 }
 ```
 

--- a/.github/contributing/transports-and-results.md
+++ b/.github/contributing/transports-and-results.md
@@ -62,9 +62,9 @@ const user = result.getData().result
 ```ts
 import { ApiVersion } from '@bitrix24/b24jssdk'
 
-const result = await b24.actions.v2.callList.make({
+const result = await b24.actions.v2.call.make({
   method: 'crm.deal.list',
-  params: { filter, select: ['ID', 'TITLE'] },
+  params: { filter: {}, select: ['ID', 'TITLE'] },
   requestId: 'app/crm.deal.list'
 })
 
@@ -72,6 +72,8 @@ if (result.isMore()) {
   const next = await result.getNext(b24.getHttpClient(ApiVersion.v2)) // continues the cursor
 }
 ```
+
+> Compile-checked example: [`test/some-code-from-docs/contributing/transports-and-results-paging.ts`](../../test/some-code-from-docs/contributing/transports-and-results-paging.ts)
 
 - Pass the http client (from `b24.getHttpClient(version)`) to `getNext()` — it preserves the same limiter stack.
 - Do **not** loop with raw `start` parameters; use `isMore()` + `getNext()`.
@@ -106,9 +108,11 @@ const result = await b24.actions.v3.call.make({
 })
 const [err] = result.getErrors()
 if (err instanceof AjaxError) {
-  // err.getCode(), err.getStatus(), err.getDescription()
+  // err.code (string), err.status (number), err.message (string)
 }
 ```
+
+> Compile-checked example: [`test/some-code-from-docs/contributing/transports-and-results-error-handling.ts`](../../test/some-code-from-docs/contributing/transports-and-results-error-handling.ts)
 
 Rules:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ pnpm run docs:dev         # start docs dev server
 | `docs:typecheck-blocks` | Type-check ` ```ts ` code fences in docs/content/docs/**/*.md |
 | `docs:typecheck` | Nuxt's own type-check for the docs Nuxt app |
 | `docs:generate` | Generate the static docs site (`docs/.output/public/`) |
+| `contributing:typecheck` | Type-check canonical TS snippets in test/some-code-from-docs/contributing/ |
 | `typecheck` | Runs all of the above plus SDK / playground type-checks |
 
 ## Documentation upkeep
@@ -85,3 +86,26 @@ const pages = [
 ```
 
 The URL slug is the filename with the numeric sort-prefix stripped: `99.examples/3.my-new-page.md` → `/docs/examples/my-new-page/`.
+
+### 5. Contributing guide snippet type-checking (`contributing:typecheck`)
+
+Canonical TS snippets extracted from `.github/contributing/` guides live as real `.ts` files under `test/some-code-from-docs/contributing/`. They are type-checked by `pnpm run contributing:typecheck` (tsc against `test/some-code-from-docs/contributing/tsconfig.json`) and run by vitest under the `jsSdk:contributing-snippets` project. Both gates are wired into `pnpm run typecheck`. Introduced in v1.1.3 to prevent agent-facing guide drift (see issue #49).
+
+**Currently wired snippets:**
+
+| File | Guide section |
+|---|---|
+| `package-structure-manager.ts` | `.github/contributing/package-structure.md` § Standard Module Template |
+| `transports-and-results-paging.ts` | `.github/contributing/transports-and-results.md` § Result Type (v2 paging) |
+| `transports-and-results-error-handling.ts` | `.github/contributing/transports-and-results.md` § Error Types |
+
+**Rule for new contributing guide snippets:** If you add a new canonical TS pattern to a `.github/contributing/*.md` page, either:
+- Extract it to a new `.ts` file in `test/some-code-from-docs/contributing/` and add a companion `// Compile-checked example:` footnote in the guide, OR
+- Mark it with a `<!-- @contributing-check-ignore: <reason> -->` comment if it's intentionally incomplete.
+
+**Prerequisites for local runs:**
+```bash
+pnpm install
+pnpm run dev:prepare   # must run first to build jssdk types
+pnpm run contributing:typecheck
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ pnpm run docs:dev         # start docs dev server
 | `docs:typecheck` | Nuxt's own type-check for the docs Nuxt app |
 | `docs:generate` | Generate the static docs site (`docs/.output/public/`) |
 | `contributing:typecheck` | Type-check canonical TS snippets in test/some-code-from-docs/contributing/ |
+| `package-jssdk:test-contributing-snippets` | Run contributing-snippet vitest project in isolation |
 | `typecheck` | Runs all of the above plus SDK / playground type-checks |
 
 ## Documentation upkeep
@@ -89,7 +90,16 @@ The URL slug is the filename with the numeric sort-prefix stripped: `99.examples
 
 ### 5. Contributing guide snippet type-checking (`contributing:typecheck`)
 
-Canonical TS snippets extracted from `.github/contributing/` guides live as real `.ts` files under `test/some-code-from-docs/contributing/`. They are type-checked by `pnpm run contributing:typecheck` (tsc against `test/some-code-from-docs/contributing/tsconfig.json`) and run by vitest under the `jsSdk:contributing-snippets` project. Both gates are wired into `pnpm run typecheck`. Introduced in v1.1.3 to prevent agent-facing guide drift (see issue #49).
+Canonical TS snippets extracted from `.github/contributing/` guides live as real `.ts` files under `test/some-code-from-docs/contributing/`. Two complementary gates exist:
+
+- **tsc gate** (`pnpm run contributing:typecheck`): runs `tsc --noEmit` against `test/some-code-from-docs/contributing/tsconfig.json`. This is the **authoritative type check** and is wired into `pnpm run typecheck` (CI).
+- **vitest gate** (`pnpm run package-jssdk:test-contributing-snippets`, project `jsSdk:contributing-snippets`): loads each fixture via esbuild to confirm the module imports without throwing at runtime. **esbuild does not type-check** — it only transpiles. This gate runs via `package-jssdk:test:run` (local tests), not via `typecheck`.
+
+Introduced in v1.1.3 to prevent agent-facing guide drift (see issue #49).
+
+**Import note:** fixture files import from `@bitrix24/b24jssdk` (the workspace package, resolving to `dist/esm/index.d.ts`), not from relative paths into `packages/jssdk/src/`. Importing from source triggers false-positive TS errors (TS2612, TS2578, TS2591) from SDK-internal implementation details that are not part of the public API. The guide snippets may show relative imports for illustrative purposes — this divergence is intentional.
+
+**tsconfig note:** `*.spec.ts` files are excluded from `test/some-code-from-docs/contributing/tsconfig.json` because the spec files use vitest globals (`describe`, `it`, `expect`) that are not declared in that tsconfig. The vitest project has its own environment that provides those globals at runtime.
 
 **Currently wired snippets:**
 
@@ -100,7 +110,7 @@ Canonical TS snippets extracted from `.github/contributing/` guides live as real
 | `transports-and-results-error-handling.ts` | `.github/contributing/transports-and-results.md` § Error Types |
 
 **Rule for new contributing guide snippets:** If you add a new canonical TS pattern to a `.github/contributing/*.md` page, either:
-- Extract it to a new `.ts` file in `test/some-code-from-docs/contributing/` and add a companion `// Compile-checked example:` footnote in the guide, OR
+- Extract it to a new `.ts` file in `test/some-code-from-docs/contributing/` and add a companion `> Compile-checked example:` footnote in the guide, OR
 - Mark it with a `<!-- @contributing-check-ignore: <reason> -->` comment if it's intentionally incomplete.
 
 **Prerequisites for local runs:**

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "skills:typecheck": "tsc -p .claude/skills/b24jssdk-recipes/tsconfig.json",
     "package-jssdk:test:run-unit": "vitest run --project jsSdk:unit",
     "package-jssdk:test": "vitest --project jsSdk:integration",
-    "package-jssdk:test:run": "vitest run --project jsSdk:integration",
+    "package-jssdk:test:run": "vitest run --project jsSdk:integration --project jsSdk:contributing-snippets",
+    "package-jssdk:test-contributing-snippets": "vitest run --project jsSdk:contributing-snippets",
+    "contributing:typecheck": "tsc --noEmit -p test/some-code-from-docs/contributing/tsconfig.json",
     "package-jssdk:test-integration-js-docs": "vitest -t \"js-docs\" --project jsSdk:integration",
     "package-jssdk:test-integration-core": "vitest -t \"core\" --project jsSdk:integration",
     "package-jssdk:test:run-underLoad-v3-call": "vitest run -t \"tasksTaskGet @apiV3\" --project jsSdk:underLoad",
@@ -63,7 +65,7 @@
     "docs:lint-pages:strict": "node scripts/docs-lint.mjs --strict",
     "docs:lint-links": "node scripts/docs-link-check.mjs",
     "docs:lint:test": "node --test \"scripts/__tests__/**/*.test.mjs\"",
-    "typecheck": "pnpm run package-jssdk:typecheck && pnpm run package-jssdk-nuxt:typecheck && pnpm run docs:typecheck && pnpm run playground-nuxt:typecheck && pnpm run playground-cli:typecheck && pnpm run docs:typecheck-blocks && pnpm run skills:typecheck",
+    "typecheck": "pnpm run package-jssdk:typecheck && pnpm run package-jssdk-nuxt:typecheck && pnpm run docs:typecheck && pnpm run playground-nuxt:typecheck && pnpm run playground-cli:typecheck && pnpm run docs:typecheck-blocks && pnpm run skills:typecheck && pnpm run contributing:typecheck",
     "release:bump": "node scripts/bump-version.mjs"
   },
   "devDependencies": {

--- a/scripts/__tests__/docs-typecheck.test.mjs
+++ b/scripts/__tests__/docs-typecheck.test.mjs
@@ -19,13 +19,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..', '..')
 const TYPECHECK_SCRIPT = resolve(__dirname, '..', 'docs-typecheck.mjs')
 
-// Integration tests spawn docs-typecheck.mjs which requires `pnpm install`
-// (TypeScript) and `pnpm run dev:prepare` (SDK dist types). Skip gracefully
-// when running in environments that only install Node (e.g. docs-lint CI job).
+// Integration tests spawn docs-typecheck.mjs, which needs both tsc (from
+// node_modules) and the built SDK types (dist/). The docs-lint CI job runs
+// this file but intentionally skips pnpm install / dev:prepare because all
+// other tests here are pure-Node unit tests. Skip integration tests gracefully
+// when prereqs are absent; docs-typecheck coverage in CI comes from the `ci`
+// job's `pnpm run typecheck` → `docs:typecheck-blocks` step.
 const TSC_BIN = join(REPO_ROOT, 'node_modules', 'typescript', 'bin', 'tsc')
 const SDK_TYPES = join(REPO_ROOT, 'packages', 'jssdk', 'dist', 'esm', 'index.d.ts')
 const INTEGRATION_SKIP = !existsSync(TSC_BIN) || !existsSync(SDK_TYPES)
-  ? 'requires pnpm install + pnpm run dev:prepare'
+  ? 'requires pnpm install && pnpm run dev:prepare'
   : false
 
 // Import extractTsBlocks directly for unit testing.
@@ -234,19 +237,6 @@ test('escapeAnnotation: newlines and % are escaped for GitHub Actions', () => {
 })
 
 // ── Integration tests (require pnpm run dev:prepare) ─────────────────────
-//
-// The docs-lint CI job runs this file but intentionally skips pnpm install /
-// dev:prepare because all other tests here are pure-Node unit tests. These
-// integration tests spawn docs-typecheck.mjs, which needs both tsc (from
-// node_modules) and the built SDK types (dist/). Skip them gracefully when
-// those prereqs are absent; the actual docs-typecheck coverage in CI comes
-// from the `ci` job's `pnpm run typecheck` → `docs:typecheck-blocks` step.
-
-const _tscBin = join(REPO_ROOT, 'node_modules', 'typescript', 'bin', 'tsc')
-const _sdkTypes = join(REPO_ROOT, 'packages', 'jssdk', 'dist', 'esm', 'index.d.ts')
-const SKIP_INTEGRATION = existsSync(_tscBin) && existsSync(_sdkTypes)
-  ? false
-  : 'requires pnpm install && pnpm run dev:prepare'
 
 function runTypecheckScript(env = {}) {
   return spawnSync(process.execPath, [TYPECHECK_SCRIPT], {

--- a/scripts/__tests__/docs-typecheck.test.mjs
+++ b/scripts/__tests__/docs-typecheck.test.mjs
@@ -234,6 +234,19 @@ test('escapeAnnotation: newlines and % are escaped for GitHub Actions', () => {
 })
 
 // ── Integration tests (require pnpm run dev:prepare) ─────────────────────
+//
+// The docs-lint CI job runs this file but intentionally skips pnpm install /
+// dev:prepare because all other tests here are pure-Node unit tests. These
+// integration tests spawn docs-typecheck.mjs, which needs both tsc (from
+// node_modules) and the built SDK types (dist/). Skip them gracefully when
+// those prereqs are absent; the actual docs-typecheck coverage in CI comes
+// from the `ci` job's `pnpm run typecheck` → `docs:typecheck-blocks` step.
+
+const _tscBin = join(REPO_ROOT, 'node_modules', 'typescript', 'bin', 'tsc')
+const _sdkTypes = join(REPO_ROOT, 'packages', 'jssdk', 'dist', 'esm', 'index.d.ts')
+const SKIP_INTEGRATION = existsSync(_tscBin) && existsSync(_sdkTypes)
+  ? false
+  : 'requires pnpm install && pnpm run dev:prepare'
 
 function runTypecheckScript(env = {}) {
   return spawnSync(process.execPath, [TYPECHECK_SCRIPT], {

--- a/test/some-code-from-docs/contributing/package-structure-manager.spec.ts
+++ b/test/some-code-from-docs/contributing/package-structure-manager.spec.ts
@@ -1,8 +1,9 @@
-import { describe, it } from 'vitest'
-import './package-structure-manager'
+// vitest transpiles via esbuild — no type-checking. The authoritative type gate is `contributing:typecheck`.
+import { describe, expect, it } from 'vitest'
+import { MyManager } from './package-structure-manager'
 
 describe('contributing/package-structure-manager', () => {
-  it('compiles', () => {
-    // type-check fixture only — no runtime behaviour to assert
+  it('module loads without throwing', () => {
+    expect(typeof MyManager).toBe('function')
   })
 })

--- a/test/some-code-from-docs/contributing/package-structure-manager.spec.ts
+++ b/test/some-code-from-docs/contributing/package-structure-manager.spec.ts
@@ -1,0 +1,8 @@
+import { describe, it } from 'vitest'
+import './package-structure-manager'
+
+describe('contributing/package-structure-manager', () => {
+  it('compiles', () => {
+    // type-check fixture only — no runtime behaviour to assert
+  })
+})

--- a/test/some-code-from-docs/contributing/package-structure-manager.ts
+++ b/test/some-code-from-docs/contributing/package-structure-manager.ts
@@ -6,7 +6,7 @@
  * Prerequisite: pnpm run dev:prepare (builds dist/ and its type declarations).
  */
 
-import type { LoggerInterface, TypeB24 } from '@bitrix24/b24jssdk'
+import type { AjaxResult, LoggerInterface, TypeB24 } from '@bitrix24/b24jssdk'
 import { LoggerFactory, SdkError } from '@bitrix24/b24jssdk'
 
 export class MyManager {
@@ -26,7 +26,7 @@ export class MyManager {
     return this._logger
   }
 
-  async fetch(id: number) {
+  async fetch(id: number): Promise<AjaxResult<{ item: { id: number } }>> {
     if (id <= 0) {
       throw new SdkError({
         code: 'MY_MANAGER_BAD_ID',

--- a/test/some-code-from-docs/contributing/package-structure-manager.ts
+++ b/test/some-code-from-docs/contributing/package-structure-manager.ts
@@ -1,0 +1,44 @@
+/**
+ * Canonical compile-checked example for the "Standard Module Template" from
+ * .github/contributing/package-structure.md (§ Standard Module Template).
+ *
+ * If this file stops compiling, the contributing guide is out of sync with the SDK.
+ * Prerequisite: pnpm run dev:prepare (builds dist/ and its type declarations).
+ */
+
+import type { LoggerInterface, TypeB24 } from '@bitrix24/b24jssdk'
+import { LoggerFactory, SdkError } from '@bitrix24/b24jssdk'
+
+export class MyManager {
+  protected _b24: TypeB24
+  protected _logger: LoggerInterface
+
+  constructor(b24: TypeB24) {
+    this._b24 = b24
+    this._logger = LoggerFactory.createNullLogger()
+  }
+
+  setLogger(logger: LoggerInterface): void {
+    this._logger = logger
+  }
+
+  getLogger(): LoggerInterface {
+    return this._logger
+  }
+
+  async fetch(id: number) {
+    if (id <= 0) {
+      throw new SdkError({
+        code: 'MY_MANAGER_BAD_ID',
+        description: 'MyManager.fetch: id must be positive',
+        status: 400
+      })
+    }
+
+    return this._b24.actions.v3.call.make<{ item: { id: number } }>({
+      method: 'my.entity.get',
+      params: { id },
+      requestId: 'my-manager/fetch'
+    })
+  }
+}

--- a/test/some-code-from-docs/contributing/transports-and-results-error-handling.spec.ts
+++ b/test/some-code-from-docs/contributing/transports-and-results-error-handling.spec.ts
@@ -1,8 +1,9 @@
-import { describe, it } from 'vitest'
-import './transports-and-results-error-handling'
+// vitest transpiles via esbuild — no type-checking. The authoritative type gate is `contributing:typecheck`.
+import { describe, expect, it } from 'vitest'
+import { callAndHandleResult } from './transports-and-results-error-handling'
 
 describe('contributing/transports-and-results-error-handling', () => {
-  it('compiles', () => {
-    // type-check fixture only — no runtime behaviour to assert
+  it('module loads without throwing', () => {
+    expect(typeof callAndHandleResult).toBe('function')
   })
 })

--- a/test/some-code-from-docs/contributing/transports-and-results-error-handling.spec.ts
+++ b/test/some-code-from-docs/contributing/transports-and-results-error-handling.spec.ts
@@ -1,0 +1,8 @@
+import { describe, it } from 'vitest'
+import './transports-and-results-error-handling'
+
+describe('contributing/transports-and-results-error-handling', () => {
+  it('compiles', () => {
+    // type-check fixture only — no runtime behaviour to assert
+  })
+})

--- a/test/some-code-from-docs/contributing/transports-and-results-error-handling.spec.ts
+++ b/test/some-code-from-docs/contributing/transports-and-results-error-handling.spec.ts
@@ -1,9 +1,15 @@
 // vitest transpiles via esbuild — no type-checking. The authoritative type gate is `contributing:typecheck`.
 import { describe, expect, it } from 'vitest'
-import { callAndHandleResult } from './transports-and-results-error-handling'
+import {
+  assertHookUrl,
+  callAndHandleResult,
+  callAndInspectAjaxError
+} from './transports-and-results-error-handling'
 
 describe('contributing/transports-and-results-error-handling', () => {
   it('module loads without throwing', () => {
     expect(typeof callAndHandleResult).toBe('function')
+    expect(typeof callAndInspectAjaxError).toBe('function')
+    expect(typeof assertHookUrl).toBe('function')
   })
 })

--- a/test/some-code-from-docs/contributing/transports-and-results-error-handling.ts
+++ b/test/some-code-from-docs/contributing/transports-and-results-error-handling.ts
@@ -1,0 +1,57 @@
+/**
+ * Canonical compile-checked example for Result handling and error inspection from
+ * .github/contributing/transports-and-results.md (§ Result Type, § Error Types).
+ *
+ * Covers:
+ *  - v3 call + isSuccess guard + getData()
+ *  - SdkError thrown for invariant violations (constructor takes SdkErrorDetails, not a string)
+ *  - AjaxError surfaced via Result.getErrors() — access via .code / .status / .message
+ *
+ * If this file stops compiling, the contributing guide is out of sync with the SDK.
+ * Prerequisite: pnpm run dev:prepare (builds dist/ and its type declarations).
+ */
+
+import type { TypeB24 } from '@bitrix24/b24jssdk'
+import { AjaxError, SdkError } from '@bitrix24/b24jssdk'
+
+export async function callAndHandleResult(b24: TypeB24) {
+  const result = await b24.actions.v3.call.make({
+    method: 'user.get',
+    params: { ID: 1 },
+    requestId: 'app/user.get'
+  })
+
+  if (!result.isSuccess) {
+    // result.getErrorMessages() returns string[]; result.getErrors() returns IterableIterator<Error>
+    void result.getErrorMessages()
+    void result.getErrors()
+    return
+  }
+
+  void result.getData()
+}
+
+export async function callAndInspectAjaxError(b24: TypeB24) {
+  const payload = { fields: { TITLE: 'New Lead' } }
+  const result = await b24.actions.v3.call.make({
+    method: 'crm.lead.add',
+    params: payload,
+    requestId: 'app/crm.lead.add'
+  })
+  const [err] = result.getErrors()
+  if (err instanceof AjaxError) {
+    // AjaxError properties: .code (string), .status (number), .message (string)
+    void err.code
+    void err.status
+    void err.message
+  }
+}
+
+export function sdkErrorExample(): never {
+  // SdkError constructor takes a SdkErrorDetails object, not a plain string.
+  throw new SdkError({
+    code: 'B24_HOOK_URL_REQUIRED',
+    description: 'B24Hook.fromWebhookUrl: url is required',
+    status: 400
+  })
+}

--- a/test/some-code-from-docs/contributing/transports-and-results-error-handling.ts
+++ b/test/some-code-from-docs/contributing/transports-and-results-error-handling.ts
@@ -22,13 +22,16 @@ export async function callAndHandleResult(b24: TypeB24) {
   })
 
   if (!result.isSuccess) {
-    // result.getErrorMessages() returns string[]; result.getErrors() returns IterableIterator<Error>
-    void result.getErrorMessages()
-    void result.getErrors()
+    // getErrorMessages() returns string[]; getErrors() returns IterableIterator<Error>
+    const messages: string[] = result.getErrorMessages()
+    const errors: IterableIterator<Error> = result.getErrors()
+    void messages
+    void errors
     return
   }
 
-  void result.getData()
+  const data = result.getData()
+  void data
 }
 
 export async function callAndInspectAjaxError(b24: TypeB24) {
@@ -41,17 +44,23 @@ export async function callAndInspectAjaxError(b24: TypeB24) {
   const [err] = result.getErrors()
   if (err instanceof AjaxError) {
     // AjaxError properties: .code (string), .status (number), .message (string)
-    void err.code
-    void err.status
-    void err.message
+    const code: string = err.code
+    const status: number = err.status
+    const message: string = err.message
+    void code
+    void status
+    void message
   }
 }
 
-export function sdkErrorExample(): never {
-  // SdkError constructor takes a SdkErrorDetails object, not a plain string.
-  throw new SdkError({
-    code: 'B24_HOOK_URL_REQUIRED',
-    description: 'B24Hook.fromWebhookUrl: url is required',
-    status: 400
-  })
+// SdkError constructor takes a SdkErrorDetails object — not a plain string.
+// Realistic usage: a guard function that throws on invalid input.
+export function assertHookUrl(url: string | undefined): asserts url is string {
+  if (!url) {
+    throw new SdkError({
+      code: 'B24_HOOK_URL_REQUIRED',
+      description: 'B24Hook.fromWebhookUrl: url is required',
+      status: 400
+    })
+  }
 }

--- a/test/some-code-from-docs/contributing/transports-and-results-paging.spec.ts
+++ b/test/some-code-from-docs/contributing/transports-and-results-paging.spec.ts
@@ -1,0 +1,8 @@
+import { describe, it } from 'vitest'
+import './transports-and-results-paging'
+
+describe('contributing/transports-and-results-paging', () => {
+  it('compiles', () => {
+    // type-check fixture only — no runtime behaviour to assert
+  })
+})

--- a/test/some-code-from-docs/contributing/transports-and-results-paging.spec.ts
+++ b/test/some-code-from-docs/contributing/transports-and-results-paging.spec.ts
@@ -1,8 +1,9 @@
-import { describe, it } from 'vitest'
-import './transports-and-results-paging'
+// vitest transpiles via esbuild — no type-checking. The authoritative type gate is `contributing:typecheck`.
+import { describe, expect, it } from 'vitest'
+import { pagingV2Example } from './transports-and-results-paging'
 
 describe('contributing/transports-and-results-paging', () => {
-  it('compiles', () => {
-    // type-check fixture only — no runtime behaviour to assert
+  it('module loads without throwing', () => {
+    expect(typeof pagingV2Example).toBe('function')
   })
 })

--- a/test/some-code-from-docs/contributing/transports-and-results-paging.ts
+++ b/test/some-code-from-docs/contributing/transports-and-results-paging.ts
@@ -1,0 +1,31 @@
+/**
+ * Canonical compile-checked example for v2 cursor-based paging from
+ * .github/contributing/transports-and-results.md (§ Result Type).
+ *
+ * v2 paging: result.isMore() + result.getNext(b24.getHttpClient(ApiVersion.v2)).
+ * AjaxResult (returned by b24.actions.v2.call.make) has isMore() and getNext().
+ *
+ * v3 does NOT support getNext() — calling it throws at runtime:
+ *   "restApi:v3 not support method getNext"
+ * Use b24.actions.v3.callList.make() / fetchList.make() for v3 list iteration instead.
+ *
+ * If this file stops compiling, the contributing guide is out of sync with the SDK.
+ * Prerequisite: pnpm run dev:prepare (builds dist/ and its type declarations).
+ */
+
+import type { TypeB24 } from '@bitrix24/b24jssdk'
+import { ApiVersion } from '@bitrix24/b24jssdk'
+
+export async function pagingV2Example(b24: TypeB24) {
+  const result = await b24.actions.v2.call.make({
+    method: 'crm.deal.list',
+    params: { filter: {}, select: ['ID', 'TITLE'] },
+    requestId: 'app/crm.deal.list'
+  })
+
+  if (result.isMore()) {
+    // Pass the v2 http client so the same limiter stack is preserved on the next page.
+    const next = await result.getNext(b24.getHttpClient(ApiVersion.v2))
+    void next
+  }
+}

--- a/test/some-code-from-docs/contributing/transports-and-results-paging.ts
+++ b/test/some-code-from-docs/contributing/transports-and-results-paging.ts
@@ -5,6 +5,9 @@
  * v2 paging: result.isMore() + result.getNext(b24.getHttpClient(ApiVersion.v2)).
  * AjaxResult (returned by b24.actions.v2.call.make) has isMore() and getNext().
  *
+ * NOTE: isMore() and getNext() are @deprecated and will be removed in v2.0.0.
+ * For new code prefer b24.actions.v3.callList.make() or fetchList.make().
+ *
  * v3 does NOT support getNext() — calling it throws at runtime:
  *   "restApi:v3 not support method getNext"
  * Use b24.actions.v3.callList.make() / fetchList.make() for v3 list iteration instead.
@@ -23,6 +26,7 @@ export async function pagingV2Example(b24: TypeB24) {
     requestId: 'app/crm.deal.list'
   })
 
+  // isMore() and getNext() are @deprecated — removed in v2.0.0. Shown here for guide coverage only.
   if (result.isMore()) {
     // Pass the v2 http client so the same limiter stack is preserved on the next page.
     const next = await result.getNext(b24.getHttpClient(ApiVersion.v2))

--- a/test/some-code-from-docs/contributing/tsconfig.json
+++ b/test/some-code-from-docs/contributing/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleDetection": "force",
 
     "allowJs": false,
-    "isolatedModules": false
+    "isolatedModules": true
   },
   "include": ["./**/*.ts"],
   "exclude": ["./**/*.spec.ts"]

--- a/test/some-code-from-docs/contributing/tsconfig.json
+++ b/test/some-code-from-docs/contributing/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM"],
+
+    "strict": false,
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "noEmit": true,
+
+    "moduleDetection": "force",
+
+    "allowJs": false,
+    "isolatedModules": false
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.spec.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,6 +34,14 @@ export default defineConfig({
       {
         extends: true,
         test: {
+          name: 'jsSdk:contributing-snippets',
+          environment: 'node',
+          include: ['./test/some-code-from-docs/contributing/**/*.spec.ts']
+        }
+      },
+      {
+        extends: true,
+        test: {
           name: 'jsSdk:underLoad',
           environment: 'node',
           maxConcurrency: 10,


### PR DESCRIPTION
## Summary

- New test infrastructure `test/some-code-from-docs/contributing/` that compile-checks 3 canonical TS snippets from `.github/contributing/` guides against the live `@bitrix24/b24jssdk` types.
- Wired into both `pnpm run package-jssdk:test:run` (vitest) and `pnpm run typecheck` (tsc), so a future SDK rename or type change produces a compile error instead of silent guide drift.

## Approach

**Approach (c) — canonical snippets as real `.ts` files** (per issue #49 scope).

The contributing guides contain ~12 TS snippets total. Issue #49 explicitly scopes to the 2 highest-value ones (3 files):

| Fixture | Guide section |
|---|---|
| `package-structure-manager.ts` | `package-structure.md` § Standard Module Template |
| `transports-and-results-paging.ts` | `transports-and-results.md` § Result Type (v2 paging) |
| `transports-and-results-error-handling.ts` | `transports-and-results.md` § Error Types |

**Vitest wiring:** New project `jsSdk:contributing-snippets` (no `setupFiles`, no `B24_HOOK` required). `package-jssdk:test:run` extended to include it. A separate `contributing:typecheck` script runs `tsc --noEmit` for real type-checking, and is wired into the root `typecheck` chain.

**Why `@bitrix24/b24jssdk` imports (not `../../../packages/jssdk/src/`):** importing from the source path causes tsc to transitively check all SDK internals under the contributing tsconfig's settings, producing false positives (unused `@ts-expect-error` directives, missing node types) unrelated to our snippets. The workspace package import resolves to `dist/esm/index.d.ts` via the `exports.types` field — same types, no false positives. Requires `pnpm run dev:prepare` before `contributing:typecheck`.

## Files restructured in contributing/

No prose changed. Two bug fixes uncovered by the new gate (docs were previously un-gated):

### Fix 1 — paging example used wrong action (`transports-and-results.md`)

`callList.make()` returns `Result<T[]>` which has no `isMore()` / `getNext()`. The `isMore()` + `getNext()` pattern requires `AjaxResult`, returned by `call.make()`. Corrected:

```diff
- const result = await b24.actions.v2.callList.make({
+ const result = await b24.actions.v2.call.make({
-   params: { filter, select: ['ID', 'TITLE'] },
+   params: { filter: {}, select: ['ID', 'TITLE'] },
```

### Fix 2 — `AjaxError` method references didn't exist (`transports-and-results.md`)

`err.getCode()`, `err.getStatus()`, `err.getDescription()` do not exist on `AjaxError`. Corrected to `.code`, `.status`, `.message` (properties/getter inherited from `SdkError`).

Both guide pages received a one-line `> Compile-checked example: [...]` footnote linking to the fixture. Gate documented in `CLAUDE.md`.

## Smoke test (ШАГ 5)

Deliberately set `code: 12345` (number) in `package-structure-manager.ts`:

```
test/some-code-from-docs/contributing/package-structure-manager.ts(32,9):
  error TS2322: Type 'number' is not assignable to type 'string'.
```

File:line:col reported correctly. Restored and confirmed green.

## Closes

Closes #49

## Test plan (AC from #49)

- [x] CI fails on a deliberately-broken canonical snippet (smoke test above)
- [x] Existing canonical snippets pass (`pnpm run contributing:typecheck` → exit 0)
- [x] `pnpm run package-jssdk:test:run` picks up the new project (3 spec files, 3 tests pass)
- [x] Documented in `CLAUDE.md` (new § 4, rule for future contributing snippets)
- [x] All other lint/typecheck green: `lint`, `package-jssdk:typecheck`, `docs:typecheck-blocks`, `docs:lint-pages`, `docs:lint-links`

## Out of scope

- README-AI.md (deprecated, #55)
- `docs/content/docs/**` (under #50)
- `.claude/skills/**` recipes (under `skills:typecheck`)
- Remaining ~9 contributing snippets (further follow-ups)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWy9vapPNnVSmHkuPxg6T1)_