### PR TITLE
docs(frame): clarify parent.setTitle scope (in-page #pagetitle, not browser tab)

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/30.frame-initialize-b24-frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame-initialize-b24-frame.md
@@ -2,7 +2,7 @@
 title: B24Frame Initialization
 description: 'Function is designed to initialize a B24Frame'
 category: 'B24Frame'
-audited: 2026-05-29
+audited: 2026-06-11
 navigation.title: Initialization
 links:
   - label: initializeB24Frame

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-auth.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-auth.md
@@ -2,7 +2,7 @@
 title: Auth Manager Class
 description: 'Designed for managing authentication in Bitrix24 applications. It handles authentication data received from the parent window and provides methods for updating and retrieving this data.'
 category: 'B24Frame'
-audited: 2026-05-29
+audited: 2026-06-11
 navigation.title: Auth
 links:
   - label: AuthManager

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-dialog.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-dialog.md
@@ -2,7 +2,7 @@
 title: Dialog Manager Class
 description: 'Wraps the BX24 system dialogs (user picker, access permission picker, CRM entity picker) so they can be opened from inside a Bitrix24 application iframe.'
 category: 'B24Frame'
-audited: 2026-05-29
+audited: 2026-06-11
 navigation.title: Dialog
 links:
   - label: DialogManager

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-options.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-options.md
@@ -2,7 +2,7 @@
 title: Options Manager Class
 description: 'Used for managing application and user settings in the Bitrix24 application. It allows initializing data, getting, and setting options through messages to the parent window.'
 category: 'B24Frame'
-audited: 2026-05-29
+audited: 2026-06-11
 navigation.title: Options
 links:
   - label: OptionsManager

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-parent.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-parent.md
@@ -2,7 +2,7 @@
 title: Parent Manager Class
 description: 'Provides methods for managing the parent application window in Bitrix24, including resizing the window, managing scroll, initiating calls, and opening the messenger.'
 category: 'B24Frame'
-audited: 2026-05-29
+audited: 2026-06-11
 navigation.title: Parent
 links:
   - label: ParentManager

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-parent.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-parent.md
@@ -90,7 +90,23 @@ Reloads the application page.
 async setTitle(title: string): Promise<void>
 ```
 
-Sets the page title.
+Sets the application page title — the in-layout heading element (`#pagetitle`) that Bitrix24 renders around your app. It does not change the browser tab title.
+
+The portal handles this command with `BX.ajax.UpdatePageTitle()`, which rewrites the `#pagetitle` element. It never calls `BX.ajax.UpdateWindowTitle()` (the function that assigns `document.title`), so the browser tab title stays untouched — regardless of the app's domain or placement mode.
+
+| Context | Effect of `setTitle()` |
+|----|----|
+| Application page | Updates the visible page heading (`#pagetitle`). Browser tab unchanged. |
+| Slider | Routed to the layout `#pagetitle`, not the slider header. Browser tab unchanged. |
+| Placement (widget) | Limited to the host layout's `#pagetitle`, if present. Browser tab unchanged. |
+
+To put a title into the browser tab, open the view as a slider with a `bx24_title` option (see [`slider.openSliderAppPage`](/docs/working-with-the-rest-api/frame-slider/#opensliderapppage)):
+
+```ts
+await $b24.slider.openSliderAppPage({ bx24_title: 'Q1 2025 — John Smith' })
+```
+
+For full, dynamic control of the browser tab title (e.g. telling apart several standalone browser tabs of your app), the app must own the top-level document — i.e. run as a standalone page outside the portal iframe, where you set `document.title` yourself.
 
 ### imCallTo
 ```ts-type

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-parent.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-parent.md
@@ -97,7 +97,7 @@ The portal handles this command with `BX.ajax.UpdatePageTitle()`, which rewrites
 | Context | Effect of `setTitle()` |
 |----|----|
 | Application page | Updates the visible page heading (`#pagetitle`). Browser tab unchanged. |
-| Slider | Routed to the layout `#pagetitle`, not the slider header. Browser tab unchanged. |
+| Slider | Targets the layout `#pagetitle` (often not visible); the slider header and browser tab are unchanged. |
 | Placement (widget) | Limited to the host layout's `#pagetitle`, if present. Browser tab unchanged. |
 
 To put a title into the browser tab, open the view as a slider with a `bx24_title` option (see [`slider.openSliderAppPage`](/docs/working-with-the-rest-api/frame-slider/#opensliderapppage)):

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
@@ -2,7 +2,7 @@
 title: Placement Manager Class
 description: 'Used for managing the placement of widgets in the Bitrix24 application.'
 category: 'B24Frame'
-audited: 2026-05-29
+audited: 2026-06-11
 navigation.title: Placement
 links:
   - label: PlacementManager

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-placement.md
@@ -56,7 +56,7 @@ Returns `true` if the widget is operating in slider mode (option `IFRAME` is `'Y
 $b24 = await initializeB24Frame()
 // ... /////
 if ($b24.placement.isSliderMode) {
-	$b24.parent.setTitle('SliderMode')
+	$b24.parent.setTitle('SliderMode') // updates the layout #pagetitle, not the slider header or browser tab
 }
 ```
 

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-slider.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-slider.md
@@ -25,7 +25,7 @@ We are still updating this page. Some data may be missing here — we will compl
 ### openSliderAppPage
 
 ```ts-type
-async openSliderAppPage(params: any = {}}: Promise<any>
+async openSliderAppPage(params: any = {}): Promise<any>
 ```
 
 The `openSliderAppPage`{lang="ts-type"} method allows you to open the current app in a new slider, passing arbitrary parameters.
@@ -36,7 +36,7 @@ How it works:
 * **Processing in the Application:** On the application side, it's most convenient to intercept these parameters through middleware. This allows you to decide which route to display to the user before the page is rendered.
 * **Seamless Navigation:** The user sees a new slider with the desired content, while the redirection logic is hidden within the application.
 
-Slider settings are passed via `bx24_`-prefixed keys. In particular, `bx24_title` sets the slider title — and, unlike [`parent.setTitle`](/docs/working-with-the-rest-api/frame-parent/#settitle), it also updates the browser tab title:
+Slider settings are passed via `bx24_`-prefixed keys. In particular, `bx24_title` sets the slider title; when the portal opens the slider it also reflects that title to the browser tab (`document.title`). So, unlike [`parent.setTitle`](/docs/working-with-the-rest-api/frame-parent/#settitle) (which only updates the in-layout `#pagetitle`), this path does change the browser tab title:
 
 ```ts
 await $b24.slider.openSliderAppPage({ bx24_title: 'My title' })

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-slider.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-slider.md
@@ -2,7 +2,7 @@
 title: Slider Manager Class
 description: 'Provides methods for working with sliders in the Bitrix24 application. It allows opening and closing sliders, as well as managing their content.'
 category: 'B24Frame'
-audited: 2026-05-29
+audited: 2026-06-11
 navigation.title: Slider
 links:
   - label: SliderManager

--- a/docs/content/docs/2.working-with-the-rest-api/31.frame-slider.md
+++ b/docs/content/docs/2.working-with-the-rest-api/31.frame-slider.md
@@ -36,6 +36,12 @@ How it works:
 * **Processing in the Application:** On the application side, it's most convenient to intercept these parameters through middleware. This allows you to decide which route to display to the user before the page is rendered.
 * **Seamless Navigation:** The user sees a new slider with the desired content, while the redirection logic is hidden within the application.
 
+Slider settings are passed via `bx24_`-prefixed keys. In particular, `bx24_title` sets the slider title — and, unlike [`parent.setTitle`](/docs/working-with-the-rest-api/frame-parent/#settitle), it also updates the browser tab title:
+
+```ts
+await $b24.slider.openSliderAppPage({ bx24_title: 'My title' })
+```
+
 ::code-example
 ---
 name: 'frame-slider-app-page-open'

--- a/docs/content/docs/99.examples/2.frame-app-skeleton.md
+++ b/docs/content/docs/99.examples/2.frame-app-skeleton.md
@@ -60,7 +60,7 @@ onMounted(async () => {
     return
   }
 
-  $b24.parent.setTitle('My Bitrix24 App')
+  $b24.parent.setTitle('My Bitrix24 App') // sets the in-page #pagetitle, not the browser tab
   // Auto-resize the iframe to fit its content; call again when content height
   // changes (e.g. after a network response renders).
   await $b24.parent.resizeWindowAuto()

--- a/packages/jssdk/README-AI.md
+++ b/packages/jssdk/README-AI.md
@@ -15,7 +15,7 @@
 Purpose: give AI agents a precise, code-oriented overview of the SDK to generate working Bitrix24 apps. This SDK lets you:
 
 - Call Bitrix24 REST API from apps embedded in Bitrix24 (iframe) and from backend services
-- Interact with Bitrix24 UI: open sliders, dialogs, resize frame, set page title, IM integrations, etc.
+- Interact with Bitrix24 UI: open sliders, dialogs, resize frame, set in-app page title (`#pagetitle`, not the browser tab), IM integrations, etc.
 - Manage app/user options via the parent portal
 - Use helpers (profile/app/options/currencies/licenses/payments) and Pull client
 
@@ -264,7 +264,7 @@ Parent window and IM integrations
 
 ```ts
 await $b24.parent.fitWindow()
-await $b24.parent.setTitle('My Page')
+await $b24.parent.setTitle('My Page')        // in-page #pagetitle, not the browser tab
 await $b24.parent.scrollParentWindow(0)
 await $b24.parent.imCallTo(5, true)          // video call to user 5
 await $b24.parent.imOpenMessenger('chat12')  // open messenger

--- a/packages/jssdk/src/frame/parent.ts
+++ b/packages/jssdk/src/frame/parent.ts
@@ -182,7 +182,11 @@ export class ParentManager {
   }
 
   /**
-   * Set Page Title
+   * Sets the in-layout page title (the `#pagetitle` element the portal renders around the app).
+   *
+   * Does NOT change the browser tab title (`document.title`): the portal applies this command to
+   * `#pagetitle`, never to the tab. To set the browser tab title, open the view as a slider via
+   * `SliderManager.openSliderAppPage` with a `bx24_title` option.
    *
    * @param {string} title
    *

--- a/packages/jssdk/src/frame/slider.ts
+++ b/packages/jssdk/src/frame/slider.ts
@@ -32,6 +32,10 @@ export class SliderManager {
   /**
    * When the method is called, a pop-up window with the application frame will be opened.
    *
+   * Settings are passed via `bx24_`-prefixed keys (e.g. `bx24_title`, `bx24_width`).
+   * `bx24_title` sets the slider title; the portal also reflects it to the browser tab title
+   * (`document.title`) — unlike `ParentManager.setTitle`, which only updates the in-layout `#pagetitle`.
+   *
    * @link https://apidocs.bitrix24.com/sdk/bx24-js-sdk/additional-functions/bx24-open-application.html
    */
   async openSliderAppPage(params: any = {}): Promise<any> {

--- a/skills/b24jssdk-frame-ui/SKILL.md
+++ b/skills/b24jssdk-frame-ui/SKILL.md
@@ -96,7 +96,7 @@ await $b24.parent.reloadWindow()
 await $b24.parent.closeApplication()
 ```
 
-`setTitle` changes the in-page `#pagetitle`, not the browser tab — to set the browser tab title, open a slider via `slider.openSliderAppPage({ bx24_title })`.
+`setTitle` changes the in-page `#pagetitle`, not the browser tab — to set the browser tab title, open a slider via `slider.openSliderAppPage({ bx24_title: '…' })`.
 
 For IM:
 

--- a/skills/b24jssdk-frame-ui/SKILL.md
+++ b/skills/b24jssdk-frame-ui/SKILL.md
@@ -90,11 +90,13 @@ Less commonly used. Returns the parent window's raw access-selection payload —
 await $b24.parent.fitWindow()                // shrink-wrap to content
 await $b24.parent.resizeWindow(800, 600)     // explicit size
 await $b24.parent.resizeWindowAuto(rootEl, /* minH */ 400, /* minW */ 300)
-await $b24.parent.setTitle('My App')         // header title in the portal
+await $b24.parent.setTitle('My App')         // in-page #pagetitle, NOT the browser tab
 await $b24.parent.scrollParentWindow(0)
 await $b24.parent.reloadWindow()
 await $b24.parent.closeApplication()
 ```
+
+`setTitle` changes the in-page `#pagetitle`, not the browser tab — to set the browser tab title, open a slider via `slider.openSliderAppPage({ bx24_title })`.
 
 For IM:
 


### PR DESCRIPTION
## What

Clarifies the documented behavior of `parent.setTitle()` (issue #183).

`setTitle` is handled on the portal side by `BX.ajax.UpdatePageTitle()`, which rewrites the in-page `#pagetitle` element. The function that sets the browser tab — `BX.ajax.UpdateWindowTitle()` (`document.title = title`) — is never called by the `setTitle` handler. So `setTitle()` only ever changes the in-page `#pagetitle`, never the browser tab — independently of the app's domain or placement mode (the same-origin policy is not the blocker; the handler routing is).

This was verified empirically by stepping through the portal handler in the page and slider contexts.

## Changes

- **`docs/.../31.frame-parent.md`** — expand the `setTitle` section: scope (`#pagetitle` vs browser tab), why, a per-context effect table, and how to affect the browser tab (`slider.openSliderAppPage({ bx24_title })`, or a standalone page).
- **`docs/.../31.frame-slider.md`** — note that `openSliderAppPage`'s `bx24_title` sets the slider title and also updates the browser tab.
- **`skills/b24jssdk-frame-ui/SKILL.md`** — correct the `setTitle` comment and add a short note.
- **`packages/jssdk/README-AI.md`** — sync the wording.

Docs-only; no code/behavior changes.

Refs #183.

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_