### PR TITLE
fix(nuxt): derive module meta.version from package.json at build time

### DIFF
--- a/.github/contributing/package-structure.md
+++ b/.github/contributing/package-structure.md
@@ -1,6 +1,6 @@
 # Package Structure
 
-<sub>Last reviewed: 2026-05-29.</sub>
+<sub>Last reviewed: 2026-06-12.</sub>
 
 > **Agent-facing mirror:** the published surface from the angle of agents writing usage code lives in [`.claude/skills/b24jssdk-core/`](../../.claude/skills/b24jssdk-core/SKILL.md), [`b24jssdk-frame-ui/`](../../.claude/skills/b24jssdk-frame-ui/SKILL.md), and [`b24jssdk-helpers/`](../../.claude/skills/b24jssdk-helpers/SKILL.md). Keep this guide and those skills in sync when the underlying API changes.
 

--- a/.github/contributing/package-structure.md
+++ b/.github/contributing/package-structure.md
@@ -196,9 +196,9 @@ Internal-only helpers go to `src/core/tools/`. Do not export those from `index.t
 
 ## Build Tokens
 
-The build replaces these placeholders at bundle time (see [packages/jssdk/build.config.ts](../../packages/jssdk/build.config.ts)):
+The build replaces these placeholders at bundle time (see [packages/jssdk/build.config.ts](../../packages/jssdk/build.config.ts), and [packages/jssdk-nuxt/build.config.ts](../../packages/jssdk-nuxt/build.config.ts) for the Nuxt module's `meta.version`):
 
-- `__SDK_VERSION__` → the `version` from `packages/jssdk/package.json`
+- `__SDK_VERSION__` → the `version` from `packages/jssdk/package.json` (the Nuxt module injects the same token from `packages/jssdk-nuxt/package.json` into its `meta.version`)
 - `__SDK_USER_AGENT__` → the user-agent string sent on REST calls
 
 Use the placeholders directly — never read `package.json` at runtime, never hard-code a version string.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,24 @@ jobs:
         # tsconfig "extends". jssdk must be built first so @bitrix24/b24jssdk resolves.
         run: pnpm --filter ./packages/jssdk-nuxt build
 
+      - name: Verify jssdk-nuxt version token was replaced (#119)
+        # The real build (above, not the dev:prepare stub) must substitute the
+        # __SDK_VERSION__ placeholder in meta.version from package.json. Catch a
+        # build-config regression here, on every PR — not only at publish time.
+        shell: bash
+        run: |
+          PKG_VER=$(node -p "require('./packages/jssdk-nuxt/package.json').version")
+          DIST=packages/jssdk-nuxt/dist/module.mjs
+          if grep -q "__SDK_VERSION__" "$DIST"; then
+            echo "::error::__SDK_VERSION__ left unreplaced in $DIST — check packages/jssdk-nuxt/build.config.ts"
+            exit 1
+          fi
+          if ! grep -qF "\"$PKG_VER\"" "$DIST"; then
+            echo "::error::version \"$PKG_VER\" (from package.json) not found in $DIST — wrong or empty replacement"
+            exit 1
+          fi
+          echo "jssdk-nuxt meta.version = $PKG_VER (token replaced) — OK"
+
   # Verifies that the documentation site generates cleanly on every PR.
   # Previously this only ran in deploy.yml (push to main), so broken doc
   # builds could slip through undetected.

--- a/.github/workflows/npm-publish-js-sdk-nuxt.yml
+++ b/.github/workflows/npm-publish-js-sdk-nuxt.yml
@@ -80,11 +80,17 @@ jobs:
       - name: Verify version token was replaced
         shell: bash
         run: |
-          if grep -q "__SDK_VERSION__" packages/jssdk-nuxt/dist/module.mjs; then
-            echo "::error::__SDK_VERSION__ was not replaced in dist/module.mjs — check packages/jssdk-nuxt/build.config.ts (#119)"
+          PKG_VER=$(node -p "require('./packages/jssdk-nuxt/package.json').version")
+          DIST=packages/jssdk-nuxt/dist/module.mjs
+          if grep -q "__SDK_VERSION__" "$DIST"; then
+            echo "::error::__SDK_VERSION__ was not replaced in $DIST — check packages/jssdk-nuxt/build.config.ts (#119)"
             exit 1
           fi
-          echo "module.mjs version token replaced — OK"
+          if ! grep -qF "\"$PKG_VER\"" "$DIST"; then
+            echo "::error::version \"$PKG_VER\" (from package.json) not found in $DIST — wrong or empty replacement"
+            exit 1
+          fi
+          echo "module.mjs meta.version = $PKG_VER (token replaced) — OK"
 
       - name: 'Publish NUXT 🚀'
         shell: bash

--- a/.github/workflows/npm-publish-js-sdk-nuxt.yml
+++ b/.github/workflows/npm-publish-js-sdk-nuxt.yml
@@ -77,6 +77,15 @@ jobs:
       - name: Build
         run: pnpm --filter ./packages/jssdk-nuxt build
 
+      - name: Verify version token was replaced
+        shell: bash
+        run: |
+          if grep -q "__SDK_VERSION__" packages/jssdk-nuxt/dist/module.mjs; then
+            echo "::error::__SDK_VERSION__ was not replaced in dist/module.mjs — check packages/jssdk-nuxt/build.config.ts (#119)"
+            exit 1
+          fi
+          echo "module.mjs version token replaced — OK"
+
       - name: 'Publish NUXT 🚀'
         shell: bash
         run: pnpm --filter ./packages/jssdk-nuxt publish --no-git-checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ packages/
 │   │   └── index.ts                # public surface — treat as a contract
 │   ├── README-AI.md                # caller-facing API guide (being absorbed into this guide)
 │   └── build.config.ts             # unbuild config (replaces __SDK_VERSION__ etc.)
-├── jssdk-nuxt/                     # Nuxt module — only registers runtime/plugin
+├── jssdk-nuxt/                     # Nuxt module (registers runtime/plugin; build.config.ts injects __SDK_VERSION__ into meta.version)
 playgrounds/
 ├── cli/                            # Node smoke
 └── nuxt/                           # Nuxt smoke (live SDK)
@@ -76,7 +76,7 @@ Cross-cutting modules:
 - [packages/jssdk/src/types](packages/jssdk/src/types) — public types and enums (CRM, catalog, bizproc, event, placement, pull, payloads, etc.). Prefer importing enums like `EnumCrmEntityTypeId` from the package root.
 - [packages/jssdk/src/tools](packages/jssdk/src/tools) — `Text` (Luxon dates, number/format helpers, UUID v7), `Type` runtime guards, `Browser`, `useFormatters`, `pick / omit / getEnumValue`, scroll/environment utilities.
 - [packages/jssdk/src/logger](packages/jssdk/src/logger) — `LoggerBrowser.build(name, isDev)` + `LoggerFactory`. `AbstractB24` defaults to `LoggerFactory.createNullLogger()`; a real logger is installed via `b24.setLogger(logger)`.
-- The build-time tokens `__SDK_VERSION__` and `__SDK_USER_AGENT__` are replaced by unbuild ([packages/jssdk/build.config.ts](packages/jssdk/build.config.ts)).
+- The build-time tokens `__SDK_VERSION__` and `__SDK_USER_AGENT__` are replaced by unbuild ([packages/jssdk/build.config.ts](packages/jssdk/build.config.ts)). The Nuxt module replaces `__SDK_VERSION__` the same way for its `meta.version` ([packages/jssdk-nuxt/build.config.ts](packages/jssdk-nuxt/build.config.ts)).
 
 The Nuxt module ([packages/jssdk-nuxt/src/module.ts](packages/jssdk-nuxt/src/module.ts)) is intentionally tiny — it only registers [packages/jssdk-nuxt/src/runtime/plugin.ts](packages/jssdk-nuxt/src/runtime/plugin.ts). Any new SDK surface that needs Nuxt auto-import / SSR handling has to be wired through that runtime plugin.
 
@@ -171,7 +171,7 @@ pnpm vitest run --project jsSdk:unit -t "<test name>"
 - **Public contract**: exports from [packages/jssdk/src/index.ts](packages/jssdk/src/index.ts) are a public API. Any breaking change needs a deprecation cycle, not a silent rename.
 - **Cross-package awareness**: when you change the core SDK API, check whether [packages/jssdk-nuxt/src/runtime/plugin.ts](packages/jssdk-nuxt/src/runtime/plugin.ts) needs an update.
 - **Code formatting**: `@nuxt/eslint-config` (flat) with stylistic overrides — 2-space indent, no trailing commas, 1tbs braces. `.editorconfig` enforces LF + 2 spaces. The protobuf JS files in `packages/jssdk/src/pullClient` are eslint-ignored intentionally.
-- **Build tokens**: `__SDK_VERSION__` and `__SDK_USER_AGENT__` are replaced at build time by [packages/jssdk/build.config.ts](packages/jssdk/build.config.ts). Do not hard-code versions.
+- **Build tokens**: `__SDK_VERSION__` and `__SDK_USER_AGENT__` are replaced at build time by [packages/jssdk/build.config.ts](packages/jssdk/build.config.ts); the Nuxt module's `meta.version` uses the same `__SDK_VERSION__` token via [packages/jssdk-nuxt/build.config.ts](packages/jssdk-nuxt/build.config.ts). Do not hard-code versions.
 - **English only** in code, comments, and documentation pages.
 
 ## SDK Source (`packages/jssdk/src/` and `test/`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-<sub>Last reviewed: 2026-06-11.</sub>
+<sub>Last reviewed: 2026-06-12.</sub>
 
 This file is the single source of truth for AI coding agents and human contributors working on the `@bitrix24/b24jssdk` repository. The four detailed guides under `.github/contributing/` are referenced from the relevant sections below — load them only when they apply to your task.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Chore
 
 * **docs-lint:** audit-freshness now tracks source-code link targets only — Markdown sources (skills, `AGENTS.md`, `CHANGELOG.md`) no longer staleify the pages that cite them, removing the 1→N `audited:` bump cascade on every skill/changelog edit (#190)
+* **build(nuxt):** the Nuxt module's `meta.version` is now injected from `package.json` at build time via the `__SDK_VERSION__` token (matching the core SDK) instead of a hand-maintained literal in `module.ts`, so `release:bump` can no longer leave it stale; the publish workflow also fails if the token is left unreplaced (#119)
 
 ## [1.2.0](https://github.com/bitrix24/b24jssdk/compare/v1.1.2...v1.2.0) (2026-05-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Chore
 
 * **docs-lint:** audit-freshness now tracks source-code link targets only — Markdown sources (skills, `AGENTS.md`, `CHANGELOG.md`) no longer staleify the pages that cite them, removing the 1→N `audited:` bump cascade on every skill/changelog edit (#190)
-* **build(nuxt):** the Nuxt module's `meta.version` is now injected from `package.json` at build time via the `__SDK_VERSION__` token (matching the core SDK) instead of a hand-maintained literal in `module.ts`, so `release:bump` can no longer leave it stale; the publish workflow also fails if the token is left unreplaced (#119)
+* **nuxt:** the Nuxt module's `meta.version` is now injected from `package.json` at build time via the `__SDK_VERSION__` token (matching the core SDK) instead of a hand-maintained literal in `module.ts`, so `release:bump` can no longer leave it stale; CI and the publish workflow both fail if the token is left unreplaced (#119)
 
 ## [1.2.0](https://github.com/bitrix24/b24jssdk/compare/v1.1.2...v1.2.0) (2026-05-29)
 

--- a/packages/jssdk-nuxt/build.config.ts
+++ b/packages/jssdk-nuxt/build.config.ts
@@ -1,8 +1,20 @@
 import { defineBuildConfig } from 'unbuild'
+import packageInfo from './package.json'
 
+// Single source of truth for the module version: the `version: '__SDK_VERSION__'`
+// placeholder in src/module.ts is replaced from package.json at build time — the
+// same mechanism the core SDK uses for `__SDK_VERSION__` (see
+// packages/jssdk/build.config.ts). Keeps meta.version from drifting (#119).
 export default defineBuildConfig({
   entries: [],
-  rollup: {},
+  rollup: {
+    replace: {
+      values: {
+        __SDK_VERSION__: packageInfo.version
+      },
+      preventAssignment: true
+    }
+  },
   hooks: {
     'mkdist:entry:options'(ctx, entry, options) {
       options.addRelativeDeclarationExtensions = false

--- a/packages/jssdk-nuxt/build.config.ts
+++ b/packages/jssdk-nuxt/build.config.ts
@@ -8,6 +8,9 @@ import packageInfo from './package.json'
 export default defineBuildConfig({
   entries: [],
   rollup: {
+    // Only the rolled-up module entry (src/module) is processed here; runtime/*
+    // files go through mkdist and are NOT replaced — keep version tokens out of
+    // runtime code.
     replace: {
       values: {
         __SDK_VERSION__: packageInfo.version

--- a/packages/jssdk-nuxt/src/module.ts
+++ b/packages/jssdk-nuxt/src/module.ts
@@ -5,7 +5,7 @@ export type ModuleOptions = object
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: '@bitrix24/b24jssdk-nuxt',
-    version: '1.2.0',
+    version: '__SDK_VERSION__',
     configKey: 'B24JsSdkNuxt',
     compatibility: {
       nuxt: '>=4.2.2'

--- a/packages/jssdk-nuxt/src/module.ts
+++ b/packages/jssdk-nuxt/src/module.ts
@@ -5,6 +5,8 @@ export type ModuleOptions = object
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: '@bitrix24/b24jssdk-nuxt',
+    // Replaced from package.json at build time by rollup.replace (build.config.ts).
+    // In `dev:prepare` (stub) mode the placeholder is left as-is — expected.
     version: '__SDK_VERSION__',
     configKey: 'B24JsSdkNuxt',
     compatibility: {


### PR DESCRIPTION
## Problem

The Nuxt module's `meta.version` was a hard-coded literal `'1.2.0'` in `src/module.ts` that `release:bump` never touched, so it drifted from package.json on every release (e.g. the literal sat at 1.1.1 while the packages were at 1.1.3) and violated the AGENTS.md "never literal version strings" convention. This was the one hard blocker for cutting 1.3.0 cleanly.

## Fix

Derive it from package.json at build time via the `__SDK_VERSION__` token — the same mechanism the core SDK uses (`packages/jssdk/build.config.ts`):

- `src/module.ts`: `version: '__SDK_VERSION__'`
- `build.config.ts`: rollup `replace` of `__SDK_VERSION__` ← `packageInfo.version`

Single source of truth (package.json); the literal — and the drift — are gone for good.

## Guards (defense-in-depth)

- **CI** (`ci.yml`, every PR): after the real nuxt build, assert the token was replaced — no surviving `__SDK_VERSION__` **and** the package.json version present in `dist/module.mjs`.
- **Publish** (`npm-publish-js-sdk-nuxt.yml`): the same assertion before publishing.

## Verification

- fresh build → `dist/module.mjs` carries `version: "1.2.0"` (from package.json)
- eslint · nuxt typecheck · both workflow YAMLs parse · docs-lint `--strict` 0/0

## Review

Reviewed by 5 specialists (docs, programmer, tester, security, CTO) + a `/review` pass; all findings addressed in-PR (CI guard, positive assertion, doc-convention sync, comments).

Follow-ups (out of scope): a symmetric token guard for the core `jssdk` publish (needs a `.map`-aware grep), and the pre-existing `release.tag_name` interpolation (tracked in #152).

Closes #119.

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_