### PR TITLE
fix(docs): register 12 recipe pages in nuxt.config.ts prerender list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ pnpm run docs:dev         # start docs dev server
 | `docs:lint-links` | Check all internal `/docs/` links and fragment anchors |
 | `docs:typecheck-blocks` | Type-check ` ```ts ` code fences in docs/content/docs/**/*.md |
 | `docs:typecheck` | Nuxt's own type-check for the docs Nuxt app |
+| `docs:generate` | Generate the static docs site (`docs/.output/public/`) |
 | `typecheck` | Runs all of the above plus SDK / playground type-checks |
 
 ## Documentation upkeep
@@ -74,11 +75,11 @@ pnpm run docs:typecheck-blocks
 
 Every new docs page **must** also be added to the `pages` array in `docs/nuxt.config.ts`. Nitro uses this list to prerender the `/raw/docs/…<slug>.md` routes used for `Accept: text/markdown` content negotiation and `llms-full.txt` generation. Pages that exist as `.md` files but are absent from `pages` will be missing their raw routes, and `pnpm run docs:generate` will exit with code 1.
 
-```
+```ts
 // docs/nuxt.config.ts
 const pages = [
   ...
-  '/docs/examples/my-new-page/',   // ← add one line per new page
+  '/docs/examples/my-new-page/', // add one line per new page
   ...
 ]
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,18 @@ pnpm run docs:typecheck-blocks
 **Opt-out marker:** Add `// @check-ignore` (or `// @check-ignore: <short reason>`) on the line immediately before a ` ```ts ` fence to skip a block. Use sparingly — prefer fixing the example. Always include a reason when the cause is non-obvious (e.g. `// @check-ignore: top-level return`, `// @check-ignore: partial snippet`).
 
 **Adding new ambient globals:** If a new pattern appears on many pages (e.g. a new top-level helper), add a `declare const …` to `.docs-typecheck/globals.d.ts`. Keep it in sync with SDK public API — if a type is renamed or removed, update globals.d.ts accordingly.
+
+### 4. Registering new pages in the prerender list
+
+Every new docs page **must** also be added to the `pages` array in `docs/nuxt.config.ts`. Nitro uses this list to prerender the `/raw/docs/…<slug>.md` routes used for `Accept: text/markdown` content negotiation and `llms-full.txt` generation. Pages that exist as `.md` files but are absent from `pages` will be missing their raw routes, and `pnpm run docs:generate` will exit with code 1.
+
+```
+// docs/nuxt.config.ts
+const pages = [
+  ...
+  '/docs/examples/my-new-page/',   // ← add one line per new page
+  ...
+]
+```
+
+The URL slug is the filename with the numeric sort-prefix stripped: `99.examples/3.my-new-page.md` → `/docs/examples/my-new-page/`.

--- a/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
+++ b/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
@@ -1,7 +1,7 @@
 ---
 title: LLMs.txt
 description: 'How to get AI tools like Cursor, Windsurf, GitHub Copilot, ChatGPT, and Claude to understand Bitrix24 JS SDK methods, tools, and best practices.'
-audited: 2026-05-28
+audited: 2026-05-29
 links:
   - label: Nuxt config (nuxt-llms)
     iconName: GitHubIcon

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
@@ -2,7 +2,7 @@
 title: Placement Manager Class
 description: 'Used for managing the placement of widgets in the Bitrix24 application.'
 category: 'B24Frame'
-audited: 2026-05-28
+audited: 2026-05-29
 navigation.title: Placement
 links:
   - label: PlacementManager

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
@@ -92,15 +92,15 @@ async call(command: string, parameters?: Record<string, any>): Promise<any>
 Call the registered interface command.
 
 ```ts
-import { LoggerBrowser, LoggerType } from '@bitrix24/b24jssdk'
+import { LoggerFactory } from '@bitrix24/b24jssdk'
 // ... /////
-const logger = LoggerBrowser.build('Demo', true)
+const logger = LoggerFactory.createForBrowser('Demo', true)
 
 $b24 = await initializeB24Frame()
 // ... /////
 $b24.placement.call('reloadData')
   .then((respose: any) => {
-    logger.log('reload call')
+    logger.info('reload call')
   })
 ```
 

--- a/docs/content/docs/99.examples/0.index.md
+++ b/docs/content/docs/99.examples/0.index.md
@@ -1,7 +1,7 @@
 ---
 title: Examples
 description: 'Runnable cookbook recipes and a catalogue of SDK-native scripts that show how to combine the SDK into real apps.'
-audited: 2026-05-28
+audited: 2026-05-29
 navigation:
   title: Introduction
 links: []

--- a/docs/content/docs/99.examples/0.index.md
+++ b/docs/content/docs/99.examples/0.index.md
@@ -81,7 +81,7 @@ A broader set of end-to-end scripts on the canonical `$b24.actions.v{2,3}.*.make
 Every extended-catalogue recipe starts with the same loader:
 
 ```ts
-import { B24Hook, LoggerBrowser, type TypeB24 } from '@bitrix24/b24jssdk'
+import { B24Hook, Logger, ConsoleV2Handler, LogLevel, type TypeB24 } from '@bitrix24/b24jssdk'
 
 export function bootB24(): TypeB24 {
   const url = process.env.B24_HOOK
@@ -91,7 +91,8 @@ export function bootB24(): TypeB24 {
   return $b24
 }
 
-export const logger = LoggerBrowser.build('Recipe', process.env.NODE_ENV !== 'production')
+export const logger = Logger.create('Recipe')
+logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO, { useStyles: false }))
 ```
 
 Functions inside each recipe accept `$b24: TypeB24`, so the same code runs unchanged with `B24Frame` (in-iframe app) or `B24OAuth` (OAuth-installed app). Only the boot step changes.

--- a/docs/content/docs/99.examples/2.frame-app-skeleton.md
+++ b/docs/content/docs/99.examples/2.frame-app-skeleton.md
@@ -42,10 +42,10 @@ import { onBeforeUnmount, onMounted, ref } from 'vue'
 import {
   initializeB24Frame,
   type B24Frame,
-  LoggerBrowser
+  LoggerFactory
 } from '@bitrix24/b24jssdk'
 
-const logger = LoggerBrowser.build('AppShell', import.meta.env.DEV)
+const logger = LoggerFactory.createForBrowser('AppShell', import.meta.env.DEV)
 const ready = ref(false)
 const userTheme = ref<'light' | 'dark'>('light')
 const portalDomain = ref('')

--- a/docs/content/docs/99.examples/2.frame-app-skeleton.md
+++ b/docs/content/docs/99.examples/2.frame-app-skeleton.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Frame app skeleton'
 description: 'Minimum viable Bitrix24 iframe app: init handshake, set title, persist app state, open a slider, close cleanly.'
-audited: 2026-05-05
+audited: 2026-05-29
 category: 'examples'
 navigation:
   title: Frame app skeleton

--- a/docs/content/docs/99.examples/5.pull-subscribe-frame.md
+++ b/docs/content/docs/99.examples/5.pull-subscribe-frame.md
@@ -42,13 +42,13 @@ import { onBeforeUnmount, onMounted, ref } from 'vue'
 import {
   initializeB24Frame,
   LoadDataType,
-  LoggerBrowser,
+  LoggerFactory,
   useB24Helper,
   type B24Frame,
   type TypePullMessage
 } from '@bitrix24/b24jssdk'
 
-const logger = LoggerBrowser.build('PullPanel', import.meta.env.DEV)
+const logger = LoggerFactory.createForBrowser('PullPanel', import.meta.env.DEV)
 const events = ref<Array<{ at: string, command: string }>>([])
 let $b24: B24Frame | null = null
 

--- a/docs/content/docs/99.examples/5.pull-subscribe-frame.md
+++ b/docs/content/docs/99.examples/5.pull-subscribe-frame.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Subscribe to Pull events'
 description: 'Open a live channel from a Bitrix24 frame app and react to push events using useB24Helper + the Pull client.'
-audited: 2026-05-05
+audited: 2026-05-29
 category: 'examples'
 navigation:
   title: Pull subscribe

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -15,7 +15,7 @@ const pages = [
   '/docs/getting-started/migration/v1/',
   '/docs/getting-started/ai/llms-txt/',
   // endregion ////
-  // region examples ////
+  // region working-with-the-rest-api ////
   '/docs/working-with-the-rest-api/',
   '/docs/working-with-the-rest-api/call-rest-api-ver2/',
   '/docs/working-with-the-rest-api/call-rest-api-ver3/',

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -50,7 +50,19 @@ const pages = [
   '/docs/examples/frame-app-skeleton/',
   '/docs/examples/webhook-cli-node/',
   '/docs/examples/bulk-update-deals/',
-  '/docs/examples/pull-subscribe-frame/'
+  '/docs/examples/pull-subscribe-frame/',
+  '/docs/examples/crm-analytics/',
+  '/docs/examples/mass-messaging/',
+  '/docs/examples/task-automation/',
+  '/docs/examples/erp-sync/',
+  '/docs/examples/disk-files/',
+  '/docs/examples/telegram-bot/',
+  '/docs/examples/webhook-handler/',
+  '/docs/examples/ai-assistant/',
+  '/docs/examples/web-search-llm/',
+  '/docs/examples/error-handling/',
+  '/docs/examples/event-registration/',
+  '/docs/examples/oauth-install/'
   // endregion ////
 ]
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause:** `docs:generate` (Nuxt static build) exited with code 1 after PR #38 merged. The 12 new recipe pages were not registered in the `pages` array in `docs/nuxt.config.ts`. Nitro uses that list to prerender `/raw/docs/examples/<slug>.md` routes (served for `Accept: text/markdown` and included in `llms-full.txt`). Pages discovered only via `crawlLinks` do not get their raw routes prerendered, causing the build failure.
- Added all 12 routes (`/docs/examples/crm-analytics/` … `/docs/examples/oauth-install/`) to the `pages` array in `docs/nuxt.config.ts`.
- Updated the "Common boot snippet" in `docs/content/docs/99.examples/0.index.md` from the deprecated `LoggerBrowser.build()` to `Logger.create()` + `ConsoleV2Handler` (consistent with all 12 recipe `.ts` files).

## Test plan

- [ ] GitHub Actions **Deploy to Pages** — step **Generate Docs** passes green after merge
- [ ] `https://bitrix24.github.io/b24jssdk/docs/examples/crm-analytics/` loads correctly
- [ ] `https://bitrix24.github.io/b24jssdk/raw/docs/examples/crm-analytics.md` returns Markdown
- [ ] `/docs/examples/` index page shows `Logger.create()` in the boot snippet

https://claude.ai/code/session_016QWk3vjhi53bbNRw1PFLBa
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016QWk3vjhi53bbNRw1PFLBa)_