### PR TITLE
fix(home): improve cookbook card hover, wrap catalogue in B24Card

### DIFF
--- a/docs/app/pages/index.vue
+++ b/docs/app/pages/index.vue
@@ -115,7 +115,7 @@ const iconFromIconName = (iconName?: string) => {
           >
             <B24Card
               :b24ui="{
-                root: 'h-full transition-shadow hover:shadow-md cursor-pointer',
+                root: 'h-full transition-all duration-200 hover:shadow-xl hover:-translate-y-0.5 hover:ring-1 hover:ring-(--ui-border-color-accented) cursor-pointer',
                 body: 'p-4'
               }"
             >
@@ -138,48 +138,55 @@ const iconFromIconName = (iconName?: string) => {
         <p class="text-muted mb-6">
           End-to-end TypeScript scripts — run with <code>tsx</code> after setting <code>B24_HOOK</code> to your incoming webhook URL.
         </p>
-        <div class="overflow-x-auto">
-          <table class="w-full text-sm border-collapse">
-            <thead>
-              <tr class="border-b border-(--ui-border-color)">
-                <th class="text-left py-2 px-3 font-semibold text-muted w-8">
-                  #
-                </th>
-                <th class="text-left py-2 px-3 font-semibold text-muted">
-                  Recipe
-                </th>
-                <th class="text-left py-2 px-3 font-semibold text-muted hidden sm:table-cell">
-                  Stack
-                </th>
-                <th class="text-left py-2 px-3 font-semibold text-muted hidden md:table-cell">
-                  Scopes
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="(recipe, i) in catalogueRecipes"
-                :key="recipe.to"
-                class="border-b border-(--ui-border-color)/50 hover:bg-(--ui-color-accent-soft-element-violet)/30 transition-colors"
-              >
-                <td class="py-2 px-3 text-muted">
-                  {{ i + 1 }}
-                </td>
-                <td class="py-2 px-3">
-                  <NuxtLink :to="recipe.to" class="text-primary hover:underline font-medium">
-                    {{ recipe.title }}
-                  </NuxtLink>
-                </td>
-                <td class="py-2 px-3 text-muted hidden sm:table-cell">
-                  {{ recipe.stack }}
-                </td>
-                <td class="py-2 px-3 hidden md:table-cell">
-                  <code class="text-xs">{{ recipe.scopes }}</code>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <B24Card
+          :b24ui="{
+            root: 'rounded-(--ui-border-radius-md) overflow-hidden',
+            body: 'p-0'
+          }"
+        >
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm border-collapse">
+              <thead>
+                <tr class="border-b border-(--ui-border-color)">
+                  <th class="text-left py-2.5 px-4 font-semibold text-muted w-10">
+                    #
+                  </th>
+                  <th class="text-left py-2.5 px-4 font-semibold text-muted">
+                    Recipe
+                  </th>
+                  <th class="text-left py-2.5 px-4 font-semibold text-muted hidden sm:table-cell">
+                    Stack
+                  </th>
+                  <th class="text-left py-2.5 px-4 font-semibold text-muted hidden md:table-cell">
+                    Scopes
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="(recipe, i) in catalogueRecipes"
+                  :key="recipe.to"
+                  class="border-b border-(--ui-border-color)/50 last:border-0 hover:bg-(--ui-color-accent-soft-element-violet)/30 transition-colors"
+                >
+                  <td class="py-2.5 px-4 text-muted">
+                    {{ i + 1 }}
+                  </td>
+                  <td class="py-2.5 px-4">
+                    <NuxtLink :to="recipe.to" class="text-primary hover:underline font-medium">
+                      {{ recipe.title }}
+                    </NuxtLink>
+                  </td>
+                  <td class="py-2.5 px-4 text-muted hidden sm:table-cell">
+                    {{ recipe.stack }}
+                  </td>
+                  <td class="py-2.5 px-4 hidden md:table-cell">
+                    <code class="text-xs">{{ recipe.scopes }}</code>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </B24Card>
         <div class="mt-4">
           <NuxtLink to="/docs/examples" class="text-sm text-primary hover:underline">
             View all examples →

--- a/docs/app/pages/index.vue
+++ b/docs/app/pages/index.vue
@@ -115,7 +115,7 @@ const iconFromIconName = (iconName?: string) => {
           >
             <B24Card
               :b24ui="{
-                root: 'h-full transition-all duration-200 hover:shadow-xl hover:-translate-y-0.5 hover:ring-1 hover:ring-(--ui-border-color-accented) cursor-pointer',
+                root: 'h-full transition-[transform,box-shadow,outline-color] duration-200 hover:shadow-xl hover:-translate-y-0.5 hover:ring-1 hover:ring-(--ui-border-color-accented) cursor-pointer',
                 body: 'p-4'
               }"
             >
@@ -140,8 +140,8 @@ const iconFromIconName = (iconName?: string) => {
         </p>
         <B24Card
           :b24ui="{
-            root: 'rounded-(--ui-border-radius-md) overflow-hidden',
-            body: 'p-0'
+            root: 'rounded-(--ui-border-radius-md)',
+            body: 'p-0 overflow-hidden'
           }"
         >
           <div class="overflow-x-auto">


### PR DESCRIPTION
## Что сделано

Два визуальных улучшения главной страницы (`docs/app/pages/index.vue`).

### 1. Cookbook-карточки — улучшен hover

| | До | После |
|---|---|---|
| Эффект | только тень `shadow-md` | тень `shadow-xl` + подъём + ring-акцент |
| Transition | `transition-shadow` | `transition-[transform,box-shadow,outline-color]` (скоупная, не `all`) |

```
hover:shadow-xl hover:-translate-y-0.5 hover:ring-1 hover:ring-(--ui-border-color-accented)
```

### 2. Extended catalogue — подложка B24Card

- Таблица обёрнута в `B24Card` с `body: 'p-0 overflow-hidden'`
- `overflow-hidden` перенесён на `body` (не `root`) — Safari iOS не блокирует горизонтальный скролл
- `last:border-0` на последней строке — нет лишней нижней границы
- Отступы ячеек: `py-2 px-3` → `py-2.5 px-4`

## Changelog note
```
fix(home): improve cookbook card hover UX; wrap catalogue table in B24Card
```

## Нет breaking changes

https://claude.ai/code/session_01SeopDqVuDyvaKffwui5bJ3