### PR TITLE
fix(docs): replace relative links with absolute paths in examples index

### DIFF
--- a/docs/content/docs/99.examples/0.index.md
+++ b/docs/content/docs/99.examples/0.index.md
@@ -19,7 +19,7 @@ Each cookbook recipe is a single, copy-paste-friendly file with environment vari
   ::card
   ---
   title: Webhook CLI smoke test
-  to: /docs/examples/webhook-cli-node/
+  to: /docs/examples/webhook-cli-node
   ---
   Verify a freshly created inbound webhook in 30 lines. Always start here.
   ::
@@ -27,7 +27,7 @@ Each cookbook recipe is a single, copy-paste-friendly file with environment vari
   ::card
   ---
   title: Export deals to CSV
-  to: /docs/examples/dashboard-deals-csv/
+  to: /docs/examples/dashboard-deals-csv
   ---
   Stream every deal in a date window into a CSV using `FetchListV2.make()`. Memory stays flat regardless of result size.
   ::
@@ -35,7 +35,7 @@ Each cookbook recipe is a single, copy-paste-friendly file with environment vari
   ::card
   ---
   title: Bulk update deals
-  to: /docs/examples/bulk-update-deals/
+  to: /docs/examples/bulk-update-deals
   ---
   Migrate thousands of deals to a new stage using `BatchByChunkV2.make()` with partial-error handling.
   ::
@@ -43,7 +43,7 @@ Each cookbook recipe is a single, copy-paste-friendly file with environment vari
   ::card
   ---
   title: Frame app skeleton
-  to: /docs/examples/frame-app-skeleton/
+  to: /docs/examples/frame-app-skeleton
   ---
   A minimum viable Vue 3 iframe app: handshake, parent title, persisted options, slider open/close.
   ::
@@ -51,7 +51,7 @@ Each cookbook recipe is a single, copy-paste-friendly file with environment vari
   ::card
   ---
   title: Subscribe to Pull events
-  to: /docs/examples/pull-subscribe-frame/
+  to: /docs/examples/pull-subscribe-frame
   ---
   Live events in a frame app via `useB24Helper` and the Pull client (WebSocket + long-polling).
   ::
@@ -63,18 +63,18 @@ A broader set of end-to-end scripts on the canonical `$b24.actions.v{2,3}.*.make
 
 | # | Page | Stack | Bitrix24 scopes |
 |---|---|---|---|
-| 1 | [CRM analytics — sales funnel](./crm-analytics) | Node | `crm` |
-| 2 | [Mass messaging](./mass-messaging) | Node | `crm`, `im` |
-| 3 | [Task automation on stage transitions](./task-automation) | Node | `crm`, `task` |
-| 4 | [ERP / 1C contact sync](./erp-sync) | Node, `node-cron` | `crm` |
-| 5 | [Disk: storages, folders, files](./disk-files) | Node | `disk` |
-| 6 | [Telegram bot for new deals](./telegram-bot) | Node, `grammy`, `node-cron` | `crm` |
-| 7 | [Outbound webhook handler](./webhook-handler) | Node, `express` | `crm` |
-| 8 | [AI assistant: analyse a deal, create a task](./ai-assistant) | Node, `openai` | `crm`, `task` |
-| 9 | [Web search + LLM with timeline write-back](./web-search-llm) | Node, BYOC | `crm` |
-| 10 | [Error-handling cookbook](./error-handling) | Node | any |
-| 11 | [Outbound event registration](./event-registration) | Node | `crm` |
-| 12 | [OAuth install handshake](./oauth-install) | Node, `express` | OAuth app |
+| 1 | [CRM analytics — sales funnel](/docs/examples/crm-analytics) | Node | `crm` |
+| 2 | [Mass messaging](/docs/examples/mass-messaging) | Node | `crm`, `im` |
+| 3 | [Task automation on stage transitions](/docs/examples/task-automation) | Node | `crm`, `task` |
+| 4 | [ERP / 1C contact sync](/docs/examples/erp-sync) | Node, `node-cron` | `crm` |
+| 5 | [Disk: storages, folders, files](/docs/examples/disk-files) | Node | `disk` |
+| 6 | [Telegram bot for new deals](/docs/examples/telegram-bot) | Node, `grammy`, `node-cron` | `crm` |
+| 7 | [Outbound webhook handler](/docs/examples/webhook-handler) | Node, `express` | `crm` |
+| 8 | [AI assistant: analyse a deal, create a task](/docs/examples/ai-assistant) | Node, `openai` | `crm`, `task` |
+| 9 | [Web search + LLM with timeline write-back](/docs/examples/web-search-llm) | Node, BYOC | `crm` |
+| 10 | [Error-handling cookbook](/docs/examples/error-handling) | Node | any |
+| 11 | [Outbound event registration](/docs/examples/event-registration) | Node | `crm` |
+| 12 | [OAuth install handshake](/docs/examples/oauth-install) | Node, `express` | OAuth app |
 
 ## Common boot snippet
 


### PR DESCRIPTION
## Problem

After PR #100 (`withoutTrailingSlash` fix), the examples index page is rendered at `/docs/examples` (no trailing slash). Relative links in the Extended catalogue table like `./crm-analytics` now resolve to `/docs/crm-analytics` instead of `/docs/examples/crm-analytics`, causing 12 prerender 404 errors:

```
├─ /b24jssdk/docs/crm-analytics [404] Linked from /b24jssdk/docs/examples
├─ /b24jssdk/docs/telegram-bot  [404] Linked from /b24jssdk/docs/examples
... (12 total)
```

## Fix

Replace all relative `./slug` links in the table with absolute `/docs/examples/slug` paths. Also update `::card` `to:` values (had trailing slash) for consistency.

## Changes

- `docs/content/docs/99.examples/0.index.md` — 12 table links + 5 card links updated

https://claude.ai/code/session_01SeopDqVuDyvaKffwui5bJ3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeopDqVuDyvaKffwui5bJ3)_