### PR TITLE
ci: upgrade deprecated Node.js 20 actions to Node 24 runtimes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Keeps the GitHub Actions pinned in .github/workflows/* current, so the class
+# of problem in #103 (an action stranded on a removed Node runtime) is caught
+# automatically instead of by hand. All action bumps are collected into a single
+# grouped weekly PR to keep the noise down.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "ci"
+      - "tooling"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: pnpm run dev:prepare
 
       - name: Upload prepared workspace
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: prepared-workspace
           path: |
@@ -111,7 +111,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prepared workspace
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: prepared-workspace
 
@@ -146,7 +146,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prepared workspace
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: prepared-workspace
 
@@ -176,7 +176,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prepared workspace
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: prepared-workspace
 
@@ -209,7 +209,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prepared workspace
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: prepared-workspace
 
@@ -255,7 +255,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prepared workspace
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: prepared-workspace
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prepared workspace
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: prepared-workspace
 
@@ -146,7 +146,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prepared workspace
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: prepared-workspace
 
@@ -176,7 +176,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prepared workspace
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: prepared-workspace
 
@@ -209,7 +209,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prepared workspace
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: prepared-workspace
 
@@ -255,7 +255,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prepared workspace
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: prepared-workspace
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,6 @@ jobs:
         node: [ 22 ]
 
     env:
-      # FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       NUXT_PUBLIC_USE_AI: false
       NUXT_PUBLIC_USE_TAB_B24FRAME: false
       NUXT_PUBLIC_SITE_URL: https://bitrix24.github.io
@@ -46,7 +45,7 @@ jobs:
           cache: pnpm
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: pnpm install
@@ -64,7 +63,7 @@ jobs:
           touch combined-artifact/.nojekyll
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: combined-artifact
   deploy:
@@ -77,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Closes #103.

## Problem

GitHub forces Node 20 actions onto the Node 24 runner as of **2026-06-02** and removes Node 20 from runners entirely on **2026-09-16**. Several pinned actions still resolved to `runs.using: node20`, producing deprecation warnings on every run and (since the soft deadline) forced-runtime substitution.

## What changed

Every version was verified against the action's own `action.yml` (`runs.using`) at the candidate tag — not release-note paraphrase. Two non-obvious traps surfaced:

- The original issue suggested `configure-pages@v5`, but **v5 is still `node20`** — the first node24 major is **v6**.
- For `download-artifact`, **v5 and v6 are also still `node20`**; v7 is the first node24 major.

| Action | File | Before | After | Reason |
|---|---|---|---|---|
| `actions/configure-pages` | deploy.yml | `@v4` | `@v6` | v4/v5 = node20, v6 = node24 |
| `actions/upload-pages-artifact` | deploy.yml | `@v4` | `@v5` | composite; v4 bundles `upload-artifact@v4.6.2` (node20), v5 bundles `@v7.0.0` (node24) |
| `actions/deploy-pages` | deploy.yml | `@v4` | `@v5` | v4 = node20, v5 = node24 |
| `actions/upload-artifact` | ci.yml | `@v4` | `@v7` | v4 = node20, v7 = node24 |
| `actions/download-artifact` | ci.yml (×5) | `@v4` | `@v7` | v4–v6 = node20, v7 = first node24 (kept on the same major as upload-artifact) |

Also removed the now-obsolete `# FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` mitigation placeholder from `deploy.yml`.

**Left unchanged** — already resolve to node24: `actions/checkout@v6`, `actions/setup-node@v6`, `pnpm/action-setup@v5`.

## Review follow-ups included in this PR

A multi-perspective review (engineering / QA / security / CTO / docs) produced two changes folded in here:

- **Consistency** — `upload-artifact` and `download-artifact` are pinned to the **same major (v7)** rather than v7/v8; both are node24 and share the v4+ artifact backend.
- **Supply-chain (`.github/dependabot.yml`)** — added Dependabot for the `github-actions` ecosystem (weekly, grouped into one PR, `ci`-prefixed). This automates the exact maintenance #103 required by hand, so actions no longer silently strand on a removed Node runtime.

## Verification

- ✅ No node20 runtime remains: a resolver script walks every `uses:` pin in `.github/workflows/*` and confirms each `action.yml` reports `runs.using: node24` (composites resolved one level deep). Result: **8/8 OK**, including `upload-pages-artifact@v5 → upload-artifact@v7.0.0`.
- ✅ All workflow files + `dependabot.yml` parse as valid YAML.
- ⚠️ Not run here: a live Pages deploy (`deploy.yml` only triggers on push to `main` / `workflow_dispatch`). This PR does exercise the `ci.yml` `upload-artifact@v7` → `download-artifact@v7` handoff; please confirm a manual `deploy.yml` run after merge.

## Deferred (agreed, not in this PR)

- **Least-privilege permissions in `deploy.yml`** (move `pages: write` / `id-token: write` off the workflow level onto the `deploy` job) — tracked for a separate PR, since it needs a real deploy run to confirm `configure-pages` in the build job keeps working.

https://claude.ai/code/session_01977J3EFoxeffXCHS2TE7Kw