### PR TITLE
docs(llms-txt): remove the unused Nuxt-config link from the LLMs.txt page

### DIFF
--- a/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
+++ b/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
@@ -2,10 +2,6 @@
 title: LLMs.txt
 description: 'How to get AI tools like Cursor, Windsurf, GitHub Copilot, ChatGPT, and Claude to understand Bitrix24 JS SDK methods, tools, and best practices.'
 audited: 2026-06-02
-links:
-  - label: Nuxt config (nuxt-llms)
-    iconName: GitHubIcon
-    to: https://github.com/bitrix24/b24jssdk/blob/main/docs/nuxt.config.ts
 ---
 
 ## What is LLMs.txt?


### PR DESCRIPTION
## What

Removes the lone `links:` frontmatter block from the **LLMs.txt** getting-started page (`docs/content/docs/1.getting-started/7.ai/2.llms-txt.md`). Its single entry deep-linked to the internal `docs/nuxt.config.ts` — build config, not anything reader-facing — so on an end-user "how to use `/llms.txt` with Cursor/ChatGPT/Claude" guide it was just noise (the sibling `skills.md` page keeps its `links:` because those point at genuinely useful `skills/` + `AGENTS.md`). Closes #130.

## Credit / provenance

This is **@ded-furby's** work from #132, cherry-picked onto current `main` (authorship preserved). #132 was opened against an older `main` from a fork; rather than ask for a rebase I took it over. The commit is unchanged — it's a clean 4-line frontmatter deletion, no follow-up needed.

Supersedes #132 (will close it with thanks).

## Verification (against current main)

- `docs-lint --strict` — clean (the page keeps its `audited:` stamp; removing its only source-link target leaves nothing to staleify).
- `docs-link-check` — `0 broken / 0 warnings`.
- Frontmatter-only change → no eslint/type surface; CI's `docs-build` will confirm the page still prerenders (now without a header-links rail, as expected).

## Note (out of scope here)

#130 also asks for the same removal on the **RU** docs — that's a separate surface (this repo is English-only per `AGENTS.md`), so it's for whoever maintains the RU docs, not this PR.

Closes #130.

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_