### PR TITLE
ci: parallelize lint, typecheck, build, and docs-build jobs

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -14,7 +14,7 @@ Project skills for the `@bitrix24/b24jssdk` workspace. Source of truth:
 | **b24jssdk-filtering** | Two filter dialects — v2 prefix-keyed objects (`'>=createdTime'`) and v3 array-of-triples (`[['fld', '>=', v]]`). NOT, IN, dates via `Text.toB24Format`, the `order`-stripping rule of `callList`. |
 | **b24jssdk-frame-ui** | UI managers available only inside Bitrix24 iframe: slider, dialog (`selectUser/Users/CRM/Access`), parent, placement (with `setValue`), options, auth. |
 | **b24jssdk-helpers** | `useB24Helper`, `B24HelperManager`, Pull client, currency formatting, app/user options. |
-| **b24jssdk-recipes** | Nine end-to-end mini-apps (CRM analytics, ERP sync, Telegram bot, mass mailing, task automation, AI assistant, web search + LLM, Disk files, webhook handler) — built on `actions.v{2,3}.*`. |
+| **b24jssdk-recipes** | Twelve end-to-end mini-apps (CRM analytics, ERP sync, Telegram bot, mass mailing, task automation, AI assistant, web search + LLM, Disk files, webhook handler, error-handling, event registration, OAuth install) — built on `actions.v{2,3}.*`. |
 | **b24jssdk-vibecode** | How to use the SDK alongside the VibeCode HTTP API. Mostly: don't — keep them apart. The "AI add-on" pattern is the only sane mix. |
 
 ## Top-level docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,3 +261,19 @@ jobs:
 
       - name: Build docs
         run: pnpm run docs:generate
+
+  # Gate job: satisfies the "ci" required status check in branch protection.
+  # Fails if any upstream job failed or was cancelled.
+  ci:
+    needs: [docs-lint, lint, typecheck, test, build, docs-build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    steps:
+      - name: All checks passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more CI jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All CI jobs passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
             packages/jssdk-nuxt/.nuxt
             docs/.nuxt
             playgrounds/nuxt/.nuxt
+          include-hidden-files: true
           retention-days: 1
 
   lint:
@@ -197,11 +198,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Download prepared workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: prepared-workspace
+
       - name: Build (jssdk)
         run: pnpm --filter ./packages/jssdk build
 
       - name: Build (jssdk-nuxt)
-        # jssdk must be built first so @bitrix24/b24jssdk resolves correctly
+        # Requires packages/jssdk-nuxt/.nuxt/tsconfig.json (from artifact) to resolve
+        # tsconfig "extends". jssdk must be built first so @bitrix24/b24jssdk resolves.
         run: pnpm --filter ./packages/jssdk-nuxt build
 
   # Verifies that the documentation site generates cleanly on every PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,20 +197,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Download prepared workspace
-        uses: actions/download-artifact@v4
-        with:
-          name: prepared-workspace
-
       - name: Build (jssdk)
         run: pnpm --filter ./packages/jssdk build
 
       - name: Build (jssdk-nuxt)
+        # jssdk must be built first so @bitrix24/b24jssdk resolves correctly
         run: pnpm --filter ./packages/jssdk-nuxt build
 
   # Verifies that the documentation site generates cleanly on every PR.
   # Previously this only ran in deploy.yml (push to main), so broken doc
   # builds could slip through undetected.
+  # Note: docs app does not import from @bitrix24/b24jssdk at runtime, so
+  # the prepared-workspace artifact is not needed here.
   docs-build:
     needs: prepare
     runs-on: ubuntu-latest
@@ -236,11 +234,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Download prepared workspace
-        uses: actions/download-artifact@v4
-        with:
-          name: prepared-workspace
 
       - name: Build docs
         run: pnpm run docs:generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Docs lint runs in its own job with full history because docs:lint-pages
   # reads `git log -1 -- <source>` and needs each linked source file's real
@@ -20,6 +23,7 @@ jobs:
   # from `build` so the rest of CI can stay on a shallow checkout.
   docs-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -46,6 +50,7 @@ jobs:
   # without repeating the prepare step.
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       NUXT_PUBLIC_USE_AI: false
       NUXT_PUBLIC_USE_TAB_B24FRAME: false
@@ -88,6 +93,7 @@ jobs:
   lint:
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -115,6 +121,7 @@ jobs:
   typecheck:
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       NUXT_PUBLIC_USE_AI: false
       NUXT_PUBLIC_USE_TAB_B24FRAME: false
@@ -148,10 +155,10 @@ jobs:
         # against @bitrix24/b24jssdk. Runs after dev:prepare so dist/ types are available.
         run: pnpm run typecheck
 
-
   test:
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -174,6 +181,8 @@ jobs:
           name: prepared-workspace
 
       - name: Unit tests (no portal required)
+        # Integration and load tests require B24_HOOK — run locally or in a
+        # dedicated environment with secrets. See .github/contributing/testing.md.
         run: pnpm run package-jssdk:test:run-unit
 
       - name: Security audit
@@ -182,6 +191,7 @@ jobs:
   build:
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -220,6 +230,7 @@ jobs:
   docs-build:
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       NUXT_PUBLIC_USE_AI: false
       NUXT_PUBLIC_USE_TAB_B24FRAME: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,9 @@ jobs:
   # Verifies that the documentation site generates cleanly on every PR.
   # Previously this only ran in deploy.yml (push to main), so broken doc
   # builds could slip through undetected.
-  # Note: docs app does not import from @bitrix24/b24jssdk at runtime, so
-  # the prepared-workspace artifact is not needed here.
+  # Note: prepared-workspace is needed here because Vite (via nuxt generate)
+  # crawls workspace packages including jssdk-nuxt/src/runtime/plugin.ts,
+  # which resolves tsconfig "extends" from packages/jssdk-nuxt/.nuxt/.
   docs-build:
     needs: prepare
     runs-on: ubuntu-latest
@@ -241,6 +242,11 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Download prepared workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: prepared-workspace
 
       - name: Build docs
         run: pnpm run docs:generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,11 @@ jobs:
       - name: Test docs-lint scripts
         run: node --test "scripts/__tests__/**/*.test.mjs"
 
-  ci:
+  # Installs dependencies and runs dev:prepare once; the generated outputs
+  # (packages/jssdk/dist, .nuxt type dirs) are uploaded as an artifact so
+  # the parallel lint / typecheck / build / docs-build jobs can restore them
+  # without repeating the prepare step.
+  prepare:
     runs-on: ubuntu-latest
     env:
       NUXT_PUBLIC_USE_AI: false
@@ -68,13 +72,105 @@ jobs:
       - name: Prepare
         run: pnpm run dev:prepare
 
+      - name: Upload prepared workspace
+        uses: actions/upload-artifact@v4
+        with:
+          name: prepared-workspace
+          path: |
+            packages/jssdk/dist
+            packages/jssdk-nuxt/dist
+            packages/jssdk-nuxt/.nuxt
+            docs/.nuxt
+            playgrounds/nuxt/.nuxt
+          retention-days: 1
+
+  lint:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Install node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download prepared workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: prepared-workspace
+
       - name: Lint
         run: pnpm run lint
+
+  typecheck:
+    needs: prepare
+    runs-on: ubuntu-latest
+    env:
+      NUXT_PUBLIC_USE_AI: false
+      NUXT_PUBLIC_USE_TAB_B24FRAME: false
+      NUXT_PUBLIC_SITE_URL: https://bitrix24.github.io
+      NUXT_PUBLIC_BASE_URL: /b24jssdk
+      NUXT_PUBLIC_CANONICAL_URL: https://bitrix24.github.io
+      NUXT_PUBLIC_GIT_URL: https://github.com/bitrix24/b24jssdk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Install node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download prepared workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: prepared-workspace
 
       - name: Typecheck
         # Includes docs:typecheck-blocks — type-checks ```ts fences in docs/content/docs/**/*.md
         # against @bitrix24/b24jssdk. Runs after dev:prepare so dist/ types are available.
         run: pnpm run typecheck
+
+
+  test:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Install node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download prepared workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: prepared-workspace
 
       - name: Unit tests (no portal required)
         run: pnpm run package-jssdk:test:run-unit
@@ -82,8 +178,69 @@ jobs:
       - name: Security audit
         run: pnpm audit --prod --audit-level=high
 
+  build:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Install node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download prepared workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: prepared-workspace
+
       - name: Build (jssdk)
         run: pnpm --filter ./packages/jssdk build
 
       - name: Build (jssdk-nuxt)
         run: pnpm --filter ./packages/jssdk-nuxt build
+
+  # Verifies that the documentation site generates cleanly on every PR.
+  # Previously this only ran in deploy.yml (push to main), so broken doc
+  # builds could slip through undetected.
+  docs-build:
+    needs: prepare
+    runs-on: ubuntu-latest
+    env:
+      NUXT_PUBLIC_USE_AI: false
+      NUXT_PUBLIC_USE_TAB_B24FRAME: false
+      NUXT_PUBLIC_SITE_URL: https://bitrix24.github.io
+      NUXT_PUBLIC_BASE_URL: /b24jssdk
+      NUXT_PUBLIC_CANONICAL_URL: https://bitrix24.github.io
+      NUXT_PUBLIC_GIT_URL: https://github.com/bitrix24/b24jssdk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Install node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download prepared workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: prepared-workspace
+
+      - name: Build docs
+        run: pnpm run docs:generate


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Introduce a `prepare` job that installs dependencies and runs `dev:prepare` once, uploading `dist/` and `.nuxt/` directories as a short-lived artifact (retention: 1 day).
- Four jobs now run in **parallel** after `prepare`: `lint`, `typecheck`, `build`, and the new `docs-build`. Each job restores the pnpm store from cache and downloads the prepared artifact instead of re-running `dev:prepare`.
- `docs-build` (`docs:generate`) is **new** — previously it only ran in `deploy.yml` on push to `main`, so a broken docs build could slip through on PRs undetected.

## Expected impact

| Before | After |
|---|---|
| Sequential: prepare → lint → typecheck → build (~12 min) | Parallel: prepare (~4-5 min) + longest of lint/typecheck/build/docs-build (~3-4 min) ≈ **~7-8 min** |

## Test plan

- [ ] Verify all five jobs appear in the Actions run graph and the parallel ones start simultaneously after `prepare` completes.
- [ ] Confirm `lint`, `typecheck`, and `build` pass with the downloaded artifact (no need to re-run `dev:prepare`).
- [ ] Confirm new `docs-build` job completes `docs:generate` successfully.
- [ ] Verify `docs-lint` continues to run independently (full checkout, no pnpm).

Closes #89

https://claude.ai/code/session_01CQGL5vSegkeoV3qe6TCpBv
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQGL5vSegkeoV3qe6TCpBv)_