### PR TITLE
docs+skills: fix v3 API accuracy — #163 broken call snippets, #164 phantom aggregate action

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: CallV2.make
 description: 'A method for making Bitrix24 REST API version 2 calls.'
 category: 'actions'
-audited: 2026-06-11
+audited: 2026-06-17
 restApiVersion: 'rest-api-ver2'
 navigation.title: Call
 links:
@@ -44,7 +44,7 @@ The method returns a `Promise` with an `AjaxResult`{lang="ts-type"} object conta
 import { EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
 
 const response = await $b24.actions.v2.call.make({
-  method: 'crm.contact.get',
+  method: 'crm.item.get',
   params: {
     entityTypeId: EnumCrmEntityTypeId.contact,
     id: 123

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
@@ -67,7 +67,7 @@ The `options` object contains the following properties:
 
 | Parameter | Type | Required | Description |
 |----|----|----|----|
-| **`method`** | `string`{lang="ts-type"} | Yes | REST API method name (e.g., `crm.contact.get`, `tasks.task.get`). |
+| **`method`** | `string`{lang="ts-type"} | Yes | REST API method name (e.g., `crm.item.get`, `tasks.task.get`). |
 | **`params`** | `TypeCallParams`{lang="ts-type"} | No | Object with parameters to pass to the REST API method. |
 | **`requestId`** | `string`{lang="ts-type"} | No | Unique request identifier for tracking. Used for request deduplication and debugging. |
 

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallV3.make
 description: 'Method for making Bitrix24 REST API version 3 calls.'
 category: 'actions'
-audited: 2026-06-11
+audited: 2026-06-17
 restApiVersion: 'rest-api-ver3'
 navigation.title: Call
 links:
@@ -58,7 +58,7 @@ The `options` object contains the following properties:
 
 | Parameter | Type | Required | Description |
 |----|----|----|----|
-| **`method`** | `string`{lang="ts-type"} | Yes | REST API method name (e.g., `crm.contact.get`, `tasks.task.get`). |
+| **`method`** | `string`{lang="ts-type"} | Yes | REST API method name (e.g., `tasks.task.get`, `tasks.task.add`). |
 | **`params`** | `TypeCallParams`{lang="ts-type"} | No | Object with parameters to pass to the REST API method. |
 | **`requestId`** | `string`{lang="ts-type"} | No | Unique request identifier for tracking. Used for request deduplication and debugging. |
 
@@ -108,10 +108,10 @@ name: 'call-rest-api-ver3'
 
 ## Long-Running Requests
 
-Heavy non-idempotent methods like `crm.documentgenerator.document.add`
-routinely exceed the default 30-second axios timeout. On a timeout the SDK
-retries by default, which can create **duplicate entities** server-side (see
-[issue #24](https://github.com/bitrix24/b24jssdk/issues/24)).
+Non-idempotent methods that create or persist state — for example
+`tasks.task.add` — can exceed the default 30-second axios timeout on a busy
+portal. On a timeout the SDK retries by default, which can create **duplicate
+entities** server-side (see [issue #24](https://github.com/bitrix24/b24jssdk/issues/24)).
 
 For any method that creates or persists state, raise the axios timeout and
 disable retries on transport errors:
@@ -127,7 +127,7 @@ await $b24.setRestrictionManagerParams({
 })
 
 await $b24.actions.v3.call.make({
-  method: 'crm.deal.add',
+  method: 'tasks.task.add',
   params: {/*…*/}
 })
 ```

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: BatchV2.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 2. Allows executing up to 50 commands in a single API call.'
 category: 'actions'
-audited: 2026-06-11
+audited: 2026-06-17
 restApiVersion: 'rest-api-ver2'
 navigation.title: Batch
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3. Allows executing up to 50 commands in a single API call.'
 category: 'actions'
-audited: 2026-06-11
+audited: 2026-06-17
 restApiVersion: 'rest-api-ver3'
 navigation.title: Batch
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV2.make
 description: 'Method for executing batch requests with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-06-11
+audited: 2026-06-17
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3 with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-06-11
+audited: 2026-06-17
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/6.errors.md
+++ b/docs/content/docs/2.working-with-the-rest-api/6.errors.md
@@ -3,7 +3,7 @@ title: Error codes and handling
 description: 'Reference for SdkError and AjaxError codes raised by the SDK, plus the Bitrix24 REST error codes that surface through them.'
 navigation:
   title: Errors
-audited: 2026-06-11
+audited: 2026-06-17
 links:
   - label: SdkError
     iconName: GitHubIcon

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -2,7 +2,7 @@
 title: Logging & Credential Redaction
 description: 'What the SDK redacts automatically before any request information enters the logger or an AjaxError, what it does not redact, and how to wire a custom logger via setLogger(...) without re-introducing credential leaks.'
 category: 'logging'
-audited: 2026-06-11
+audited: 2026-06-17
 navigation.title: Logging & Redaction
 links:
   - label: redact.ts (canonical key list)

--- a/docs/content/docs/99.examples/1.crm-analytics.md
+++ b/docs/content/docs/99.examples/1.crm-analytics.md
@@ -157,4 +157,4 @@ main().catch((e: unknown) => {
 - Multi-funnel portals: stage IDs come prefixed (`C2:WON`). The `baseStage()` helper aggregates them under the base name.
 - `fetchList.make` keeps memory bounded — it streams 50-row chunks internally using a keyset cursor on `idKey`.
 - The action **strips any user-supplied `order`** because keyset pagination requires `idKey ASC` — narrow with `filter` instead.
-- For a more efficient revenue roll-up an `actions.v3.aggregate.make` would issue a single `sum` call, but that action surface is not yet exposed in the SDK.
+- For a more efficient revenue roll-up, a v3 `aggregate` action (a single `sum` query) is planned but not yet exposed in the SDK; until then, aggregate client-side as shown above.

--- a/packages/jssdk/README-AI.md
+++ b/packages/jssdk/README-AI.md
@@ -42,7 +42,7 @@ widely-used path today, but new code should target the `actions.v{2,3}.*` API.
 | `b24.callBatchByChunk(calls, isHaltOnError)` | `b24.actions.v2.batchByChunk.make({ calls, options })` / `b24.actions.v3.batchByChunk.make(...)` |
 | `b24.callListMethod(method, params, progress?, customKey?)` | `b24.actions.v2.callList.make({ method, params, customKeyForResult })` / `b24.actions.v3.callList.make(...)` |
 | `b24.fetchListMethod(method, params, idKey?, customKey?)` | `b24.actions.v2.fetchList.make({ method, params, idKey, customKeyForResult })` / `b24.actions.v3.fetchList.make(...)` |
-| `AjaxResult#isMore()`, `#hasMore()`, `#getNext()`, `#fetchNext()`, `#getTotal()` | The `next`/`total` envelope fields are `restApi:v2`-only (no `restApi:v3` counterpart). Do not iterate manually — let `actions.v{2,3}.{callList,fetchList}` handle pagination. For element counts in `restApi:v3` use the `aggregate` action with `count` / `countDistinct`. |
+| `AjaxResult#isMore()`, `#hasMore()`, `#getNext()`, `#fetchNext()`, `#getTotal()` | The `next`/`total` envelope fields are `restApi:v2`-only (no `restApi:v3` counterpart). Do not iterate manually — let `actions.v{2,3}.{callList,fetchList}` handle pagination. `restApi:v3` has no element-count replacement yet — an `aggregate` action (`count` / `countDistinct`) is planned but not exposed in the SDK. |
 
 `AjaxResult.getData()` returns exactly `{ result: T, time: PayloadTime }` — the
 v2-only `next` and `total` fields are no longer surfaced through the public type.

--- a/packages/jssdk/src/core/http/ajax-result.ts
+++ b/packages/jssdk/src/core/http/ajax-result.ts
@@ -167,10 +167,10 @@ export class AjaxResult<T = unknown> extends Result<Payload<T>> implements IResu
 
   /**
    * @deprecated Will be removed in `2.0.0`. Tied to the `restApi:v2` envelope
-   *   field `total`, which `restApi:v3` does not return. For `restApi:v3` the
-   *   SDK exposes element counts via the `aggregate` action (`count` /
-   *   `countDistinct`); for `restApi:v2` use the list helpers, which iterate
-   *   without exposing `total`.
+   *   field `total`, which `restApi:v3` does not return. `restApi:v3` has no
+   *   element-count replacement yet — an `aggregate` action (`count` /
+   *   `countDistinct`) is planned but not exposed in the SDK; for `restApi:v2`
+   *   use the list helpers, which iterate without exposing `total`.
    *
    * @removed 2.0.0
    */

--- a/skills/b24jssdk-filtering/SKILL.md
+++ b/skills/b24jssdk-filtering/SKILL.md
@@ -53,7 +53,7 @@ filter: { '!stageId': ['LOST', 'WON'] }
 
 ## v3 — array of triples
 
-Used by `$b24.actions.v3.{call,callList,fetchList,aggregate}.make({ params: { filter: ... }})`. The filter is a JSON **array**, each element is a condition.
+Used by `$b24.actions.v3.{call,callList,fetchList}.make({ params: { filter: ... }})`. The filter is a JSON **array**, each element is a condition.
 
 ```ts
 filter: [

--- a/skills/b24jssdk-recipes/SKILL.md
+++ b/skills/b24jssdk-recipes/SKILL.md
@@ -103,4 +103,4 @@ npx tsx examples/01-crm-analytics.ts
 
 ## Cross-reference
 
-For v3 wire-level details (filter grammar, aggregate functions, batch `$ref`/`$refArray`, cursor pagination), use the `b24jssdk-rest` and `b24jssdk-filtering` skills.
+For v3 wire-level details (filter grammar, batch `$ref`/`$refArray`, cursor pagination), use the `b24jssdk-rest` and `b24jssdk-filtering` skills.

--- a/skills/b24jssdk-rest/SKILL.md
+++ b/skills/b24jssdk-rest/SKILL.md
@@ -269,7 +269,7 @@ res.getQuery()              // { method, params, requestId }
 
 Removed from the public surface for `2.0.0`:
 - `isMore()`, `hasMore()` — was tied to v2 envelope `next`
-- `getTotal()` — was tied to v2 envelope `total`. For v3 use `actions.v3.aggregate.make` with `count` / `countDistinct`.
+- `getTotal()` — was tied to v2 envelope `total`. **No v3 count replacement yet**: an `aggregate` action (`count` / `countDistinct`) is planned but not exposed in the SDK.
 - `getNext()`, `fetchNext()` — replaced by `callList.make` / `fetchList.make`
 
 ## Null result is passthrough
@@ -322,7 +322,7 @@ For tuning retry/throw behaviour per error code see the `hardErrorCodes` / `soft
 ## Anti-patterns
 
 - ❌ `$b24.callMethod(...)`, `$b24.callBatch(...)`, etc. — `@deprecated`, removed in 2.0.0. Use the actions API.
-- ❌ `res.getTotal()` / `res.isMore()` / `res.getNext()` — `@deprecated`, throw on v3. Use `callList` / `fetchList` for paging, `aggregate` (v3) for counts.
+- ❌ `res.getTotal()` / `res.isMore()` / `res.getNext()` — `@deprecated`, throw on v3. Use `callList` / `fetchList` for paging; v3 has **no count replacement yet** (an `aggregate` action is planned but not exposed).
 - ❌ Calling `$b24.actions.v3.call.make({ method: 'crm.item.get', ... })` — throws because `crm.item.get` is not in the v3 whitelist (yet).
 - ❌ Passing `order` to `callList.make` — silently ignored with a warning. Narrow with `filter` instead.
 - ❌ `customKeyForResult: 'result'` for `crm.item.list` — wrong, use `'items'`. Otherwise you'll get an empty list silently.


### PR DESCRIPTION
## Two v3-accuracy bugs from the 2026-06-09 audit, one PR

Both are cases where published / AI-facing material describes the v3 API as it *isn't* — copy-paste fails 100% of the time. One commit per issue.

| Commit | Issue | What was wrong | Fix |
|---|---|---|---|
| `docs(rest)` | **#163** | The **v3 call page** demonstrated methods that aren't on the v3 whitelist (`crm.contact.get` in the param table, `crm.deal.add` in the long-running snippet). `CallV3.make` throws `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3` **before any HTTP request** for those — the page contradicted its own Error Handling section. The **v2 page** paired `crm.contact.get` with `{ entityTypeId, id }`, but `entityTypeId` belongs to `crm.item.get` (so the param was silently ignored and the enum import was dead). | v3 page → whitelisted `tasks.task.get` / `tasks.task.add`; long-running prose kept generic. v2 page → `crm.item.get` (matches the `v2/call.ts` JSDoc, makes the `EnumCrmEntityTypeId` import meaningful). |
| `docs+skills` | **#164** | `ActionsManagerV3` exposes only `call` / `callList` / `fetchList` / `batch` / `batchByChunk` — there is **no `aggregate` action**. Four AI-facing spots recommended `actions.v3.aggregate.make`, so an agent following them emits a call that resolves to `undefined` → runtime `TypeError`. | Rephrased all of them (rest + filtering skills, `README-AI.md`, the `getTotal()` `@deprecated` JSDoc) to *"an `aggregate` action is planned but not yet exposed; v3 has no count replacement for `getTotal()` yet"* — matching the already-correct `examples/crm-analytics` wording. |

### Plain-language summary

Two bits of documentation were "lying" about REST v3:

1. **#163** — the example code on the v3 *Call* page used CRM methods that v3 doesn't accept, so anyone who copied them got an instant error (the SDK refuses them before even calling the server). The v2 page had a method/parameter mismatch that quietly did nothing. Both now use real, working methods.
2. **#164** — several agent-facing files told the reader to use `actions.v3.aggregate.make(...)` for counts. That function doesn't exist in the SDK, so generated code would crash. All those spots now say the truth: it's planned, not shipped — and there's no v3 replacement for the old `getTotal()` yet.

### A note on the freshness-stamp churn

The `ajax-result.ts` change is **comment-only** (a `@deprecated` JSDoc). Because the docs audit-freshness check tracks source-file link targets, touching that file flags the 8 pages that cite it. I re-confirmed each is still accurate (5 are pure `AjaxResult` type references; `6.errors.md` already states the correct getTotal/callList guidance) and bumped their `audited:` stamp to the review date — keeping `docs-lint` at **0 warnings**.

## Verification (local)

- `docs:lint-pages` **0 errors / 0 warnings** · `docs:lint-links` **0 broken**
- `docs:typecheck-blocks` **111 blocks / 0 errors** (the edited v2/v3 snippets type-check)
- `eslint` **0 errors** · `package-jssdk:typecheck` clean (comment-only source change)
- v3 whitelist re-checked against current `version-manager.ts` (`tasks.task.get` / `tasks.task.add` are routed; `crm.*` is not)

Closes #163. Closes #164.

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_