### PR TITLE
ci(deploy): scope Pages permissions to the jobs that need them

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -16,6 +14,13 @@ concurrency:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+
+    # Build only needs to read the repo and the Pages site config (configure-pages
+    # GETs it to derive the base path). It does NOT need id-token:write — only the
+    # deploy job mints the OIDC token.
+    permissions:
+      contents: read
+      pages: read
 
     strategy:
       matrix:
@@ -67,6 +72,11 @@ jobs:
         with:
           path: combined-artifact
   deploy:
+    # Privileged scope is confined to the deploy step: pages:write to publish and
+    # id-token:write for the OIDC token actions/deploy-pages exchanges.
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Security-review follow-up to #103 / #134 (deferred from that PR by agreement).

## Problem

`deploy.yml` declared the privileged Pages scope at the **workflow level**, so every job inherited it. The `build` job (checkout, install, `docs:generate`, `configure-pages`, `upload-pages-artifact`) ran with `id-token: write` (an OIDC token it never mints) and `pages: write` (it never publishes).

## Change

Confine privilege to `deploy`; drop `build` to read-only.

| Scope | Before | After |
|---|---|---|
| workflow | `contents:read, pages:write, id-token:write` | **`contents:read`** |
| `build` | (inherited write + OIDC) | **`contents:read, pages:read`** |
| `deploy` | (inherited) | **`pages:write, id-token:write`** |

`build` keeps `pages: read` because `actions/configure-pages` GETs the Pages site config to derive the base path; `upload-pages-artifact` needs no `pages` scope.

## Review & checks

Reviewed from five angles (eng / QA / security / CTO / docs) — the diff was assessed correct, no code changes requested on `deploy.yml`. A dependency-free permission-invariant script confirms: workflow == `{contents:read}`, `build` has no `id-token`/`pages:write`, `deploy` scoped to exactly `{pages:write, id-token:write}` — **6/6 OK**.

## ⚠️ Draft — verify before marking ready

`deploy.yml` runs only on `push: main` / `workflow_dispatch`, so CI cannot exercise it on a branch.

1. **Preferred:** run `workflow_dispatch` on this branch (Actions → "Deploy to Pages 📰" → Run workflow → `claude/deploy-perms-least-privilege`) and confirm the `build` job — especially the `configure-pages` step — is green.
   - Caveat: if the `github-pages` environment restricts deployments to `main`, the `deploy` job will pause/skip on a non-main run due to **environment protection** — expected, not a failure of this change. The `build` result is what matters in this run.
2. **Or:** merge and watch the first `main` deploy.

**Rollback path:** if `configure-pages` fails with `403 Resource not accessible by integration`, add `pages: write` to the `build` job (or restore the workflow-level `pages: write`). The core win — removing `id-token: write` from `build` — holds regardless. A failed `build` simply skips `deploy`, so live Pages stay on the last good version (no broken deploy).

## Defence-in-depth (repo setting, not in this diff)

Confirm Settings → Environments → `github-pages` restricts deployments to `main`.

https://claude.ai/code/session_01977J3EFoxeffXCHS2TE7Kw