### PR TITLE
fix(actions): decouple cursor field from response id in list helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 * **http:** a 401 `expired_token` / `invalid_token` response now refreshes the token and retries the request once on every entry point (`B24Frame`, `B24OAuth`, `B24Hook`). Previously the auth-retry branch was silently skipped, so the 401 surfaced to the caller on the first attempt — e.g. a long-lived Frame app idling past the access-token TTL (#182)
+* **actions:** `callList` / `fetchList` (v2 and v3) gain a `cursorIdKey` option so keyset pagination works when a method sorts/filters by one field name but returns another — e.g. `tasks.task.list` sorts by `ID` (uppercase) yet returns a lowercase `id`. Previously the single `idKey` drove both the request cursor and the response read, so the default silently stopped after the first 50 records. The helpers now also log a `warning` when a full page is returned but `idKey` cannot be read from its items (#185)
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bug Fixes
 
 * **http:** a 401 `expired_token` / `invalid_token` response now refreshes the token and retries the request once on every entry point (`B24Frame`, `B24OAuth`, `B24Hook`). Previously the auth-retry branch was silently skipped, so the 401 surfaced to the caller on the first attempt — e.g. a long-lived Frame app idling past the access-token TTL (#182)
-* **actions:** `callList` / `fetchList` (v2 and v3) gain a `cursorIdKey` option so keyset pagination works when a method sorts/filters by one field name but returns another — e.g. `tasks.task.list` sorts by `ID` (uppercase) yet returns a lowercase `id`. Previously the single `idKey` drove both the request cursor and the response read, so the default silently stopped after the first 50 records. The helpers now also log a `warning` when a full page is returned but `idKey` cannot be read from its items (#185)
+* **actions:** `callList` / `fetchList` (v2 and v3) gain a `cursorIdKey` option so keyset pagination works when a method sorts/filters by one field name but returns another — e.g. `tasks.task.list` sorts by `ID` (uppercase) yet returns a lowercase `id`. Previously the single `idKey` drove both the request cursor and the response read, so the default silently stopped after the first 50 records (the `b24jssdk-rest` skill cheat sheet recommended that broken config — now corrected). The helpers now also log a `warning` when a full page is returned but no numeric id can be read via `idKey` (#185)
 
 ### Chore
 

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: CallListV2.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 2.'
 category: 'actions'
-audited: 2026-06-11
+audited: 2026-06-12
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: CallList
@@ -79,7 +79,8 @@ The `options` object contains the following properties:
 |----|----|----|----|
 | **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `crm.contact.list`, `tasks.task.list`). |
 | **`params`** | `Omit<TypeCallParams, 'start' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `start` and `order` parameters. The `start` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `idKey` ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
-| **`idKey`** | `string`{lang="ts-type"} | No | Name of the field containing the unique element identifier. Default: `'ID'` (uppercase). Can also be `'id'` (lowercase) or another field depending on the REST API data structure.|
+| **`idKey`** | `string`{lang="ts-type"} | No | Name of the id field **as it appears in each response item**; its value drives the cursor. Default: `'ID'` (uppercase). For methods that return a lowercase / camelCase id (e.g. `tasks.task.list` returns `id`), set `'id'`. |
+| **`cursorIdKey`** | `string`{lang="ts-type"} | No | Field name used in the **request** for `order` and the `>` page filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs from the response field name — e.g. `tasks.task.list` sorts and filters by `ID` but returns `id`: pass `idKey: 'id', cursorIdKey: 'ID'`. |
 | **`customKeyForResult`** | `string`{lang="ts-type"} | No | Custom key indicating that the REST API response will be selected by this field. For example: `items` for a list of CRM elements. |
 | **`requestId`** | `string`{lang="ts-type"} | No | Unique request identifier for tracking. Used for request deduplication and debugging. |
 
@@ -125,7 +126,7 @@ The `customKeyForResult`{lang="ts-type"} parameter allows you to specify the key
 ### Limitations
 
 - **Page size**: Fixed limitation of Bitrix24 REST API version 2 — `50` records per request.
-- **Sorting is fixed**: The method always sorts by `idKey` ascending, because cursor pagination relies on `>idKey` to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
+- **Sorting is fixed**: The method always sorts by `cursorIdKey` (which defaults to `idKey`) ascending, because cursor pagination relies on a `>cursorIdKey` filter to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
 - **Only for list methods**: Intended only for methods that return data arrays.
 
 ## Error Handling
@@ -213,6 +214,29 @@ try {
   }
 }
 ```
+
+### Fetching all `tasks.task.list` records (request field ≠ response field)
+
+`tasks.task.list` sorts and filters by `ID` (uppercase) but returns each task with a lowercase `id`. Set `idKey` to the **response** field and `cursorIdKey` to the **request** field:
+
+```ts [AllTasks.ts]
+type TaskListItem = { id: string, title: string }
+
+const response = await $b24.actions.v2.callList.make<TaskListItem>({
+  method: 'tasks.task.list',
+  params: {
+    filter: { RESPONSIBLE_ID: 1 }, // tasks filter fields are uppercase
+    select: ['ID', 'TITLE']
+  },
+  idKey: 'id', // read task.id from the response
+  cursorIdKey: 'ID', // order + ">ID" page filter in the request
+  customKeyForResult: 'tasks'
+})
+
+console.log(`Loaded ${response.getData()?.length ?? 0} tasks`)
+```
+
+Without `cursorIdKey`, the default `idKey: 'ID'` can't be read from the lowercase response, so pagination stops after the first 50 tasks — and the SDK logs a `warning` that points you here.
 
 ## Alternatives and Recommendations
 

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
@@ -78,7 +78,7 @@ The `options` object contains the following properties:
 | Parameter | Type | Required | Description |
 |----|----|----|----|
 | **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `crm.contact.list`, `tasks.task.list`). |
-| **`params`** | `Omit<TypeCallParams, 'start' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `start` and `order` parameters. The `start` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `idKey` ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
+| **`params`** | `Omit<TypeCallParams, 'start' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `start` and `order` parameters. The `start` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `cursorIdKey` (which defaults to `idKey`) ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
 | **`idKey`** | `string`{lang="ts-type"} | No | Name of the id field **as it appears in each response item**; its value drives the cursor. Default: `'ID'` (uppercase). For methods that return a lowercase / camelCase id (e.g. `tasks.task.list` returns `id`), set `'id'`. |
 | **`cursorIdKey`** | `string`{lang="ts-type"} | No | Field name used in the **request** for `order` and the `>` page filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs from the response field name — e.g. `tasks.task.list` sorts and filters by `ID` but returns `id`: pass `idKey: 'id', cursorIdKey: 'ID'`. |
 | **`customKeyForResult`** | `string`{lang="ts-type"} | No | Custom key indicating that the REST API response will be selected by this field. For example: `items` for a list of CRM elements. |
@@ -111,7 +111,7 @@ This indicates that you should consider migrating to the newer REST API version.
 The method implements the [Bitrix24 recommended algorithm](https://apidocs.bitrix24.com/settings/performance/huge-data.html) for efficient work with large data volumes:
 
 1. `start: -1`: Disables counting the total number of records, significantly speeding up query execution.
-2. **Filtering by increasing ID**: Each subsequent query uses a `>ID` filter with the ID of the last retrieved element.
+2. **Filtering by increasing id**: Each subsequent query uses a `>cursorIdKey` filter with the id of the last retrieved element (read via `idKey`).
 3. **Automatic data end detection**: Requests stop when an empty array is received or the number of elements is less than the page size (`50`).
 
 ### REST API v2 Response Structure
@@ -226,7 +226,7 @@ const response = await $b24.actions.v2.callList.make<TaskListItem>({
   method: 'tasks.task.list',
   params: {
     filter: { RESPONSIBLE_ID: 1 }, // tasks filter fields are uppercase
-    select: ['ID', 'TITLE']
+    select: ['ID', 'TITLE'] // selected uppercase, but the response carries lowercase id / title
   },
   idKey: 'id', // read task.id from the response
   cursorIdKey: 'ID', // order + ">ID" page filter in the request

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallListV3.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 3.'
 category: 'actions'
-audited: 2026-06-11
+audited: 2026-06-12
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: CallList
@@ -77,7 +77,8 @@ The `options` object contains the following properties:
 |----|----|----|----|
 | **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `crm.contact.list`, `tasks.task.list`). |
 | **`params`** | `Omit<TypeCallParams, 'pagination' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `pagination` and `order` parameters. The `pagination` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `idKey` ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
-| **`idKey`** | `string`{lang="ts-type"} | No | Name of the field containing the unique element identifier. Default: `'id'`. Can also be another field depending on the REST API data structure. |
+| **`idKey`** | `string`{lang="ts-type"} | No | Name of the id field **as it appears in each response item**; its value drives the cursor. Default: `'id'`. Set it to match the id field the method returns. |
+| **`cursorIdKey`** | `string`{lang="ts-type"} | No | Field name used in the **request** for `order` and the `[field, '>', n]` page filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs from the response field name (e.g. an uppercase request field but a lowercase response id): pass `idKey: 'id', cursorIdKey: 'ID'`. |
 | **`customKeyForResult`** | `string`{lang="ts-type"} | Yes | Custom key indicating that the REST API response will be selected by this field. For example: `items` for a list of CRM elements. |
 | **`requestId`** | `string`{lang="ts-type"} | No | Unique request identifier for tracking. Used for request deduplication and debugging. |
 | **`limit`** | `number`{lang="ts-type"} | No | How many records to retrieve at a time. Default is `50`. Maximum is `1000`. |
@@ -116,7 +117,7 @@ The `customKeyForResult`{lang="ts-type"} parameter allows you to specify the key
 ### Limitations
 
 - **Page size**: Bitrix24 REST API version 3 limitation — maximum `1000` records per request.
-- **Sorting is fixed**: The method always sorts by `idKey` ascending, because cursor pagination relies on `[idKey, '>', nextId]` filters to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
+- **Sorting is fixed**: The method always sorts by `cursorIdKey` (which defaults to `idKey`) ascending, because cursor pagination relies on `[cursorIdKey, '>', nextId]` filters to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
 - **Only for list methods**: Intended only for methods that return data arrays.
 
 ## Error Handling
@@ -203,6 +204,22 @@ try {
   }
 }
 ```
+
+### When the request and response id fields differ
+
+Some methods sort / filter by one field name but return another (for example an uppercase `ID` in the request vs a lowercase `id` in the payload). Set `idKey` to the **response** field and `cursorIdKey` to the **request** field:
+
+```ts
+const response = await $b24.actions.v3.callList.make({
+  method: 'some.list',
+  params: { select: ['ID', 'TITLE'] },
+  idKey: 'id', // read the id from each returned item
+  cursorIdKey: 'ID', // order + ["ID", ">", n] page filter in the request
+  customKeyForResult: 'items'
+})
+```
+
+If `idKey` can't be read from a full page, the SDK logs a `warning` and stops paginating instead of silently truncating.
 
 ## Alternatives and Recommendations
 

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
@@ -76,7 +76,7 @@ The `options` object contains the following properties:
 | Parameter | Type | Required | Description |
 |----|----|----|----|
 | **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `crm.contact.list`, `tasks.task.list`). |
-| **`params`** | `Omit<TypeCallParams, 'pagination' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `pagination` and `order` parameters. The `pagination` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `idKey` ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
+| **`params`** | `Omit<TypeCallParams, 'pagination' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `pagination` and `order` parameters. The `pagination` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `cursorIdKey` (which defaults to `idKey`) ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
 | **`idKey`** | `string`{lang="ts-type"} | No | Name of the id field **as it appears in each response item**; its value drives the cursor. Default: `'id'`. Set it to match the id field the method returns. |
 | **`cursorIdKey`** | `string`{lang="ts-type"} | No | Field name used in the **request** for `order` and the `[field, '>', n]` page filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs from the response field name (e.g. an uppercase request field but a lowercase response id): pass `idKey: 'id', cursorIdKey: 'ID'`. |
 | **`customKeyForResult`** | `string`{lang="ts-type"} | Yes | Custom key indicating that the REST API response will be selected by this field. For example: `items` for a list of CRM elements. |
@@ -99,7 +99,7 @@ This object provides:
 
 The method implements the [Bitrix24 recommended algorithm](https://apidocs.bitrix24.com/settings/performance/huge-data.html) for efficient work with large data volumes:
 
-1. **Filtering by increasing id**: Each subsequent query uses a `>id` filter with the id of the last retrieved element.
+1. **Filtering by increasing id**: Each subsequent query uses a `[cursorIdKey, '>', id]` filter with the id of the last retrieved element (read via `idKey`).
 2. **Automatic data end detection**: Requests stop when an empty array is received or the number of elements is less than the page size (`options.limit`).
 
 ### REST API v3 Response Structure

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: FetchListV2.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 2 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-06-11
+audited: 2026-06-12
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: FetchList
@@ -80,7 +80,8 @@ The `options` object contains the following properties:
 |----|----|----|----|
 | **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `crm.contact.list`, `tasks.task.list`). |
 | **`params`** | `Omit<TypeCallParams, 'start' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `start` and `order` parameters. The `start` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `idKey` ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
-| **`idKey`** | `string`{lang="ts-type"} | No | Name of the field containing the unique element identifier. Default: `'ID'` (uppercase). Can also be `'id'` (lowercase) or another field depending on the REST API data structure. |
+| **`idKey`** | `string`{lang="ts-type"} | No | Name of the id field **as it appears in each response item**; its value drives the cursor. Default: `'ID'` (uppercase). For methods that return a lowercase / camelCase id (e.g. `tasks.task.list` returns `id`), set `'id'`. |
+| **`cursorIdKey`** | `string`{lang="ts-type"} | No | Field name used in the **request** for `order` and the `>` page filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs from the response field name — e.g. `tasks.task.list` sorts and filters by `ID` but returns `id`: pass `idKey: 'id', cursorIdKey: 'ID'`. |
 | **`customKeyForResult`** | `string`{lang="ts-type"} | No | Custom key indicating that the REST API response will be selected by this field. For example: `items` for a list of CRM elements. |
 | **`requestId`** | `string`{lang="ts-type"} | No | Unique request identifier for tracking. Used for request deduplication and debugging. |
 
@@ -137,7 +138,7 @@ The `customKeyForResult`{lang="ts-type"} parameter allows you to specify the key
 ### Limitations
 
 - **Page size**: Fixed limitation of Bitrix24 REST API version 2 — `50` records per request.
-- **Sorting is fixed**: The method always sorts by `idKey` ascending, because cursor pagination relies on `>idKey` to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
+- **Sorting is fixed**: The method always sorts by `cursorIdKey` (which defaults to `idKey`) ascending, because cursor pagination relies on a `>cursorIdKey` filter to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
 - **Only for list methods**: Intended only for methods that return data arrays.
 
 ## Error Handling
@@ -265,6 +266,33 @@ try {
   $logger.critical('A problem occurred', { error })
 }
 ```
+
+### Paginating `tasks.task.list` (request field ≠ response field)
+
+`tasks.task.list` sorts and filters by `ID` (uppercase) but returns each task with a lowercase `id`. Point `idKey` at the **response** field and `cursorIdKey` at the **request** field — the cursor then reads the last `id` from the page and asks for the next one with `>ID`:
+
+```ts [ProcessAllTasks.ts]
+type TaskListItem = { id: string, title: string }
+
+const generator = $b24.actions.v2.fetchList.make<TaskListItem>({
+  method: 'tasks.task.list',
+  params: {
+    filter: { RESPONSIBLE_ID: 1 }, // tasks filter fields are uppercase
+    select: ['ID', 'TITLE']
+  },
+  idKey: 'id', // read task.id from the response
+  cursorIdKey: 'ID', // order + ">ID" page filter in the request
+  customKeyForResult: 'tasks'
+})
+
+let total = 0
+for await (const chunk of generator) {
+  total += chunk.length
+}
+console.log(`Processed ${total} tasks`)
+```
+
+Without `cursorIdKey`, the default `idKey: 'ID'` can't be read from the lowercase response, so pagination stops after the first 50 tasks — and the SDK logs a `warning` that points you here.
 
 ## Alternatives and Recommendations
 

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
@@ -79,7 +79,7 @@ The `options` object contains the following properties:
 | Parameter | Type | Required | Description |
 |----|----|----|----|
 | **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `crm.contact.list`, `tasks.task.list`). |
-| **`params`** | `Omit<TypeCallParams, 'start' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `start` and `order` parameters. The `start` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `idKey` ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
+| **`params`** | `Omit<TypeCallParams, 'start' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `start` and `order` parameters. The `start` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `cursorIdKey` (which defaults to `idKey`) ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
 | **`idKey`** | `string`{lang="ts-type"} | No | Name of the id field **as it appears in each response item**; its value drives the cursor. Default: `'ID'` (uppercase). For methods that return a lowercase / camelCase id (e.g. `tasks.task.list` returns `id`), set `'id'`. |
 | **`cursorIdKey`** | `string`{lang="ts-type"} | No | Field name used in the **request** for `order` and the `>` page filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs from the response field name — e.g. `tasks.task.list` sorts and filters by `ID` but returns `id`: pass `idKey: 'id', cursorIdKey: 'ID'`. |
 | **`customKeyForResult`** | `string`{lang="ts-type"} | No | Custom key indicating that the REST API response will be selected by this field. For example: `items` for a list of CRM elements. |
@@ -122,7 +122,7 @@ Unlike `CallListV2.make()`, which returns a `Promise` with all data at once, `Fe
 The method implements the [Bitrix24 recommended algorithm](https://apidocs.bitrix24.com/settings/performance/huge-data.html) for efficient work with large data volumes:
 
 1. `start: -1`: Disables counting the total number of records, significantly speeding up query execution.
-2. **Filtering by increasing ID**: Each subsequent query uses a `>ID` filter with the ID of the last retrieved element.
+2. **Filtering by increasing id**: Each subsequent query uses a `>cursorIdKey` filter with the id of the last retrieved element (read via `idKey`).
 3. **Stream processing**: Data is processed as it is received, saving memory.
 4. **Automatic data end detection**: Requests stop when an empty array is received or the number of elements is less than the page size (`50`).
 
@@ -278,7 +278,7 @@ const generator = $b24.actions.v2.fetchList.make<TaskListItem>({
   method: 'tasks.task.list',
   params: {
     filter: { RESPONSIBLE_ID: 1 }, // tasks filter fields are uppercase
-    select: ['ID', 'TITLE']
+    select: ['ID', 'TITLE'] // selected uppercase, but the response carries lowercase id / title
   },
   idKey: 'id', // read task.id from the response
   cursorIdKey: 'ID', // order + ">ID" page filter in the request

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: FetchListV3.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 3 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-06-11
+audited: 2026-06-12
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: FetchList
@@ -75,7 +75,8 @@ The `options` object contains the following properties:
 |----|----|----|----|
 | **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `crm.contact.list`, `tasks.task.list`). |
 | **`params`** | `Omit<TypeCallParams, 'pagination' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `pagination` and `order` parameters. The `pagination` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `idKey` ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
-| **`idKey`** | `string`{lang="ts-type"} | No | Name of the field containing the unique element identifier. Default: `'id'`. Can also be another field depending on the REST API data structure. |
+| **`idKey`** | `string`{lang="ts-type"} | No | Name of the id field **as it appears in each response item**; its value drives the cursor. Default: `'id'`. Set it to match the id field the method returns. |
+| **`cursorIdKey`** | `string`{lang="ts-type"} | No | Field name used in the **request** for `order` and the `[field, '>', n]` page filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs from the response field name (e.g. an uppercase request field but a lowercase response id): pass `idKey: 'id', cursorIdKey: 'ID'`. |
 | **`customKeyForResult`** | `string`{lang="ts-type"} | Yes | Custom key indicating that the REST API response will be selected by this field. For example: `items` for a list of CRM elements. |
 | **`requestId`** | `string`{lang="ts-type"} | No | Unique request identifier for tracking. Used for request deduplication and debugging. |
 | **`limit`** | `number`{lang="ts-type"} | No | How many records to retrieve at a time. Default is `50`. Maximum is `1000`. |
@@ -125,7 +126,7 @@ The `customKeyForResult`{lang="ts-type"} parameter allows you to specify the key
 ### Limitations
 
 - **Page size**: Bitrix24 REST API version 3 limitation — maximum `1000` records per request.
-- **Sorting is fixed**: The method always sorts by `idKey` ascending, because cursor pagination relies on `[idKey, '>', nextId]` filters to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
+- **Sorting is fixed**: The method always sorts by `cursorIdKey` (which defaults to `idKey`) ascending, because cursor pagination relies on `[cursorIdKey, '>', nextId]` filters to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
 - **Only for list methods**: Intended only for methods that return data arrays.
 
 ## Error Handling
@@ -252,6 +253,22 @@ try {
   $logger.critical('A problem occurred', { error })
 }
 ```
+
+### When the request and response id fields differ
+
+Some methods sort / filter by one field name but return another (for example an uppercase `ID` in the request vs a lowercase `id` in the payload). Set `idKey` to the **response** field and `cursorIdKey` to the **request** field:
+
+```ts
+const generator = $b24.actions.v3.fetchList.make({
+  method: 'some.list',
+  params: { select: ['ID', 'TITLE'] },
+  idKey: 'id', // read the id from each returned item
+  cursorIdKey: 'ID', // order + ["ID", ">", n] page filter in the request
+  customKeyForResult: 'items'
+})
+```
+
+If `idKey` can't be read from a full page, the SDK logs a `warning` and stops paginating instead of silently truncating.
 
 ## Alternatives and Recommendations
 

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
@@ -74,7 +74,7 @@ The `options` object contains the following properties:
 | Parameter | Type | Required | Description |
 |----|----|----|----|
 | **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `crm.contact.list`, `tasks.task.list`). |
-| **`params`** | `Omit<TypeCallParams, 'pagination' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `pagination` and `order` parameters. The `pagination` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `idKey` ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
+| **`params`** | `Omit<TypeCallParams, 'pagination' \| 'order'>`{lang="ts-type"} | No | Request parameters, excluding the `pagination` and `order` parameters. The `pagination` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `cursorIdKey` (which defaults to `idKey`) ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
 | **`idKey`** | `string`{lang="ts-type"} | No | Name of the id field **as it appears in each response item**; its value drives the cursor. Default: `'id'`. Set it to match the id field the method returns. |
 | **`cursorIdKey`** | `string`{lang="ts-type"} | No | Field name used in the **request** for `order` and the `[field, '>', n]` page filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs from the response field name (e.g. an uppercase request field but a lowercase response id): pass `idKey: 'id', cursorIdKey: 'ID'`. |
 | **`customKeyForResult`** | `string`{lang="ts-type"} | Yes | Custom key indicating that the REST API response will be selected by this field. For example: `items` for a list of CRM elements. |
@@ -107,7 +107,7 @@ Unlike `CallListV3.make()`{lang="ts-type"}, which returns a `Promise`{lang="ts-t
 
 The method implements the [Bitrix24 recommended algorithm](https://apidocs.bitrix24.com/settings/performance/huge-data.html) for efficient work with large data volumes:
 
-1. **Filtering by increasing id**: Each subsequent query uses a `>id` filter with the id of the last retrieved element.
+1. **Filtering by increasing id**: Each subsequent query uses a `[cursorIdKey, '>', id]` filter with the id of the last retrieved element (read via `idKey`).
 2. **Stream processing**: Data is processed as it is received, saving memory.
 3. **Automatic data end detection**: Requests stop when an empty array is received or the number of elements is less than the page size (`options.limit`).
 
@@ -266,6 +266,10 @@ const generator = $b24.actions.v3.fetchList.make({
   cursorIdKey: 'ID', // order + ["ID", ">", n] page filter in the request
   customKeyForResult: 'items'
 })
+
+for await (const chunk of generator) {
+  console.log(`Got ${chunk.length} records`)
+}
 ```
 
 If `idKey` can't be read from a full page, the SDK logs a `warning` and stops paginating instead of silently truncating.

--- a/docs/content/docs/2.working-with-the-rest-api/90.types-type-b24.md
+++ b/docs/content/docs/2.working-with-the-rest-api/90.types-type-b24.md
@@ -18,7 +18,9 @@ async function listAdminTasks($b24: TypeB24): Promise<unknown[]> {
   const response = await $b24.actions.v2.callList.make<{ id: number, title: string }>({
     method: 'tasks.task.list',
     params: { filter: { '!=STATUS': '5' }, select: ['ID', 'TITLE'] },
-    idKey: 'id',
+    idKey: 'id', // tasks return lowercase id
+    cursorIdKey: 'ID', // ...but sort / filter by uppercase ID
+    customKeyForResult: 'tasks',
     requestId: 'admin-tasks'
   })
   return response.isSuccess ? response.getData()! : []

--- a/docs/content/docs/99.examples/1.dashboard-deals-csv.md
+++ b/docs/content/docs/99.examples/1.dashboard-deals-csv.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Export deals to CSV'
 description: 'Stream every CRM deal that matches a date filter into a CSV file using a webhook and FetchListV2.'
-audited: 2026-05-05
+audited: 2026-06-12
 category: 'examples'
 navigation:
   title: Deals → CSV
@@ -113,14 +113,14 @@ node scripts/deals-to-csv.mjs
 
 - `B24Hook.fromWebhookUrl()` parses the webhook URL and gives you a configured `TypeB24` instance — no `await` initialization needed.
 - `ParamsFactory.getBatchProcessing()` swaps the default rate-limit profile for one tuned for long-running scans, so the script doesn't fight live UI requests for the portal queue.
-- `actions.v2.fetchList.make()` returns an `AsyncGenerator<T[]>`. Each `for await` iteration yields up to `limit` records (default `50`) and uses cursor-based pagination on `idKey` ascending — the SDK takes care of stitching pages together.
+- `actions.v2.fetchList.make()` returns an `AsyncGenerator<T[]>`. Each `for await` iteration yields up to `limit` records (default `50`) and uses cursor-based pagination on `cursorIdKey` (which defaults to `idKey`) ascending — the SDK takes care of stitching pages together.
 - `Text.toB24Format(date)` converts a JS `Date` to the ISO format Bitrix24 expects in `crm.item.list` filters; passing a raw `Date` would not work.
 
 ## Limitations
 
 - `crm.item.list` returns up to 50 records per page; this is a server-side limit, not an SDK setting.
-- The generator does **not** support a custom `order` parameter — cursor pagination requires sorting by `idKey` ascending. Specifying `order` in `params` triggers a runtime warning and is stripped.
-- `idKey` defaults to `'ID'` (uppercase) for v2 endpoints. CRM item methods return `id` (lowercase), so override it explicitly as in the example.
+- The generator does **not** support a custom `order` parameter — cursor pagination requires sorting by `cursorIdKey` (default `idKey`) ascending. Specifying `order` in `params` triggers a runtime warning and is stripped.
+- `idKey` defaults to `'ID'` (uppercase) for v2 endpoints. CRM item methods return `id` (lowercase), so override it explicitly as in the example. If a method sorts/filters by a different field name than it returns (e.g. `tasks.task.list` sorts by `ID` but returns `id`), also set `cursorIdKey`.
 - One `B24Hook` instance corresponds to a single user account on the portal. If the deals you need are owned by another user, the webhook must be created by that user (or by an account with cross-user access).
 - For very large windows that exhaust the per-day method-call budget, split the date range into smaller chunks and run them sequentially.
 

--- a/packages/jssdk/src/core/actions/v2/call-list.ts
+++ b/packages/jssdk/src/core/actions/v2/call-list.ts
@@ -26,7 +26,7 @@ export class CallListV2 extends AbstractAction {
    *
    * @param {ActionCallListV2} options - parameters for executing the request.
    *     - `method: string` - The name of the REST API method that returns a list of data (for example: `crm.item.list`, `tasks.task.list`)
-   *     - `params?: Omit<TypeCallParams, 'start'>` - Request parameters, excluding the `start` parameter,
+   *     - `params?: Omit<TypeCallParams, 'start' | 'order'>` - Request parameters, excluding the `start` and `order` parameters,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
    *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value
@@ -142,18 +142,16 @@ export class CallListV2 extends AbstractAction {
 
       // Update the filter for the next iteration
       const lastItem = resultData[resultData.length - 1] as Record<string, any>
-      if (
-        lastItem
-        && typeof lastItem[idKey] !== 'undefined'
-      ) {
-        requestParams.filter[moreIdKey] = Number.parseInt(lastItem[idKey])
+      const cursorValue = lastItem ? Number.parseInt(lastItem[idKey], 10) : Number.NaN
+      if (Number.isFinite(cursorValue)) {
+        requestParams.filter[moreIdKey] = cursorValue
       } else {
-        // A full page came back, yet the cursor id can't be read from its items —
-        // almost always an `idKey` that doesn't match the response field (e.g. the
-        // default 'ID' against tasks.task.list, which returns lowercase 'id').
-        // Without a cursor value we can't advance, so stop and tell the caller how
-        // to fix it instead of silently truncating at the first page.
-        this._logger.warning(`callList.make: a full page returned but idKey "${idKey}" is missing on its items — pagination stops after the first page. Make sure idKey matches the id field in the response (e.g. tasks.task.list returns lowercase "id"); if the sortable field name differs, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
+        // A full page came back, yet no usable numeric cursor id could be read from
+        // its items via `idKey` — almost always an `idKey` that doesn't match the
+        // response field (e.g. a request that sorts by `ID` while the response
+        // carries a lowercase `id`). Without a cursor we can't advance, so stop and
+        // tell the caller how to fix it instead of silently truncating.
+        this._logger.warning(`callList.make: pagination stops here — no numeric id could be read from the returned items via idKey "${idKey}". Make sure idKey matches the id field in the response; if the sortable field name differs from it, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
         isContinue = false
         break
       }

--- a/packages/jssdk/src/core/actions/v2/call-list.ts
+++ b/packages/jssdk/src/core/actions/v2/call-list.ts
@@ -8,6 +8,7 @@ export type ActionCallListV2 = ActionOptions & {
   method: string
   params?: Omit<TypeCallParams, 'start' | 'order'>
   idKey?: string
+  cursorIdKey?: string
   customKeyForResult?: string
   requestId?: string
 }
@@ -28,9 +29,13 @@ export class CallListV2 extends AbstractAction {
    *     - `params?: Omit<TypeCallParams, 'start'>` - Request parameters, excluding the `start` parameter,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
-   *     - `idKey?: string` - The name of the field containing the unique identifier of the element.
-   *         Default is 'ID' (uppercase). Alternatively, it can be 'id' (lowercase).
-   *         or another field, depending on the REST API data structure.
+   *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value
+   *         drives the cursor. Default is 'ID' (uppercase). For methods that return a lowercase /
+   *         camelCase id (for example `tasks.task.list` returns `id`), set `idKey: 'id'`.
+   *     - `cursorIdKey?: string` - The field name used in the REQUEST for `order` and the `>` page
+   *         filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs
+   *         from the response field name — e.g. `tasks.task.list` sorts and filters by `ID` (uppercase)
+   *         but returns `id` (lowercase): pass `idKey: 'id', cursorIdKey: 'ID'`.
    *     - `customKeyForResult?: string` - A custom key indicating that the response REST API will be
    *        grouped by this field.
    *        Example: `items` to group a list of CRM items.
@@ -70,19 +75,20 @@ export class CallListV2 extends AbstractAction {
     const result: Result<T[]> = new Result()
 
     const idKey = options?.idKey ?? 'ID'
+    const cursorIdKey = options?.cursorIdKey ?? idKey
     const customKeyForResult = options?.customKeyForResult ?? null
     const params = options?.params ?? {}
 
-    // Warn and strip user-provided `order` — cursor pagination requires ordering by idKey only
+    // Warn and strip user-provided `order` — cursor pagination requires ordering by cursorIdKey only
     if ('order' in params && params['order']) {
-      this._logger.warning('callList.make: user-provided `order` parameter is ignored because cursor-based pagination requires ordering by idKey. Use `filter` to narrow results instead.')
+      this._logger.warning('callList.make: user-provided `order` parameter is ignored because cursor-based pagination requires ordering by cursorIdKey. Use `filter` to narrow results instead.')
     }
 
-    const moreIdKey = `>${idKey}`
+    const moreIdKey = `>${cursorIdKey}`
     const { order: _ignoredOrder, ...restParams } = params as TypeCallParams
     const requestParams: TypeCallParams = {
       ...restParams,
-      order: { [idKey]: 'ASC' },
+      order: { [cursorIdKey]: 'ASC' },
       filter: { ...(params['filter'] || {}), [moreIdKey]: 0 },
       start: -1
     }
@@ -142,6 +148,12 @@ export class CallListV2 extends AbstractAction {
       ) {
         requestParams.filter[moreIdKey] = Number.parseInt(lastItem[idKey])
       } else {
+        // A full page came back, yet the cursor id can't be read from its items —
+        // almost always an `idKey` that doesn't match the response field (e.g. the
+        // default 'ID' against tasks.task.list, which returns lowercase 'id').
+        // Without a cursor value we can't advance, so stop and tell the caller how
+        // to fix it instead of silently truncating at the first page.
+        this._logger.warning(`callList.make: a full page returned but idKey "${idKey}" is missing on its items — pagination stops after the first page. Make sure idKey matches the id field in the response (e.g. tasks.task.list returns lowercase "id"); if the sortable field name differs, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
         isContinue = false
         break
       }

--- a/packages/jssdk/src/core/actions/v2/fetch-list.ts
+++ b/packages/jssdk/src/core/actions/v2/fetch-list.ts
@@ -8,6 +8,7 @@ export type ActionFetchListV2 = ActionOptions & {
   method: string
   params?: Omit<TypeCallParams, 'start' | 'order'>
   idKey?: string
+  cursorIdKey?: string
   customKeyForResult?: string
   requestId?: string
 }
@@ -29,9 +30,13 @@ export class FetchListV2 extends AbstractAction {
    *     - `params?: Omit<TypeCallParams, 'start'>` - Request parameters, excluding the `start` parameter,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
-   *     - `idKey?: string` - The name of the field containing the unique identifier of the element.
-   *         Default is 'ID' (uppercase). Alternatively, it can be 'id' (lowercase).
-   *         or another field, depending on the REST API data structure.
+   *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value
+   *         drives the cursor. Default is 'ID' (uppercase). For methods that return a lowercase /
+   *         camelCase id (for example `tasks.task.list` returns `id`), set `idKey: 'id'`.
+   *     - `cursorIdKey?: string` - The field name used in the REQUEST for `order` and the `>` page
+   *         filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs
+   *         from the response field name — e.g. `tasks.task.list` sorts and filters by `ID` (uppercase)
+   *         but returns `id` (lowercase): pass `idKey: 'id', cursorIdKey: 'ID'`.
    *     - `customKeyForResult?: string` - A custom key indicating that the response REST API will be
    *        grouped by this field.
    *        Example: `items` to group a list of CRM items.
@@ -73,19 +78,20 @@ export class FetchListV2 extends AbstractAction {
     const batchSize = 50
 
     const idKey = options?.idKey ?? 'ID'
+    const cursorIdKey = options?.cursorIdKey ?? idKey
     const customKeyForResult = options?.customKeyForResult ?? null
     const params = options?.params ?? {}
 
-    // Warn and strip user-provided `order` — cursor pagination requires ordering by idKey only
+    // Warn and strip user-provided `order` — cursor pagination requires ordering by cursorIdKey only
     if ('order' in params && params['order']) {
-      this._logger.warning('fetchList.make: user-provided `order` parameter is ignored because cursor-based pagination requires ordering by idKey. Use `filter` to narrow results instead.')
+      this._logger.warning('fetchList.make: user-provided `order` parameter is ignored because cursor-based pagination requires ordering by cursorIdKey. Use `filter` to narrow results instead.')
     }
 
-    const moreIdKey = `>${idKey}`
+    const moreIdKey = `>${cursorIdKey}`
     const { order: _ignoredOrder, ...restParams } = params as TypeCallParams
     const requestParams: TypeCallParams = {
       ...restParams,
-      order: { [idKey]: 'ASC' },
+      order: { [cursorIdKey]: 'ASC' },
       filter: { ...(params['filter'] || {}), [moreIdKey]: 0 },
       start: -1
     }
@@ -144,6 +150,12 @@ export class FetchListV2 extends AbstractAction {
       ) {
         requestParams.filter[moreIdKey] = Number.parseInt(lastItem[idKey])
       } else {
+        // A full page came back, yet the cursor id can't be read from its items —
+        // almost always an `idKey` that doesn't match the response field (e.g. the
+        // default 'ID' against tasks.task.list, which returns lowercase 'id').
+        // Without a cursor value we can't advance, so stop and tell the caller how
+        // to fix it instead of silently truncating at the first page.
+        this._logger.warning(`fetchList.make: a full page returned but idKey "${idKey}" is missing on its items — pagination stops after the first page. Make sure idKey matches the id field in the response (e.g. tasks.task.list returns lowercase "id"); if the sortable field name differs, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
         isContinue = false
         break
       }

--- a/packages/jssdk/src/core/actions/v2/fetch-list.ts
+++ b/packages/jssdk/src/core/actions/v2/fetch-list.ts
@@ -27,7 +27,7 @@ export class FetchListV2 extends AbstractAction {
    *
    * @param {ActionFetchListV2} options - parameters for executing the request.
    *     - `method: string` - The name of the REST API method that returns a list of data (for example: `crm.item.list`, `tasks.task.list`)
-   *     - `params?: Omit<TypeCallParams, 'start'>` - Request parameters, excluding the `start` parameter,
+   *     - `params?: Omit<TypeCallParams, 'start' | 'order'>` - Request parameters, excluding the `start` and `order` parameters,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
    *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value
@@ -144,18 +144,16 @@ export class FetchListV2 extends AbstractAction {
 
       // Update the filter for the next iteration
       const lastItem = resultData[resultData.length - 1] as Record<string, any>
-      if (
-        lastItem
-        && typeof lastItem[idKey] !== 'undefined'
-      ) {
-        requestParams.filter[moreIdKey] = Number.parseInt(lastItem[idKey])
+      const cursorValue = lastItem ? Number.parseInt(lastItem[idKey], 10) : Number.NaN
+      if (Number.isFinite(cursorValue)) {
+        requestParams.filter[moreIdKey] = cursorValue
       } else {
-        // A full page came back, yet the cursor id can't be read from its items —
-        // almost always an `idKey` that doesn't match the response field (e.g. the
-        // default 'ID' against tasks.task.list, which returns lowercase 'id').
-        // Without a cursor value we can't advance, so stop and tell the caller how
-        // to fix it instead of silently truncating at the first page.
-        this._logger.warning(`fetchList.make: a full page returned but idKey "${idKey}" is missing on its items — pagination stops after the first page. Make sure idKey matches the id field in the response (e.g. tasks.task.list returns lowercase "id"); if the sortable field name differs, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
+        // A full page came back, yet no usable numeric cursor id could be read from
+        // its items via `idKey` — almost always an `idKey` that doesn't match the
+        // response field (e.g. a request that sorts by `ID` while the response
+        // carries a lowercase `id`). Without a cursor we can't advance, so stop and
+        // tell the caller how to fix it instead of silently truncating.
+        this._logger.warning(`fetchList.make: pagination stops here — no numeric id could be read from the returned items via idKey "${idKey}". Make sure idKey matches the id field in the response; if the sortable field name differs from it, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
         isContinue = false
         break
       }

--- a/packages/jssdk/src/core/actions/v3/call-list.ts
+++ b/packages/jssdk/src/core/actions/v3/call-list.ts
@@ -27,7 +27,7 @@ export class CallListV3 extends AbstractAction {
    *
    * @param {ActionCallListV3} options - parameters for executing the request.
    *     - `method: string` - The name of the REST API method that returns a list of data (for example: `crm.item.list`, `tasks.task.list`)
-   *     - `params?: Omit<TypeCallParams, 'pagination'>` - Request parameters, excluding the `pagination` parameter,
+   *     - `params?: Omit<TypeCallParams, 'pagination' | 'order'>` - Request parameters, excluding the `pagination` and `order` parameters,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
    *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value
@@ -137,14 +137,16 @@ export class CallListV3 extends AbstractAction {
 
       // Update the filter for the next iteration
       const lastItem = resultData[resultData.length - 1] as Record<string, any>
-      if (lastItem && typeof lastItem[idKey] !== 'undefined') {
-        nextId = Number.parseInt(lastItem[idKey] as string)
+      const cursorValue = lastItem ? Number.parseInt(lastItem[idKey], 10) : Number.NaN
+      if (Number.isFinite(cursorValue)) {
+        nextId = cursorValue
       } else {
-        // A full page came back, yet the cursor id can't be read from its items —
-        // almost always an `idKey` that doesn't match the response field. Without a
-        // cursor value we can't advance, so stop and tell the caller how to fix it
-        // instead of silently truncating at the first page.
-        this._logger.warning(`callList.make: a full page returned but idKey "${idKey}" is missing on its items — pagination stops after the first page. Make sure idKey matches the id field in the response; if the sortable field name differs, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
+        // A full page came back, yet no usable numeric cursor id could be read from
+        // its items via `idKey` — almost always an `idKey` that doesn't match the
+        // response field (e.g. a request that sorts by `ID` while the response
+        // carries a lowercase `id`). Without a cursor we can't advance, so stop and
+        // tell the caller how to fix it instead of silently truncating.
+        this._logger.warning(`callList.make: pagination stops here — no numeric id could be read from the returned items via idKey "${idKey}". Make sure idKey matches the id field in the response; if the sortable field name differs from it, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
         isContinue = false
         break
       }

--- a/packages/jssdk/src/core/actions/v3/call-list.ts
+++ b/packages/jssdk/src/core/actions/v3/call-list.ts
@@ -8,6 +8,7 @@ export type ActionCallListV3 = ActionOptions & {
   method: string
   params?: Omit<TypeCallParams, 'pagination' | 'order'>
   idKey?: string
+  cursorIdKey?: string
   customKeyForResult: string
   requestId?: string
   limit?: number
@@ -29,8 +30,12 @@ export class CallListV3 extends AbstractAction {
    *     - `params?: Omit<TypeCallParams, 'pagination'>` - Request parameters, excluding the `pagination` parameter,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
-   *     - `idKey?: string` - The name of the field containing the unique identifier of the element.
-   *         Default is 'id'. Alternatively, it can be another field, depending on the REST API data structure.
+   *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value
+   *         drives the cursor. Default is 'id'. Set it to match the id field the method returns.
+   *     - `cursorIdKey?: string` - The field name used in the REQUEST for `order` and the
+   *         `[field, '>', n]` page filter. Defaults to `idKey`. Set it only when the sortable /
+   *         filterable field name differs from the response field name (e.g. an uppercase request
+   *         field but a lowercase response id): pass `idKey: 'id', cursorIdKey: 'ID'`.
    *     - `customKeyForResult: string` - A custom key indicating that the response REST API will be
    *        grouped by this field.
    *        Example: `items` to group a list of CRM items.
@@ -70,18 +75,19 @@ export class CallListV3 extends AbstractAction {
     const result: Result<T[]> = new Result()
 
     const idKey = options?.idKey ?? 'id'
+    const cursorIdKey = options?.cursorIdKey ?? idKey
     const customKeyForResult = options?.customKeyForResult ?? null
     const params = options?.params ?? {}
 
-    // Warn and strip user-provided `order` — cursor pagination requires ordering by idKey only
+    // Warn and strip user-provided `order` — cursor pagination requires ordering by cursorIdKey only
     if ('order' in params && params['order']) {
-      this._logger.warning('callList.make: user-provided `order` parameter is ignored because cursor-based pagination requires ordering by idKey. Use `filter` to narrow results instead.')
+      this._logger.warning('callList.make: user-provided `order` parameter is ignored because cursor-based pagination requires ordering by cursorIdKey. Use `filter` to narrow results instead.')
     }
 
     const { order: _ignoredOrder, ...restParams } = params as TypeCallParams
     const requestParams: TypeCallParams = {
       ...restParams,
-      order: { [idKey]: 'ASC' },
+      order: { [cursorIdKey]: 'ASC' },
       filter: [...(params['filter'] || [])],
       pagination: { page: 0, limit: batchSize }
     }
@@ -91,7 +97,7 @@ export class CallListV3 extends AbstractAction {
     let nextId = 0
     do {
       const sendParams = { ...requestParams, filter: [...requestParams.filter] }
-      sendParams.filter.push([idKey, '>', nextId])
+      sendParams.filter.push([cursorIdKey, '>', nextId])
       const response: AjaxResult<T> = await this._b24.actions.v3.call.make<T>({
         method: options.method,
         params: sendParams,
@@ -134,6 +140,11 @@ export class CallListV3 extends AbstractAction {
       if (lastItem && typeof lastItem[idKey] !== 'undefined') {
         nextId = Number.parseInt(lastItem[idKey] as string)
       } else {
+        // A full page came back, yet the cursor id can't be read from its items —
+        // almost always an `idKey` that doesn't match the response field. Without a
+        // cursor value we can't advance, so stop and tell the caller how to fix it
+        // instead of silently truncating at the first page.
+        this._logger.warning(`callList.make: a full page returned but idKey "${idKey}" is missing on its items — pagination stops after the first page. Make sure idKey matches the id field in the response; if the sortable field name differs, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
         isContinue = false
         break
       }

--- a/packages/jssdk/src/core/actions/v3/fetch-list.ts
+++ b/packages/jssdk/src/core/actions/v3/fetch-list.ts
@@ -28,7 +28,7 @@ export class FetchListV3 extends AbstractAction {
    *
    * @param {ActionFetchListV3} options - parameters for executing the request.
    *     - `method: string` - The name of the REST API method that returns a list of data (for example: `crm.item.list`, `tasks.task.list`)
-   *     - `params?: Omit<TypeCallParams, 'pagination'>` - Request parameters, excluding the `pagination` parameter,
+   *     - `params?: Omit<TypeCallParams, 'pagination' | 'order'>` - Request parameters, excluding the `pagination` and `order` parameters,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
    *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value
@@ -138,17 +138,16 @@ export class FetchListV3 extends AbstractAction {
 
       // Update the filter for the next iteration
       const lastItem = resultData[resultData.length - 1] as Record<string, any>
-      if (
-        lastItem
-        && typeof lastItem[idKey] !== 'undefined'
-      ) {
-        nextId = Number.parseInt(lastItem[idKey] as string)
+      const cursorValue = lastItem ? Number.parseInt(lastItem[idKey], 10) : Number.NaN
+      if (Number.isFinite(cursorValue)) {
+        nextId = cursorValue
       } else {
-        // A full page came back, yet the cursor id can't be read from its items —
-        // almost always an `idKey` that doesn't match the response field. Without a
-        // cursor value we can't advance, so stop and tell the caller how to fix it
-        // instead of silently truncating at the first page.
-        this._logger.warning(`fetchList.make: a full page returned but idKey "${idKey}" is missing on its items — pagination stops after the first page. Make sure idKey matches the id field in the response; if the sortable field name differs, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
+        // A full page came back, yet no usable numeric cursor id could be read from
+        // its items via `idKey` — almost always an `idKey` that doesn't match the
+        // response field (e.g. a request that sorts by `ID` while the response
+        // carries a lowercase `id`). Without a cursor we can't advance, so stop and
+        // tell the caller how to fix it instead of silently truncating.
+        this._logger.warning(`fetchList.make: pagination stops here — no numeric id could be read from the returned items via idKey "${idKey}". Make sure idKey matches the id field in the response; if the sortable field name differs from it, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
         isContinue = false
         break
       }

--- a/packages/jssdk/src/core/actions/v3/fetch-list.ts
+++ b/packages/jssdk/src/core/actions/v3/fetch-list.ts
@@ -8,6 +8,7 @@ export type ActionFetchListV3 = ActionOptions & {
   method: string
   params?: Omit<TypeCallParams, 'pagination' | 'order'>
   idKey?: string
+  cursorIdKey?: string
   customKeyForResult: string
   requestId?: string
   limit?: number
@@ -30,8 +31,12 @@ export class FetchListV3 extends AbstractAction {
    *     - `params?: Omit<TypeCallParams, 'pagination'>` - Request parameters, excluding the `pagination` parameter,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
-   *     - `idKey?: string` - The name of the field containing the unique identifier of the element.
-   *         Default is 'id'. Alternatively, it can be another field, depending on the REST API data structure.
+   *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value
+   *         drives the cursor. Default is 'id'. Set it to match the id field the method returns.
+   *     - `cursorIdKey?: string` - The field name used in the REQUEST for `order` and the
+   *         `[field, '>', n]` page filter. Defaults to `idKey`. Set it only when the sortable /
+   *         filterable field name differs from the response field name (e.g. an uppercase request
+   *         field but a lowercase response id): pass `idKey: 'id', cursorIdKey: 'ID'`.
    *     - `customKeyForResult: string` - A custom key indicating that the response REST API will be
    *        grouped by this field.
    *        Example: `items` to group a list of CRM items.
@@ -71,18 +76,19 @@ export class FetchListV3 extends AbstractAction {
     const batchSize = options?.limit ?? 50
 
     const idKey = options?.idKey ?? 'id'
+    const cursorIdKey = options?.cursorIdKey ?? idKey
     const customKeyForResult = options?.customKeyForResult ?? null
     const params = options?.params ?? {}
 
-    // Warn and strip user-provided `order` — cursor pagination requires ordering by idKey only
+    // Warn and strip user-provided `order` — cursor pagination requires ordering by cursorIdKey only
     if ('order' in params && params['order']) {
-      this._logger.warning('fetchList.make: user-provided `order` parameter is ignored because cursor-based pagination requires ordering by idKey. Use `filter` to narrow results instead.')
+      this._logger.warning('fetchList.make: user-provided `order` parameter is ignored because cursor-based pagination requires ordering by cursorIdKey. Use `filter` to narrow results instead.')
     }
 
     const { order: _ignoredOrder, ...restParams } = params as TypeCallParams
     const requestParams: TypeCallParams = {
       ...restParams,
-      order: { [idKey]: 'ASC' },
+      order: { [cursorIdKey]: 'ASC' },
       filter: [...(params['filter'] || [])],
       pagination: { page: 0, limit: batchSize }
     }
@@ -91,7 +97,7 @@ export class FetchListV3 extends AbstractAction {
     let nextId = 0
     do {
       const sendParams = { ...requestParams, filter: [...requestParams.filter] }
-      sendParams.filter.push([idKey, '>', nextId])
+      sendParams.filter.push([cursorIdKey, '>', nextId])
 
       const response: AjaxResult<T> = await this._b24.actions.v3.call.make<T>({
         method: options.method,
@@ -138,6 +144,11 @@ export class FetchListV3 extends AbstractAction {
       ) {
         nextId = Number.parseInt(lastItem[idKey] as string)
       } else {
+        // A full page came back, yet the cursor id can't be read from its items —
+        // almost always an `idKey` that doesn't match the response field. Without a
+        // cursor value we can't advance, so stop and tell the caller how to fix it
+        // instead of silently truncating at the first page.
+        this._logger.warning(`fetchList.make: a full page returned but idKey "${idKey}" is missing on its items — pagination stops after the first page. Make sure idKey matches the id field in the response; if the sortable field name differs, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`)
         isContinue = false
         break
       }

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,7 +28,7 @@ Project skills for the `@bitrix24/b24jssdk` workspace. Source of truth:
 - The active client is always `$b24` and is treated as `TypeB24` — every example works for `B24Hook`, `B24Frame`, and `B24OAuth` because the actions surface lives on `AbstractB24`.
 - Always use **`$b24.actions.v{2,3}.*.make()`** — the legacy `callMethod`/`callBatch`/`callListMethod`/`fetchListMethod` is `@deprecated` for 2.0.0.
 - Pick `v3` only for methods on the v3 whitelist (`tasks.task.{add,get,update,delete,…}`, `main.eventlog.*`, `batch`); everything else stays on `v2`.
-- v3 entities (`crm.item.*`) on v2 still need `idKey: 'id'` (lowercase) and `customKeyForResult: 'items'` for list helpers; classic methods (`crm.deal.*`, `tasks.task.list`) use default `'ID'` and either omit `customKeyForResult` or set it to `'tasks'` / `'files'` / etc.
+- v3 entities (`crm.item.*`) on v2 still need `idKey: 'id'` (lowercase) and `customKeyForResult: 'items'` for list helpers; classic methods (`crm.deal.*`) use default `idKey: 'ID'`. `tasks.task.list` is special — it sorts / filters by `ID` but returns lowercase `id`, so it needs `idKey: 'id', cursorIdKey: 'ID'` (and `customKeyForResult: 'tasks'`).
 - Filters: v2 = prefix-keyed object; v3 = array of `[field, op, value]` triples. Never mix.
 - Dates: use `Text.toB24Format(date)` for the canonical `yyyy-MM-dd'T'HH:mm:ssZZ` format.
 

--- a/skills/b24jssdk-filtering/SKILL.md
+++ b/skills/b24jssdk-filtering/SKILL.md
@@ -104,7 +104,7 @@ The top-level array is implicitly `logic: 'and'`.
 
 ## `order` rule for callList / fetchList
 
-Both `actions.v{2,3}.callList.make` and `fetchList.make` **strip user-supplied `order`** and force `{ [idKey]: 'ASC' }` because the action uses keyset cursor pagination. If you pass an `order`, the SDK logs a warning (`callList.make: user-provided 'order' parameter is ignored…`) and discards it (see `packages/jssdk/src/core/actions/v2/call-list.ts:77-79` and the v3 equivalent).
+Both `actions.v{2,3}.callList.make` and `fetchList.make` **strip user-supplied `order`** and force `{ [cursorIdKey]: 'ASC' }` (where `cursorIdKey` defaults to `idKey`) because the action uses keyset cursor pagination. If you pass an `order`, the SDK logs a warning (`callList.make: user-provided 'order' parameter is ignored…`) and discards it (see the `order` warning in `packages/jssdk/src/core/actions/v2/call-list.ts` and the v3 equivalent).
 
 If you need a specific sort order, drop down to `call.make` and page manually — but you almost certainly want to filter more narrowly instead.
 
@@ -208,7 +208,8 @@ const response = await $b24.actions.v2.callList.make<TaskItem>({
     filter: { '!REAL_STATUS': 5 }, // 5 = COMPLETED
     select: ['ID', 'TITLE', 'STATUS', 'RESPONSIBLE_ID']
   },
-  idKey: 'ID',                   // classic uppercase id
+  idKey: 'id',                   // tasks.task.list returns lowercase id
+  cursorIdKey: 'ID',             // ...but sorts / filters by uppercase ID
   customKeyForResult: 'tasks'
 })
 ```

--- a/skills/b24jssdk-recipes/SKILL.md
+++ b/skills/b24jssdk-recipes/SKILL.md
@@ -95,9 +95,9 @@ npx tsx examples/01-crm-analytics.ts
 ## Caveats applied across recipes
 
 - **Multi-funnel pipelines**: stage IDs may carry a category prefix (`C2:WON`, `C4:LOSE`). Recipes 1, 3, and 6 strip the prefix when checking the base stage.
-- **`order` in `callList.make`**: silently dropped (the action forces `idKey ASC` for cursor stability). Use `filter` to narrow.
+- **`order` in `callList.make`**: silently dropped (the action forces `cursorIdKey ASC`, defaulting to `idKey`, for cursor stability). Use `filter` to narrow.
 - **`customKeyForResult`**: `'items'` for `crm.item.list`, omit or `'tasks'` for classic methods. Wrong value → silent empty array.
-- **`idKey`**: `'id'` for `crm.item.list`, `'ID'` (default) for classic methods.
+- **`idKey` / `cursorIdKey`**: `idKey: 'id'` for `crm.item.list`; `'ID'` (default) for classic methods. `tasks.task.list` is the exception — it returns lowercase `id` but sorts by `ID`, so use `idKey: 'id', cursorIdKey: 'ID'`.
 - **Error handling**: failed calls throw `AjaxError` for REST errors; recipes log and continue where it makes sense. Tune via `setRestrictionManagerParams` if you need different retry behaviour (see `b24jssdk-core`).
 - **Webhook events** (recipe 7): registration of the outbound webhooks themselves (which events go where) is a one-off setup. Recipe 11 (`11-event-registration.ts`) is a small CLI for that: `list` / `bind` / `unbind` via `event.get` / `event.bind` / `event.unbind`.
 

--- a/skills/b24jssdk-rest/SKILL.md
+++ b/skills/b24jssdk-rest/SKILL.md
@@ -161,7 +161,7 @@ const items = data.map((row) => row.item)
 
 ## `callList.make` — small lists in memory
 
-Loads up to 1000 items into a single array. Internally pages with keyset cursor on `idKey`.
+Loads up to 1000 items into a single array. Internally pages with a keyset cursor on `cursorIdKey` (which defaults to `idKey`).
 
 ```ts
 import { Text } from '@bitrix24/b24jssdk'
@@ -191,7 +191,7 @@ if (!response.isSuccess) throw new Error(response.getErrorMessages().join('; '))
 const items = response.getData()! // CrmItem[]
 ```
 
-> **`order` is ignored** by `callList.make`. The action forces `order: { [idKey]: 'ASC' }` for cursor stability and **logs a warning** when you pass an `order` (see `actions/v2/call-list.ts:77-79`). Use `filter` to narrow results.
+> **`order` is ignored** by `callList.make`. The action forces `order: { [cursorIdKey]: 'ASC' }` for cursor stability and **logs a warning** when you pass an `order` (see the `order` warning in `actions/v2/call-list.ts`). Use `filter` to narrow results.
 
 ## `fetchList.make` — large lists, streaming
 
@@ -231,15 +231,17 @@ const generator = $b24.actions.v3.fetchList.make<TaskItem>({
 
 > **Note the v2 vs v3 filter difference.** v2 uses prefix-keyed objects; v3 uses arrays of `[field, op, value]` triples. See the `b24jssdk-filtering` skill.
 
-## `idKey` and `customKeyForResult` cheat sheet
+## `idKey`, `cursorIdKey` and `customKeyForResult` cheat sheet
 
-| Method | `idKey` | `customKeyForResult` |
-|---|---|---|
-| `crm.item.list` (v2) | `'id'` | `'items'` |
-| `crm.deal.list`, `crm.contact.list`, … (classic v2) | `'ID'` (default) | omit (default `result`) |
-| `tasks.task.list` (v2) | `'ID'` (default) | `'tasks'` |
-| `disk.folder.getchildren` | `'ID'` (default) | omit |
-| `main.eventlog.list` (v3) | `'id'` | `'items'` |
+`idKey` is the id field **in the response** (the cursor reads its value); `cursorIdKey` is the field **in the request** used for `order` and the `>` page filter, and it defaults to `idKey`. They differ only when a method sorts/filters by one name but returns another — most notably `tasks.task.list` (request `ID`, response `id`).
+
+| Method | `idKey` (response) | `cursorIdKey` (request) | `customKeyForResult` |
+|---|---|---|---|
+| `crm.item.list` (v2) | `'id'` | — (= `idKey`) | `'items'` |
+| `crm.deal.list`, `crm.contact.list`, … (classic v2) | `'ID'` (default) | — (= `idKey`) | omit (default `result`) |
+| `tasks.task.list` (v2) | `'id'` | `'ID'` | `'tasks'` |
+| `disk.folder.getchildren` | `'ID'` (default) | — (= `idKey`) | omit |
+| `main.eventlog.list` (v3) | `'id'` | — (= `idKey`) | `'items'` |
 
 Wrong `customKeyForResult` makes `getData()` return an empty array — there is no error. If you're getting `[]` and expect data, this is the first thing to check.
 
@@ -322,6 +324,7 @@ For tuning retry/throw behaviour per error code see the `hardErrorCodes` / `soft
 - ❌ Passing `order` to `callList.make` — silently ignored with a warning. Narrow with `filter` instead.
 - ❌ `customKeyForResult: 'result'` for `crm.item.list` — wrong, use `'items'`. Otherwise you'll get an empty list silently.
 - ❌ `idKey: 'ID'` for `crm.item.list` — wrong, use `'id'`. The classic `crm.deal.list` is the opposite.
+- ❌ `idKey: 'ID'` alone for `tasks.task.list` — the response id is lowercase `id`, so the cursor can't read it and paging silently stops after 50. Use `idKey: 'id', cursorIdKey: 'ID'`.
 - ❌ `Promise.all` over `callList.make` for parallel paging — internal cursor pagination is sequential by design; you'll get duplicates or skipped rows.
 - ❌ `B24Hook` in a browser bundle — leaks the webhook secret. Use `B24Frame` there.
 

--- a/skills/b24jssdk-rest/SKILL.md
+++ b/skills/b24jssdk-rest/SKILL.md
@@ -11,7 +11,7 @@ Every example uses `$b24` of type `TypeB24`, so the same code runs on `B24Hook`,
 
 ## Pick the API version
 
-The SDK exposes both `v2` and `v3` under `$b24.actions`. **v3 only works for a small whitelist of methods** (see `packages/jssdk/src/core/version-manager.ts:21-44`):
+The SDK exposes both `v2` and `v3` under `$b24.actions`. **v3 only works for a small whitelist of methods** (see the whitelist in `packages/jssdk/src/core/version-manager.ts`):
 
 | v3-supported methods | All other Bitrix24 methods |
 |---|---|
@@ -217,7 +217,7 @@ for await (const chunk of generator) {
 For v3:
 
 ```ts
-const generator = $b24.actions.v3.fetchList.make<TaskItem>({
+const generator = $b24.actions.v3.fetchList.make<EventLogItem>({
   method: 'main.eventlog.list',
   params: {
     filter: [['timestampX', '>=', Text.toB24Format(sixMonthsAgo)]],

--- a/test/integration/core/list-cursor-id-key.unit.spec.ts
+++ b/test/integration/core/list-cursor-id-key.unit.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression for issue #185: cursor pagination in the list helpers must not
+ * assume the REQUEST field name equals the RESPONSE field name.
+ *
+ * `tasks.task.list` sorts and filters by `ID` (uppercase) but returns task
+ * objects with a lowercase `id`. The old code drove `order`, the `>` cursor
+ * filter and the response read all from a single `idKey`, so:
+ *   - idKey: 'ID'  → request was correct, but lastItem['ID'] was undefined →
+ *                    pagination silently stopped after the first 50 records;
+ *   - idKey: 'id'  → response read worked, but the request ordered/filtered by a
+ *                    lowercase field tasks.task.list does not accept.
+ *
+ * The fix adds `cursorIdKey` (request order + `>` filter), defaulting to `idKey`
+ * (the response read). A `.unit.spec.ts` — no real Bitrix24 portal: the helpers
+ * are exercised against a mock `call.make`.
+ */
+import { describe, it, expect } from 'vitest'
+import { FetchListV2 } from '../../../packages/jssdk/src/core/actions/v2/fetch-list'
+import { CallListV2 } from '../../../packages/jssdk/src/core/actions/v2/call-list'
+import { FetchListV3 } from '../../../packages/jssdk/src/core/actions/v3/fetch-list'
+import { CallListV3 } from '../../../packages/jssdk/src/core/actions/v3/call-list'
+
+type Item = Record<string, unknown>
+
+function makeLogger() {
+  const warnings: string[] = []
+  const logger = {
+    warning: (m: string) => warnings.push(m),
+    error: () => {},
+    info: () => {},
+    log: () => {},
+    debug: () => {},
+    trace: () => {}
+  }
+  return { logger: logger as never, warnings }
+}
+
+/**
+ * A mock `_b24` whose `actions.v{2,3}.call.make` serves `items` page by page,
+ * using the cursor it finds in the request (so it proves the request actually
+ * advances). Each request's params are deep-snapshotted into `calls` because v2
+ * mutates a single `requestParams` object across iterations.
+ */
+function makeB24(opts: {
+  version: 'v2' | 'v3'
+  customKey: string
+  items: Item[]
+  idField: string
+  pageSize?: number
+}) {
+  const pageSize = opts.pageSize ?? 50
+  const calls: any[] = []
+
+  const make = async (callOpts: any) => {
+    calls.push(structuredClone(callOpts.params))
+    let after = 0
+    if (opts.version === 'v2') {
+      const filter = callOpts.params.filter || {}
+      const gtKey = Object.keys(filter).find(k => k.startsWith('>') && k[1] !== '=')
+      after = Number(gtKey ? filter[gtKey] : 0)
+    } else {
+      const filter: any[] = callOpts.params.filter || []
+      const triple = [...filter].reverse().find((t: any[]) => t[1] === '>')
+      after = Number(triple ? triple[2] : 0)
+    }
+    const slice = opts.items
+      .filter(it => Number(it[opts.idField]) > after)
+      .slice(0, pageSize)
+    return {
+      isSuccess: true,
+      getData: () => ({ result: { [opts.customKey]: slice } }),
+      getErrorMessages: () => [],
+      errors: [] as Array<[number, Error]>
+    } as never
+  }
+
+  const actions = opts.version === 'v2'
+    ? { v2: { call: { make } } }
+    : { v3: { call: { make } } }
+  return { b24: { actions } as never, calls }
+}
+
+function rows(n: number, idField: string): Item[] {
+  return Array.from({ length: n }, (_, i) => ({ [idField]: String(i + 1), title: `row ${i + 1}` }))
+}
+
+describe('list helpers cursorIdKey (issue #185)', () => {
+  it('v2 fetchList: tasks-like (request ID / response id) paginates every page', async () => {
+    const { b24, calls } = makeB24({ version: 'v2', customKey: 'tasks', items: rows(120, 'id'), idField: 'id' })
+    const { logger, warnings } = makeLogger()
+    const action = new FetchListV2(b24, logger)
+
+    const collected: Item[] = []
+    for await (const chunk of action.make<Item>({
+      method: 'tasks.task.list',
+      params: { select: ['ID', 'TITLE'] },
+      idKey: 'id', // response field is lowercase
+      cursorIdKey: 'ID', // request sorts/filters by uppercase
+      customKeyForResult: 'tasks'
+    })) {
+      collected.push(...chunk)
+    }
+
+    expect(collected).toHaveLength(120) // not truncated at the first 50
+    expect(warnings).toEqual([])
+    expect(calls).toHaveLength(3) // 50 + 50 + 20
+    expect(calls[0].order).toEqual({ ID: 'ASC' }) // request orders by uppercase ID
+    expect(calls[0].filter['>ID']).toBe(0)
+    expect(calls[1].filter['>ID']).toBe(50) // cursor advanced from the lowercase response id
+    expect(calls[2].filter['>ID']).toBe(100)
+  })
+
+  it('v2 fetchList: a wrong idKey stops after one page AND warns (the reported footgun)', async () => {
+    const { b24 } = makeB24({ version: 'v2', customKey: 'tasks', items: rows(120, 'id'), idField: 'id' })
+    const { logger, warnings } = makeLogger()
+    const action = new FetchListV2(b24, logger)
+
+    const collected: Item[] = []
+    for await (const chunk of action.make<Item>({
+      method: 'tasks.task.list',
+      // idKey omitted → defaults to 'ID', but the items only carry lowercase 'id'
+      customKeyForResult: 'tasks'
+    })) {
+      collected.push(...chunk)
+    }
+
+    expect(collected).toHaveLength(50) // exactly the symptom the user reported
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toMatch(/idKey "ID" is missing/)
+    expect(warnings[0]).toMatch(/cursorIdKey/) // the message points at the fix
+  })
+
+  it('v2 fetchList: without cursorIdKey it defaults to idKey (back-compat)', async () => {
+    const { b24, calls } = makeB24({ version: 'v2', customKey: 'items', items: rows(75, 'id'), idField: 'id' })
+    const { logger, warnings } = makeLogger()
+    const action = new FetchListV2(b24, logger)
+
+    const collected: Item[] = []
+    for await (const chunk of action.make<Item>({
+      method: 'crm.item.list',
+      idKey: 'id',
+      customKeyForResult: 'items'
+    })) {
+      collected.push(...chunk)
+    }
+
+    expect(collected).toHaveLength(75)
+    expect(warnings).toEqual([])
+    expect(calls[0].order).toEqual({ id: 'ASC' }) // cursorIdKey === idKey
+    expect(calls[1].filter['>id']).toBe(50)
+  })
+
+  it('v2 callList: tasks-like decoupling returns every record in one array', async () => {
+    const { b24, calls } = makeB24({ version: 'v2', customKey: 'tasks', items: rows(120, 'id'), idField: 'id' })
+    const { logger } = makeLogger()
+    const action = new CallListV2(b24, logger)
+
+    const result = await action.make<Item>({
+      method: 'tasks.task.list',
+      idKey: 'id',
+      cursorIdKey: 'ID',
+      customKeyForResult: 'tasks'
+    })
+
+    expect(result.isSuccess).toBe(true)
+    expect(result.getData()).toHaveLength(120)
+    expect(calls[1].filter['>ID']).toBe(50)
+  })
+
+  it('v3 fetchList: cursorIdKey drives order + the [field,>,n] triple, keeping the user filter', async () => {
+    const { b24, calls } = makeB24({ version: 'v3', customKey: 'items', items: rows(120, 'id'), idField: 'id' })
+    const { logger } = makeLogger()
+    const action = new FetchListV3(b24, logger)
+
+    const collected: Item[] = []
+    for await (const chunk of action.make<Item>({
+      method: 'some.list',
+      params: { filter: [['active', '=', 'Y']] },
+      idKey: 'id',
+      cursorIdKey: 'ID',
+      customKeyForResult: 'items'
+    })) {
+      collected.push(...chunk)
+    }
+
+    expect(collected).toHaveLength(120)
+    expect(calls[0].order).toEqual({ ID: 'ASC' })
+    expect(calls[1].filter).toContainEqual(['active', '=', 'Y']) // existing filter preserved
+    expect(calls[1].filter).toContainEqual(['ID', '>', 50]) // advanced cursor on cursorIdKey
+  })
+
+  it('v3 callList: tasks-like decoupling returns every record', async () => {
+    const { b24, calls } = makeB24({ version: 'v3', customKey: 'items', items: rows(110, 'id'), idField: 'id' })
+    const { logger } = makeLogger()
+    const action = new CallListV3(b24, logger)
+
+    const result = await action.make<Item>({
+      method: 'some.list',
+      idKey: 'id',
+      cursorIdKey: 'ID',
+      customKeyForResult: 'items'
+    })
+
+    expect(result.isSuccess).toBe(true)
+    expect(result.getData()).toHaveLength(110)
+    expect(calls[1].filter).toContainEqual(['ID', '>', 50])
+  })
+})

--- a/test/integration/core/list-cursor-id-key.unit.spec.ts
+++ b/test/integration/core/list-cursor-id-key.unit.spec.ts
@@ -126,7 +126,8 @@ describe('list helpers cursorIdKey (issue #185)', () => {
 
     expect(collected).toHaveLength(50) // exactly the symptom the user reported
     expect(warnings).toHaveLength(1)
-    expect(warnings[0]).toMatch(/idKey "ID" is missing/)
+    expect(warnings[0]).toMatch(/idKey "ID"/)
+    expect(warnings[0]).toMatch(/no numeric id could be read/)
     expect(warnings[0]).toMatch(/cursorIdKey/) // the message points at the fix
   })
 
@@ -204,5 +205,106 @@ describe('list helpers cursorIdKey (issue #185)', () => {
     expect(result.isSuccess).toBe(true)
     expect(result.getData()).toHaveLength(110)
     expect(calls[1].filter).toContainEqual(['ID', '>', 50])
+  })
+
+  // ── review follow-ups (#191): negative + edge cases ──────────────────────
+
+  it('v2 fetchList: a clean short last page does NOT warn', async () => {
+    const { b24, calls } = makeB24({ version: 'v2', customKey: 'items', items: rows(30, 'id'), idField: 'id' })
+    const { logger, warnings } = makeLogger()
+    const collected: Item[] = []
+    for await (const chunk of new FetchListV2(b24, logger).make<Item>({
+      method: 'crm.item.list', idKey: 'id', customKeyForResult: 'items'
+    })) {
+      collected.push(...chunk)
+    }
+    expect(collected).toHaveLength(30)
+    expect(calls).toHaveLength(1) // one short page, no second request
+    expect(warnings).toEqual([]) // a short final page is a clean stop, not a misconfig
+  })
+
+  it('v2 fetchList: an empty result set yields nothing and does not warn', async () => {
+    const { b24 } = makeB24({ version: 'v2', customKey: 'items', items: rows(0, 'id'), idField: 'id' })
+    const { logger, warnings } = makeLogger()
+    const collected: Item[] = []
+    for await (const chunk of new FetchListV2(b24, logger).make<Item>({
+      method: 'crm.item.list', idKey: 'id', customKeyForResult: 'items'
+    })) {
+      collected.push(...chunk)
+    }
+    expect(collected).toHaveLength(0)
+    expect(warnings).toEqual([])
+  })
+
+  it('v2 fetchList: a full page of non-numeric ids warns and stops — never sends a NaN cursor', async () => {
+    let calls = 0
+    const make = async () => {
+      calls += 1
+      return {
+        isSuccess: true,
+        getData: () => ({ result: { items: Array.from({ length: 50 }, (_, i) => ({ id: `guid-${i}` })) } })
+      } as never
+    }
+    const { logger, warnings } = makeLogger()
+    const collected: Item[] = []
+    for await (const chunk of new FetchListV2({ actions: { v2: { call: { make } } } } as never, logger).make<Item>({
+      method: 'x.list', idKey: 'id', customKeyForResult: 'items'
+    })) {
+      collected.push(...chunk)
+    }
+    expect(collected).toHaveLength(50) // stopped after the first full page
+    expect(calls).toBe(1) // crucial: no second request carrying a NaN cursor
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toMatch(/no numeric id could be read/)
+  })
+
+  it('v2 callList: returns !isSuccess and surfaces errors when the API fails', async () => {
+    const make = async () => ({
+      isSuccess: false,
+      getErrorMessages: () => ['boom'],
+      errors: [[0, new Error('boom')]]
+    } as never)
+    const { logger } = makeLogger()
+    const result = await new CallListV2({ actions: { v2: { call: { make } } } } as never, logger).make<Item>({
+      method: 'x.list', idKey: 'id', customKeyForResult: 'items'
+    })
+    expect(result.isSuccess).toBe(false)
+    expect(result.getErrorMessages().join(' ')).toMatch(/boom/)
+  })
+
+  it('v3 fetchList: without cursorIdKey it defaults to idKey "id"', async () => {
+    const { b24, calls } = makeB24({ version: 'v3', customKey: 'items', items: rows(60, 'id'), idField: 'id' })
+    const { logger, warnings } = makeLogger()
+    const collected: Item[] = []
+    for await (const chunk of new FetchListV3(b24, logger).make<Item>({
+      method: 'main.eventlog.list', customKeyForResult: 'items'
+    })) {
+      collected.push(...chunk)
+    }
+    expect(collected).toHaveLength(60)
+    expect(warnings).toEqual([])
+    expect(calls[0].order).toEqual({ id: 'ASC' }) // default idKey 'id' drives the request
+    expect(calls[1].filter).toContainEqual(['id', '>', 50])
+  })
+
+  it('v3 callList: warns and stops on a full page whose idKey is missing', async () => {
+    let calls = 0
+    const make = async () => {
+      calls += 1
+      return {
+        isSuccess: true,
+        getData: () => ({ result: { items: Array.from({ length: 50 }, (_, i) => ({ id: String(i) })) } }),
+        getErrorMessages: () => [],
+        errors: []
+      } as never
+    }
+    const { logger, warnings } = makeLogger()
+    const result = await new CallListV3({ actions: { v3: { call: { make } } } } as never, logger).make<Item>({
+      method: 'x.list', idKey: 'WRONG', customKeyForResult: 'items'
+    })
+    expect(result.getData()).toHaveLength(50)
+    expect(calls).toBe(1)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toMatch(/idKey "WRONG"/)
   })
 })


### PR DESCRIPTION
## Problem

`callList` / `fetchList` (v2 and v3) drove three things from a single `idKey`:
- the request `order` field,
- the `>` cursor filter (v2) / `[idKey, '>', n]` triple (v3),
- the response read (`lastItem[idKey]`).

That only works when the request field name equals the response field name. **`tasks.task.list` breaks it**: per the [official docs](https://apidocs.bitrix24.com/api-reference/tasks/tasks-task-list.html) it sorts and filters by `ID` (uppercase) but returns each task with a lowercase `id`. So:

- `idKey: 'ID'` (the v2 default) → the request is correct, but `lastItem['ID']` is `undefined` → pagination **silently stops after the first 50 records** (the symptom reported in #185);
- `idKey: 'id'` → the response read works, but the request orders/filters by a lowercase field `tasks.task.list` does not accept.

The `b24jssdk-rest` skill cheat sheet even recommended the broken `idKey: 'ID'` for `tasks.task.list` — likely how the reporter got there.

## Fix

Add an optional `cursorIdKey` to all four list helpers:

- `idKey` — the id field **as it appears in the response** (the cursor reads its value);
- `cursorIdKey` — the field used in the **request** for `order` and the `>` page filter; **defaults to `idKey`**.

For tasks: `idKey: 'id', cursorIdKey: 'ID'`. Existing callers are unaffected — the default keeps request == response.

Also: when a full page returns but `idKey` can't be read from its items, the helper now logs a `warning` that names `idKey` / `cursorIdKey` and stops, instead of silently truncating at one page.

```ts
// tasks.task.list — request sorts/filters by ID, response carries id
const generator = $b24.actions.v2.fetchList.make({
  method: 'tasks.task.list',
  params: { filter: { RESPONSIBLE_ID: 1 }, select: ['ID', 'TITLE'] },
  idKey: 'id',        // read task.id from the response
  cursorIdKey: 'ID',  // order + ">ID" page filter in the request
  customKeyForResult: 'tasks'
})
```

## Changes

- `packages/jssdk/src/core/actions/v{2,3}/{call,fetch}-list.ts` — `cursorIdKey` option (drives `order` + the `>` cursor); `idKey` still reads the response; diagnostic `warning`
- `test/integration/core/list-cursor-id-key.unit.spec.ts` — 6 portal-free unit tests (tasks pagination, the silent-50 footgun + warning, back-compat, all 4 helpers)
- docs — 4 list-helper pages: param table (`idKey` clarified + `cursorIdKey` row), a `tasks.task.list` example, Limitations wording, `audited: 2026-06-12`
- `skills/b24jssdk-rest/SKILL.md` — corrected cheat sheet (request vs response columns) + anti-pattern
- `CHANGELOG.md` — Bug Fixes entry

## Verification

- `vitest run --project jsSdk:unit` → **66/66** (6 new)
- `package-jssdk:typecheck` / `package-jssdk:build` → clean
- `docs-lint --strict` → 0/0 · `docs-link-check` → 0 broken · `docs-typecheck` → 111 blocks, 0 errors
- `eslint` on changed files → clean

Closes #185.

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_