### PR TITLE
docs(llms-txt): remove unused page links

### DIFF
--- a/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
+++ b/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
@@ -2,10 +2,6 @@
 title: LLMs.txt
 description: 'How to get AI tools like Cursor, Windsurf, GitHub Copilot, ChatGPT, and Claude to understand Bitrix24 JS SDK methods, tools, and best practices.'
 audited: 2026-06-02
-links:
-  - label: Nuxt config (nuxt-llms)
-    iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/docs/nuxt.config.ts
 ---
 
 ## What is LLMs.txt?


### PR DESCRIPTION
## Summary
- remove the lone `links:` block from the LLMs.txt getting-started page
- keep the page focused on reader-facing AI usage guidance instead of internal Nuxt config

## Validation
- `pnpm run docs:lint-pages`
- `pnpm run dev:prepare`
- `pnpm run docs:build` (page prerender completed, including `/raw/docs/getting-started/ai/llms-txt.md`)

Closes #130.

## Note
- The RU docs surface is maintained outside this English-only repository, so I did not modify it here.