### PR TITLE
test(docs): cover docs-link-check.mjs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * **ci:** the docs site is built once per push to `main` — `deploy.yml` is removed and its Pages build + deploy fold into `ci.yml` (the `docs-build` job uploads the Pages artifact; a new `deploy` job ships it), eliminating the duplicate `docs:generate` that previously ran in both workflows on every main push. PRs still validate the docs build (#111)
 * **docs:** add a [`RELEASING.md`](RELEASING.md) runbook — the bump → changelog → tag → publish flow (single `release.yml`, npm OIDC trusted publishing, partial-release recovery) plus a bus-factor/handover checklist, so cutting a release is no longer tribal knowledge — though the account-level items (a second npm publisher and a `CODEOWNERS` file) still need a repo/org admin (#171)
 * **ci:** `release.yml` now publishes pre-release versions (e.g. `1.3.0-rc.1`) under the `next` dist-tag instead of `latest`, so a pre-release can't move `npm install` consumers off the last stable release; stable releases are unaffected (#198)
+* **test(docs-lint):** add fixture coverage for `scripts/docs-link-check.mjs` — the last untested script in the docs-lint pipeline. Valid internal/index/heading-fragment/frontmatter links pass; a missing page, a missing frontmatter `to:` target, and a missing heading fragment each fail the check. The script gained a `DOCS_LINK_CHECK_ROOT` override so the tests run against a temp fixture instead of the live docs tree (#118)
 
 ## [1.2.0](https://github.com/bitrix24/b24jssdk/compare/v1.1.2...v1.2.0) (2026-05-29)
 

--- a/scripts/__tests__/docs-link-check.test.mjs
+++ b/scripts/__tests__/docs-link-check.test.mjs
@@ -39,7 +39,7 @@ function runDocsLinkCheck(root) {
 }
 
 test('docs-link-check: valid internal pages, index pages, fragments, and frontmatter links pass', () => {
-  withFixture(root => {
+  withFixture((root) => {
     writePage(root, '0.index.md', [
       '---',
       'title: Home',
@@ -97,7 +97,7 @@ test('docs-link-check: valid internal pages, index pages, fragments, and frontma
 })
 
 test('docs-link-check: missing markdown link target exits 1', () => {
-  withFixture(root => {
+  withFixture((root) => {
     writePage(root, '0.index.md', [
       '---',
       'title: Home',
@@ -116,7 +116,7 @@ test('docs-link-check: missing markdown link target exits 1', () => {
 })
 
 test('docs-link-check: missing frontmatter link target exits 1', () => {
-  withFixture(root => {
+  withFixture((root) => {
     writePage(root, '0.index.md', [
       '---',
       'title: Home',
@@ -136,7 +136,7 @@ test('docs-link-check: missing frontmatter link target exits 1', () => {
 })
 
 test('docs-link-check: missing heading fragment exits 1', () => {
-  withFixture(root => {
+  withFixture((root) => {
     writePage(root, '0.index.md', [
       '---',
       'title: Home',

--- a/scripts/__tests__/docs-link-check.test.mjs
+++ b/scripts/__tests__/docs-link-check.test.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// Fixture tests for scripts/docs-link-check.mjs.
+//
+// Run with: node --test scripts/__tests__/docs-link-check.test.mjs
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const DOCS_LINK_CHECK = resolve(__dirname, '..', 'docs-link-check.mjs')
+
+function writePage(root, relPath, lines) {
+  const file = join(root, ...relPath.split('/'))
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, `${lines.join('\n')}\n`, 'utf8')
+}
+
+function withFixture(run) {
+  const root = mkdtempSync(join(tmpdir(), 'docs-link-check-'))
+  try {
+    return run(root)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function runDocsLinkCheck(root) {
+  return spawnSync(process.execPath, [DOCS_LINK_CHECK], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, DOCS_LINK_CHECK_ROOT: root },
+    encoding: 'utf8'
+  })
+}
+
+test('docs-link-check: valid internal pages, index pages, fragments, and frontmatter links pass', () => {
+  withFixture(root => {
+    writePage(root, '0.index.md', [
+      '---',
+      'title: Home',
+      'links:',
+      '  - label: Guide',
+      '    to: /docs/guide/intro/',
+      '  - label: External',
+      '    to: https://example.com/ignored',
+      '---',
+      '',
+      '# Home',
+      '',
+      'See [intro](/docs/guide/intro/) and [directory](/docs/directory/).',
+      'See [heading](/docs/guide/with-headings/#some-section).',
+      'See [duplicate heading](/docs/guide/with-headings/#repeated-1).',
+      'External links like [example](https://example.com/no-check) are ignored.',
+      'GitHub blob URLs like [source](https://github.com/bitrix24/b24jssdk/blob/main/missing.md) are ignored.'
+    ])
+
+    writePage(root, '1.guide/1.intro.md', [
+      '---',
+      'title: Intro',
+      '---',
+      '',
+      '# Intro'
+    ])
+
+    writePage(root, '1.guide/2.with-headings.md', [
+      '---',
+      'title: Headings',
+      '---',
+      '',
+      '# Page',
+      '',
+      '## Some Section',
+      '',
+      '## Repeated',
+      '',
+      '## Repeated'
+    ])
+
+    writePage(root, '2.directory/0.index.md', [
+      '---',
+      'title: Directory',
+      '---',
+      '',
+      '# Directory'
+    ])
+
+    const r = runDocsLinkCheck(root)
+    assert.equal(r.status, 0, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+    assert.match(r.stdout, /0 broken link\(s\)/)
+    assert.match(r.stdout, /1 warning\(s\)/)
+  })
+})
+
+test('docs-link-check: missing markdown link target exits 1', () => {
+  withFixture(root => {
+    writePage(root, '0.index.md', [
+      '---',
+      'title: Home',
+      '---',
+      '',
+      '# Home',
+      '',
+      'See [missing](/docs/missing/).'
+    ])
+
+    const r = runDocsLinkCheck(root)
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+    assert.match(r.stdout, /broken internal link/)
+    assert.match(r.stdout, /no matching page/)
+  })
+})
+
+test('docs-link-check: missing frontmatter link target exits 1', () => {
+  withFixture(root => {
+    writePage(root, '0.index.md', [
+      '---',
+      'title: Home',
+      'links:',
+      '  - label: Missing',
+      '    to: /docs/missing/',
+      '---',
+      '',
+      '# Home'
+    ])
+
+    const r = runDocsLinkCheck(root)
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+    assert.match(r.stdout, /broken internal link/)
+    assert.match(r.stdout, /no matching page/)
+  })
+})
+
+test('docs-link-check: missing heading fragment exits 1', () => {
+  withFixture(root => {
+    writePage(root, '0.index.md', [
+      '---',
+      'title: Home',
+      '---',
+      '',
+      '# Home',
+      '',
+      'See [missing heading](/docs/guide/#missing-section).'
+    ])
+
+    writePage(root, '1.guide/0.index.md', [
+      '---',
+      'title: Guide',
+      '---',
+      '',
+      '# Guide',
+      '',
+      '## Existing Section'
+    ])
+
+    const r = runDocsLinkCheck(root)
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+    assert.match(r.stdout, /broken fragment/)
+    assert.match(r.stdout, /missing-section/)
+  })
+})

--- a/scripts/docs-link-check.mjs
+++ b/scripts/docs-link-check.mjs
@@ -7,7 +7,9 @@ import { walkMarkdownFiles, parseFrontmatter } from './_docs-utils.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..')
-const DOCS_ROOT = join(REPO_ROOT, 'docs', 'content', 'docs')
+const DOCS_ROOT = process.env.DOCS_LINK_CHECK_ROOT
+  ? resolve(process.env.DOCS_LINK_CHECK_ROOT)
+  : join(REPO_ROOT, 'docs', 'content', 'docs')
 const URL_PREFIX = '/docs/'
 
 let errors = 0


### PR DESCRIPTION
## What

Adds the missing unit coverage for **`scripts/docs-link-check.mjs`** — the last script in the docs-lint pipeline without tests (`docs-lint.mjs` and `docs-typecheck.mjs` already have fixtures). Closes #118.

- `docs-link-check.mjs` gains a `DOCS_LINK_CHECK_ROOT` env override so tests can point it at a temp fixture tree instead of the live `docs/content/docs/`.
- `scripts/__tests__/docs-link-check.test.mjs` — 4 fixture tests covering every case from #118's acceptance criteria:
  - ✅ valid internal `/docs/...` links, directory `0.index.md` pages, heading fragments (incl. a `-1` collision suffix), and frontmatter `links: to:` all pass; external + GitHub blob URLs are ignored;
  - ❌ a missing page, a missing frontmatter target, and a missing heading fragment each fail with exit 1.

## Credit / provenance

This is **@echooo-agent's** work from #126, cherry-picked onto current `main` (their authorship is preserved in the first commit). #126 was opened against a months-old `main` from a fork; rather than ask for a rebase, I took it over. My follow-up commit only:
- ran `eslint --fix` on the new test (it tripped `@stylistic/arrow-parens`: `root =>` → `(root) =>`), which would have reddened the `lint` job;
- added the CHANGELOG entry.

Supersedes #126 (will close it with thanks).

## Verification (against current main)

- Full docs-lint test glob (what CI runs): **34/34 pass** (`node --test "scripts/__tests__/**/*.test.mjs"`).
- `eslint scripts/__tests__/docs-link-check.test.mjs` — clean.
- Real `node scripts/docs-link-check.mjs` (env unset) — `0 broken / 0 warnings`; the env override doesn't affect normal runs.

Closes #118.

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_