### PR TITLE
ci: publish pre-releases under the `next` dist-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,20 @@ jobs:
 
       - name: 'Publish 🚀'
         shell: bash
-        run: pnpm --filter ./packages/jssdk publish --no-git-checks
+        run: |
+          VER=$(jq -r .version packages/jssdk/package.json)
+          # A pre-release (e.g. 1.3.0-rc.1) must NOT take the default `latest`
+          # dist-tag, or every `npm install @bitrix24/b24jssdk` would jump onto the
+          # RC. Route pre-releases (version contains a `-`) to `next`; stable
+          # versions keep `latest`.
+          TAG_ARGS=()
+          if [[ "$VER" == *-* ]]; then
+            TAG_ARGS=(--tag next)
+            echo "Pre-release $VER → dist-tag 'next'"
+          else
+            echo "Stable $VER → dist-tag 'latest'"
+          fi
+          pnpm --filter ./packages/jssdk publish --no-git-checks "${TAG_ARGS[@]}"
 
   publish-nuxt:
     # Sequential: only after the core SDK is published, since the published Nuxt
@@ -188,7 +201,18 @@ jobs:
 
       - name: 'Publish NUXT 🚀'
         shell: bash
-        run: pnpm --filter ./packages/jssdk-nuxt publish --no-git-checks
+        run: |
+          VER=$(jq -r .version packages/jssdk-nuxt/package.json)
+          # Pre-release → `next` dist-tag, never `latest` (see publish-jssdk for
+          # the rationale).
+          TAG_ARGS=()
+          if [[ "$VER" == *-* ]]; then
+            TAG_ARGS=(--tag next)
+            echo "Pre-release $VER → dist-tag 'next'"
+          else
+            echo "Stable $VER → dist-tag 'latest'"
+          fi
+          pnpm --filter ./packages/jssdk-nuxt publish --no-git-checks "${TAG_ARGS[@]}"
 
   release-status:
     # Combined gate: green only if BOTH packages actually published. A partial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * **ci:** a release now runs through a single `release.yml` — one CI invocation instead of two, then `@bitrix24/b24jssdk` and `@bitrix24/b24jssdk-nuxt` publish sequentially (core first, since the Nuxt module depends on the released core version) behind a combined status gate, so a partial release turns the run red instead of passing unnoticed. Replaces the two separate `npm-publish-*` workflows; CI also gained an `actionlint` gate so workflow errors are caught on PRs (#177)
 * **ci:** the docs site is built once per push to `main` — `deploy.yml` is removed and its Pages build + deploy fold into `ci.yml` (the `docs-build` job uploads the Pages artifact; a new `deploy` job ships it), eliminating the duplicate `docs:generate` that previously ran in both workflows on every main push. PRs still validate the docs build (#111)
 * **docs:** add a [`RELEASING.md`](RELEASING.md) runbook — the bump → changelog → tag → publish flow (single `release.yml`, npm OIDC trusted publishing, partial-release recovery) plus a bus-factor/handover checklist, so cutting a release is no longer tribal knowledge — though the account-level items (a second npm publisher and a `CODEOWNERS` file) still need a repo/org admin (#171)
+* **ci:** `release.yml` now publishes pre-release versions (e.g. `1.3.0-rc.1`) under the `next` dist-tag instead of `latest`, so a pre-release can't move `npm install` consumers off the last stable release; stable releases are unaffected (#198)
 
 ## [1.2.0](https://github.com/bitrix24/b24jssdk/compare/v1.1.2...v1.2.0) (2026-05-29)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing `@bitrix24/b24jssdk`
 
-<sub>Last reviewed: 2026-06-15.</sub>
+<sub>Last reviewed: 2026-06-16.</sub>
 
 How to cut a release of the two published packages — `@bitrix24/b24jssdk` (core
 SDK) and `@bitrix24/b24jssdk-nuxt` (Nuxt module). They ship **in lockstep at one

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -59,12 +59,10 @@ fires `release.yml`, which runs CI once and publishes both packages.
   `pnpm run release:bump` rewrites all three and refuses to run if they are already
   out of sync — resolve the drift by hand first, then retry.
 - **Pre-releases** (`1.3.0-rc.1`) bump cleanly — the script accepts a `-prerelease`
-  suffix — **but the publish workflow has no pre-release handling yet.** `release.yml`
-  runs `pnpm publish` with no `--tag`, so npm would tag the pre-release as `latest`
-  and move every consumer onto the RC. Until the workflow learns `--tag next`
-  (planned follow-up), **do not cut pre-releases through the release workflow** — or
-  be ready to repair the dist-tags by hand immediately after
-  (`npm dist-tag add <pkg>@<last-stable> latest`).
+  suffix — and publish safely: `release.yml` detects the `-` in the version and ships
+  the package under the **`next`** dist-tag instead of `latest`, so a plain
+  `npm install` (which follows `latest`) stays on the last stable release. Promote a
+  pre-release to stable later with `npm dist-tag add <pkg>@<version> latest`.
 
 ## Step by step
 


### PR DESCRIPTION
## Problem (from the #197 review)

`release.yml` published with no `--tag`, so a **pre-release** version (e.g. `1.3.0-rc.1`) would take npm's default **`latest`** dist-tag — moving every `npm install @bitrix24/b24jssdk` consumer onto the RC. The `release:bump` script accepts `-prerelease` suffixes, so this foot-gun was reachable.

## Fix

Both publish steps now detect a `-` in the version and route pre-releases to the **`next`** dist-tag; stable versions keep `latest`:

```bash
VER=$(jq -r .version packages/jssdk/package.json)
TAG_ARGS=()
if [[ "$VER" == *-* ]]; then
  TAG_ARGS=(--tag next)
  echo "Pre-release $VER → dist-tag 'next'"
else
  echo "Stable $VER → dist-tag 'latest'"
fi
pnpm --filter ./packages/jssdk publish --no-git-checks "${TAG_ARGS[@]}"
```

`RELEASING.md` is updated to match — the *“don’t cut pre-releases”* warning is replaced with “pre-releases publish to `next` automatically; promote with `npm dist-tag add …@<version> latest`.”

## Provenance — investigated, deferred (not in this PR)

The review also suggested adding `--provenance`. I checked: **pnpm 11.4.0's `publish` has no `--provenance` option** (`pnpm publish --help` lists only `--tag`/`--access`/`--otp`/…). Forcing it would break the publish, so it's deferred — it needs either a pnpm version that adds provenance support, or switching the publish step to `npm publish`. That's a bigger, separate decision; happy to open an issue if you want to track it.

## Verification

- `actionlint` 1.7.7 **+ shellcheck 0.10.0** (the exact CI gate) clean on all workflows — the new bash is shellcheck-safe (quoted array expansion, empty-array safe under `set -eo pipefail`).
- Logic: `1.3.0` → `latest`; `1.3.0-rc.1` → `next`. Stable path is byte-for-byte the previous behaviour plus an explicit (default) tag decision.
- A publish can't be dry-run; first real signal is the next release.

_CHANGELOG entry added in a follow-up commit referencing this PR number._

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_