### PR TITLE
feat(docs): examples nav cleanup, top-nav entry, homepage cookbook sections

### DIFF
--- a/docs/app/composables/useHeader.ts
+++ b/docs/app/composables/useHeader.ts
@@ -6,6 +6,7 @@ import GitHubIcon from '@bitrix24/b24icons-vue/social/GitHubIcon'
 import BarcodeIcon from '@bitrix24/b24icons-vue/outline/BarcodeIcon'
 import EarthIcon from '@bitrix24/b24icons-vue/outline/EarthIcon'
 import TerminalIcon from '@bitrix24/b24icons-vue/file-type/TerminalIcon'
+import ItemIcon from '@bitrix24/b24icons-vue/crm/ItemIcon'
 import Bitrix24Icon from '@bitrix24/b24icons-vue/common-service/Bitrix24Icon'
 
 const _useHeader = () => {
@@ -31,13 +32,18 @@ const _useHeader = () => {
   const desktopLinks = computed<NavigationMenuItem[]>(() => [
     {
       label: 'Docs',
-      to: '/docs/getting-started/',
+      to: '/docs/getting-started',
       active: route.path.startsWith('/docs/getting-started')
     },
     {
       label: 'Working',
-      to: '/docs/working-with-the-rest-api/',
+      to: '/docs/working-with-the-rest-api',
       active: route.path.startsWith('/docs/working-with-the-rest-api')
+    },
+    {
+      label: 'Examples',
+      to: '/docs/examples',
+      active: route.path.startsWith('/docs/examples')
     },
     {
       label: 'Resources',
@@ -78,15 +84,21 @@ const _useHeader = () => {
   const mobileLinks = computed<NavigationMenuItem[]>(() => [
     {
       label: 'Get Started',
-      to: '/docs/getting-started/',
+      to: '/docs/getting-started',
       icon: PlayLIcon,
       active: route.path.startsWith('/docs/getting-started')
     },
     {
       label: 'Working',
-      to: '/docs/working-with-the-rest-api/',
+      to: '/docs/working-with-the-rest-api',
       icon: TerminalIcon,
       active: route.path.startsWith('/docs/working-with-the-rest-api')
+    },
+    {
+      label: 'Examples',
+      to: '/docs/examples',
+      icon: ItemIcon,
+      active: route.path.startsWith('/docs/examples')
     },
     {
       label: 'GitHub',

--- a/docs/app/composables/useHeader.ts
+++ b/docs/app/composables/useHeader.ts
@@ -43,7 +43,7 @@ const _useHeader = () => {
     {
       label: 'Examples',
       to: '/docs/examples',
-      active: route.path.startsWith('/docs/examples')
+      active: route.path === '/docs/examples' || route.path.startsWith('/docs/examples/')
     },
     {
       label: 'Resources',
@@ -98,7 +98,7 @@ const _useHeader = () => {
       label: 'Examples',
       to: '/docs/examples',
       icon: ItemIcon,
-      active: route.path.startsWith('/docs/examples')
+      active: route.path === '/docs/examples' || route.path.startsWith('/docs/examples/')
     },
     {
       label: 'GitHub',

--- a/docs/app/pages/index.vue
+++ b/docs/app/pages/index.vue
@@ -35,6 +35,29 @@ useSeoMeta({
   ogDescription: page.value.description
 })
 
+const cookbookCards = [
+  { title: 'Webhook CLI smoke test', to: '/docs/examples/webhook-cli-node', description: 'Verify a freshly created inbound webhook in 30 lines. Always start here.' },
+  { title: 'Export deals to CSV', to: '/docs/examples/dashboard-deals-csv', description: 'Stream every deal in a date window into a CSV using FetchListV2.make(). Memory stays flat regardless of result size.' },
+  { title: 'Bulk update deals', to: '/docs/examples/bulk-update-deals', description: 'Migrate thousands of deals to a new stage using BatchByChunkV2.make() with partial-error handling.' },
+  { title: 'Frame app skeleton', to: '/docs/examples/frame-app-skeleton', description: 'A minimum viable Vue 3 iframe app: handshake, parent title, persisted options, slider open/close.' },
+  { title: 'Subscribe to Pull events', to: '/docs/examples/pull-subscribe-frame', description: 'Live events in a frame app via useB24Helper and the Pull client (WebSocket + long-polling).' }
+]
+
+const catalogueRecipes = [
+  { index: 1, title: 'CRM analytics — sales funnel', to: '/docs/examples/crm-analytics', stack: 'Node', scopes: 'crm' },
+  { index: 2, title: 'Mass messaging', to: '/docs/examples/mass-messaging', stack: 'Node', scopes: 'crm, im' },
+  { index: 3, title: 'Task automation on stage transitions', to: '/docs/examples/task-automation', stack: 'Node', scopes: 'crm, task' },
+  { index: 4, title: 'ERP / 1C contact sync', to: '/docs/examples/erp-sync', stack: 'Node, node-cron', scopes: 'crm' },
+  { index: 5, title: 'Disk: storages, folders, files', to: '/docs/examples/disk-files', stack: 'Node', scopes: 'disk' },
+  { index: 6, title: 'Telegram bot for new deals', to: '/docs/examples/telegram-bot', stack: 'Node, grammy, node-cron', scopes: 'crm' },
+  { index: 7, title: 'Outbound webhook handler', to: '/docs/examples/webhook-handler', stack: 'Node, express', scopes: 'crm' },
+  { index: 8, title: 'AI assistant: analyse a deal, create a task', to: '/docs/examples/ai-assistant', stack: 'Node, openai', scopes: 'crm, task' },
+  { index: 9, title: 'Web search + LLM with timeline write-back', to: '/docs/examples/web-search-llm', stack: 'Node, BYOC', scopes: 'crm' },
+  { index: 10, title: 'Error-handling cookbook', to: '/docs/examples/error-handling', stack: 'Node', scopes: 'any' },
+  { index: 11, title: 'Outbound event registration', to: '/docs/examples/event-registration', stack: 'Node', scopes: 'crm' },
+  { index: 12, title: 'OAuth install handshake', to: '/docs/examples/oauth-install', stack: 'Node, express', scopes: 'OAuth app' }
+]
+
 const iconFromIconName = (iconName?: string) => {
   if (!iconName) {
     return undefined
@@ -74,6 +97,95 @@ const iconFromIconName = (iconName?: string) => {
       </div>
     </B24Container>
 
-    <B24PageSection :b24ui="{ container: 'py-10 sm:py-10 lg:py-10 gap-0 sm:gap-0' }" />
+    <B24PageSection :b24ui="{ container: 'py-10 sm:py-10 lg:py-10 gap-0 sm:gap-0' }">
+      <!-- Cookbook -->
+      <B24Container class="px-[22px] lg:px-8 pb-10">
+        <h2 class="text-2xl font-bold mb-2 text-label">
+          Cookbook
+        </h2>
+        <p class="text-muted mb-6">
+          Curated entry points — each recipe is a single, copy-paste-friendly file with environment variables, an expected output sketch, and a <code>Limitations</code> block.
+        </p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <NuxtLink
+            v-for="card in cookbookCards"
+            :key="card.to"
+            :to="card.to"
+            class="group block"
+          >
+            <B24Card
+              :b24ui="{
+                root: 'h-full transition-shadow hover:shadow-md cursor-pointer',
+                body: 'p-4'
+              }"
+            >
+              <p class="font-semibold text-label group-hover:text-primary mb-1">
+                {{ card.title }}
+              </p>
+              <p class="text-sm text-muted">
+                {{ card.description }}
+              </p>
+            </B24Card>
+          </NuxtLink>
+        </div>
+      </B24Container>
+
+      <!-- Extended catalogue -->
+      <B24Container class="px-[22px] lg:px-8 pb-16">
+        <h2 class="text-2xl font-bold mb-2 text-label">
+          Extended catalogue
+        </h2>
+        <p class="text-muted mb-6">
+          End-to-end TypeScript scripts — run with <code>tsx</code> after setting <code>B24_HOOK</code> to your incoming webhook URL.
+        </p>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm border-collapse">
+            <thead>
+              <tr class="border-b border-(--ui-border-color)">
+                <th class="text-left py-2 px-3 font-semibold text-muted w-8">
+                  #
+                </th>
+                <th class="text-left py-2 px-3 font-semibold text-muted">
+                  Recipe
+                </th>
+                <th class="text-left py-2 px-3 font-semibold text-muted hidden sm:table-cell">
+                  Stack
+                </th>
+                <th class="text-left py-2 px-3 font-semibold text-muted hidden md:table-cell">
+                  Scopes
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="recipe in catalogueRecipes"
+                :key="recipe.to"
+                class="border-b border-(--ui-border-color)/50 hover:bg-(--ui-color-accent-soft-element-violet)/30 transition-colors"
+              >
+                <td class="py-2 px-3 text-muted">
+                  {{ recipe.index }}
+                </td>
+                <td class="py-2 px-3">
+                  <NuxtLink :to="recipe.to" class="text-primary hover:underline font-medium">
+                    {{ recipe.title }}
+                  </NuxtLink>
+                </td>
+                <td class="py-2 px-3 text-muted hidden sm:table-cell">
+                  {{ recipe.stack }}
+                </td>
+                <td class="py-2 px-3 hidden md:table-cell">
+                  <code class="text-xs">{{ recipe.scopes }}</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="mt-4">
+          <NuxtLink to="/docs/examples" class="text-sm text-primary hover:underline">
+            View all examples →
+          </NuxtLink>
+        </div>
+      </B24Container>
+    </B24PageSection>
   </main>
 </template>

--- a/docs/app/pages/index.vue
+++ b/docs/app/pages/index.vue
@@ -44,18 +44,18 @@ const cookbookCards = [
 ]
 
 const catalogueRecipes = [
-  { index: 1, title: 'CRM analytics — sales funnel', to: '/docs/examples/crm-analytics', stack: 'Node', scopes: 'crm' },
-  { index: 2, title: 'Mass messaging', to: '/docs/examples/mass-messaging', stack: 'Node', scopes: 'crm, im' },
-  { index: 3, title: 'Task automation on stage transitions', to: '/docs/examples/task-automation', stack: 'Node', scopes: 'crm, task' },
-  { index: 4, title: 'ERP / 1C contact sync', to: '/docs/examples/erp-sync', stack: 'Node, node-cron', scopes: 'crm' },
-  { index: 5, title: 'Disk: storages, folders, files', to: '/docs/examples/disk-files', stack: 'Node', scopes: 'disk' },
-  { index: 6, title: 'Telegram bot for new deals', to: '/docs/examples/telegram-bot', stack: 'Node, grammy, node-cron', scopes: 'crm' },
-  { index: 7, title: 'Outbound webhook handler', to: '/docs/examples/webhook-handler', stack: 'Node, express', scopes: 'crm' },
-  { index: 8, title: 'AI assistant: analyse a deal, create a task', to: '/docs/examples/ai-assistant', stack: 'Node, openai', scopes: 'crm, task' },
-  { index: 9, title: 'Web search + LLM with timeline write-back', to: '/docs/examples/web-search-llm', stack: 'Node, BYOC', scopes: 'crm' },
-  { index: 10, title: 'Error-handling cookbook', to: '/docs/examples/error-handling', stack: 'Node', scopes: 'any' },
-  { index: 11, title: 'Outbound event registration', to: '/docs/examples/event-registration', stack: 'Node', scopes: 'crm' },
-  { index: 12, title: 'OAuth install handshake', to: '/docs/examples/oauth-install', stack: 'Node, express', scopes: 'OAuth app' }
+  { title: 'CRM analytics — sales funnel', to: '/docs/examples/crm-analytics', stack: 'Node', scopes: 'crm' },
+  { title: 'Mass messaging', to: '/docs/examples/mass-messaging', stack: 'Node', scopes: 'crm, im' },
+  { title: 'Task automation on stage transitions', to: '/docs/examples/task-automation', stack: 'Node', scopes: 'crm, task' },
+  { title: 'ERP / 1C contact sync', to: '/docs/examples/erp-sync', stack: 'Node, node-cron', scopes: 'crm' },
+  { title: 'Disk — storages, folders, files', to: '/docs/examples/disk-files', stack: 'Node', scopes: 'disk' },
+  { title: 'Telegram bot for new deals', to: '/docs/examples/telegram-bot', stack: 'Node, grammy, node-cron', scopes: 'crm' },
+  { title: 'Outbound webhook handler', to: '/docs/examples/webhook-handler', stack: 'Node, express', scopes: 'crm' },
+  { title: 'AI assistant — analyse a deal, create a task', to: '/docs/examples/ai-assistant', stack: 'Node, openai', scopes: 'crm, task' },
+  { title: 'Web search + LLM with timeline write-back', to: '/docs/examples/web-search-llm', stack: 'Node, BYOC', scopes: 'crm' },
+  { title: 'Error-handling cookbook', to: '/docs/examples/error-handling', stack: 'Node', scopes: 'any' },
+  { title: 'Outbound event registration', to: '/docs/examples/event-registration', stack: 'Node', scopes: 'crm' },
+  { title: 'OAuth install handshake', to: '/docs/examples/oauth-install', stack: 'Node, express', scopes: 'OAuth app' }
 ]
 
 const iconFromIconName = (iconName?: string) => {
@@ -158,12 +158,12 @@ const iconFromIconName = (iconName?: string) => {
             </thead>
             <tbody>
               <tr
-                v-for="recipe in catalogueRecipes"
+                v-for="(recipe, i) in catalogueRecipes"
                 :key="recipe.to"
                 class="border-b border-(--ui-border-color)/50 hover:bg-(--ui-color-accent-soft-element-violet)/30 transition-colors"
               >
                 <td class="py-2 px-3 text-muted">
-                  {{ recipe.index }}
+                  {{ i + 1 }}
                 </td>
                 <td class="py-2 px-3">
                   <NuxtLink :to="recipe.to" class="text-primary hover:underline font-medium">

--- a/docs/content/docs/99.examples/1.crm-analytics.md
+++ b/docs/content/docs/99.examples/1.crm-analytics.md
@@ -1,7 +1,8 @@
 ---
 title: CRM analytics — sales funnel
 description: 'Stream all deals via actions.v2.fetchList.make, group by stage, print a funnel report (counts, conversion %, avg ticket, win rate).'
-navigation.title: 1. CRM analytics
+navigation.title: CRM analytics
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/10.error-handling.md
+++ b/docs/content/docs/99.examples/10.error-handling.md
@@ -1,7 +1,8 @@
 ---
 title: Error-handling cookbook
 description: 'Demonstrates the four error layers (SdkError / AjaxError / network / soft) and the hardErrorCodes / softErrorCodes / retryOnNetworkError knobs on the restriction manager.'
-navigation.title: 10. Error handling
+navigation.title: Error handling
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/11.event-registration.md
+++ b/docs/content/docs/99.examples/11.event-registration.md
@@ -1,7 +1,8 @@
 ---
 title: Outbound event registration
 description: 'CLI tool — list, bind, and unbind Bitrix24 outbound webhook events via event.get / event.bind / event.unbind. Pairs with the webhook handler recipe.'
-navigation.title: 11. Event registration
+navigation.title: Event registration
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/12.oauth-install.md
+++ b/docs/content/docs/99.examples/12.oauth-install.md
@@ -1,7 +1,8 @@
 ---
 title: OAuth install handshake
 description: 'Express server that handles ONAPPINSTALL / ONAPPUPDATE / ONAPPUNINSTALL events for a Bitrix24 marketplace app, persists tokens per portal, and builds a B24OAuth client on demand with a refresh callback wired to storage.'
-navigation.title: 12. OAuth install
+navigation.title: OAuth install
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/2.mass-messaging.md
+++ b/docs/content/docs/99.examples/2.mass-messaging.md
@@ -1,7 +1,8 @@
 ---
 title: Mass messaging
 description: 'Filter contacts in CRM, personalise a template, send IM notifications to assigned managers.'
-navigation.title: 2. Mass messaging
+navigation.title: Mass messaging
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/3.task-automation.md
+++ b/docs/content/docs/99.examples/3.task-automation.md
@@ -1,7 +1,8 @@
 ---
 title: Task automation on stage transitions
 description: 'Poll deal stages every 60 s. When a watched transition fires, create a task with description, deadline and priority.'
-navigation.title: 3. Task automation
+navigation.title: Task automation
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/4.erp-sync.md
+++ b/docs/content/docs/99.examples/4.erp-sync.md
@@ -1,7 +1,8 @@
 ---
 title: ERP / 1C contact sync
 description: 'Two-way contact sync between Bitrix24 and an external ERP. Match by INN (primary) or email (fallback). Cron every hour.'
-navigation.title: 4. ERP sync
+navigation.title: ERP sync
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/5.disk-files.md
+++ b/docs/content/docs/99.examples/5.disk-files.md
@@ -1,7 +1,8 @@
 ---
 title: Disk — storages, folders, files
 description: 'List storages and folder children, create subfolders, inspect files. File upload (multipart) is intentionally out of scope.'
-navigation.title: 5. Disk files
+navigation.title: Disk files
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/6.telegram-bot.md
+++ b/docs/content/docs/99.examples/6.telegram-bot.md
@@ -1,7 +1,8 @@
 ---
 title: Telegram bot for new deals
 description: 'Poll new CRM deals every two minutes; notify a Telegram chat with an HTML-formatted card.'
-navigation.title: 6. Telegram bot
+navigation.title: Telegram bot
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/7.webhook-handler.md
+++ b/docs/content/docs/99.examples/7.webhook-handler.md
@@ -1,7 +1,8 @@
 ---
 title: Outbound webhook handler
 description: 'Express server that receives Bitrix24 outbound events, fetches details via REST, dispatches by event name. Always returns 200.'
-navigation.title: 7. Webhook handler
+navigation.title: Webhook handler
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/8.ai-assistant.md
+++ b/docs/content/docs/99.examples/8.ai-assistant.md
@@ -1,7 +1,8 @@
 ---
 title: AI assistant — analyse a deal, create a follow-up task
 description: 'Load a deal and its activities, ask GPT-4o for the next-best action, create a task bound to the deal with priority and deadline.'
-navigation.title: 8. AI assistant
+navigation.title: AI assistant
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/9.web-search-llm.md
+++ b/docs/content/docs/99.examples/9.web-search-llm.md
@@ -1,7 +1,8 @@
 ---
 title: Web search + LLM with timeline write-back
 description: 'Two-step RAG: ask any web-search provider, run the result through your LLM with [N] citations, post the answer as a CRM timeline comment on a deal.'
-navigation.title: 9. Web search + LLM
+navigation.title: Web search + LLM
+category: examples
 links:
   - label: Source on GitHub
     iconName: GitHubIcon


### PR DESCRIPTION
## Summary

Three related improvements to the Examples section UX:

### 1. Sidebar nav titles — strip numbering, add Recipes grouping
12 extended-catalogue `.md` files (frontmatter only):
- `navigation.title`: removed number prefix (`1. CRM analytics` → `CRM analytics`)
- Added `category: examples` so items appear inside the **Recipes** group in the sidebar (same as the 5 cookbook items)

### 2. Top navigation — add Examples entry
`docs/app/composables/useHeader.ts`:
- Desktop nav: added `Examples` link after `Working`, before `Resources`
- Mobile nav: added `Examples` link with `ItemIcon`
- Stripped trailing slashes from all internal `/docs/*` links (`/docs/getting-started/` → `/docs/getting-started`)
- Fixed active guard: `route.path === '/docs/examples' || route.path.startsWith('/docs/examples/')` (prevents false-positive on hypothetical `/docs/examples-v2`)

### 3. Homepage — Cookbook + Extended catalogue sections
`docs/app/pages/index.vue`:
- Added **Cookbook** section: 5 clickable cards linking to the featured recipes
- Added **Extended catalogue** section: 12-row responsive table with recipe name, stack, and scopes
- Row numbers derived from loop index (`v-for="(r, i)"`) — no redundant `index` field
- "View all examples →" link at the bottom

No BREAKING CHANGES. All links are absolute paths without trailing slashes, consistent with `autoSubfolderIndex: false`.

## Changelog note
```
feat(docs): Examples section — clean sidebar titles, top-nav shortcut, homepage preview (Cookbook + catalogue)
```

## Follow-up
- Issue #105: replace hardcoded homepage arrays with dynamic `queryCollection` driven by `featured: true` frontmatter

https://claude.ai/code/session_01SeopDqVuDyvaKffwui5bJ3