### PR TITLE
fix(ci): grant Pages permissions to the ci caller in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,16 @@ concurrency:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
+    # ci.yml's `deploy` job declares `pages: write` + `id-token: write`. A called
+    # reusable workflow cannot request more than its caller grants, and GitHub
+    # validates this at startup — before the job-level `if:` that skips `deploy`
+    # on a release is ever evaluated — so the run fails immediately with
+    # `startup_failure` unless the caller grants these here. `deploy` itself stays
+    # skipped during a release (its `if:` gates on `github.workflow == 'ci'`).
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
 
   publish-jssdk:
     needs: ci


### PR DESCRIPTION
## Problem

The first real run of `release.yml` (triggered by publishing the `v1.3.0` GitHub Release) failed with **`startup_failure`** after ~1 second — before any job ran, so **nothing was published to npm**.

[Failed run →](https://github.com/bitrix24/b24jssdk/actions/runs/27619724734)

## Root cause

`release.yml` sets `permissions: contents: read` at the top level and calls `ci.yml` as a reusable workflow (`uses: ./.github/workflows/ci.yml`). `ci.yml`'s `deploy` job declares:

```yaml
permissions:
  pages: write
  id-token: write
```

A called reusable workflow **cannot request more permissions than its caller grants**, and GitHub validates this **at startup — before** the job-level `if:` that skips `deploy` on a release is ever evaluated. So the run fails immediately, even though `deploy` would have been skipped anyway (its `if:` gates on `github.workflow == 'ci'`).

## Fix

Grant the required permissions on the `ci` caller job in `release.yml`:

```yaml
jobs:
  ci:
    uses: ./.github/workflows/ci.yml
    permissions:
      contents: read
      pages: write
      id-token: write
```

`deploy` still stays skipped during a release (its `github.workflow == 'ci'` guard), so this only satisfies GitHub's startup-time permission check — it does not cause a Pages deploy on release.

## Re-publishing v1.3.0 after merge

The `v1.3.0` tag points at a commit without this fix, so re-running the failed release run won't help. After this merges to `main`, publish via **Actions → release 🚀 → Run workflow** on `main` (`workflow_dispatch`): the publish jobs run because their `if:` allows `workflow_dispatch && github.ref == 'refs/heads/main'`, and the version guards confirm `@bitrix24/b24jssdk@1.3.0` isn't yet on npm.

https://claude.ai/code/session_01MwRNWz8fyZHxPZPq3n2FYD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwRNWz8fyZHxPZPq3n2FYD)_