### PR TITLE
docs(site): add 28 missing pages to the /raw prerender list + enable Examples in llms.txt (#165)

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -4,6 +4,10 @@ import { withoutTrailingSlash } from 'ufo'
 
 const { resolve } = createResolver(import.meta.url)
 
+// Hand-maintained — keep in sync with docs/content/docs/**. A page absent here has
+// no /raw/<page>.md route and 404s for LLM/agent consumers (crawlLinks only finds
+// HTML). TODO(#96): replace with a filesystem-driven generator + CI guard so this
+// can't silently drift again (it has now drifted twice — see #95, #165).
 const pages = [
   // region getting-started ////
   '/docs/getting-started/',
@@ -44,10 +48,10 @@ const pages = [
   '/docs/working-with-the-rest-api/frame-placement/',
   '/docs/working-with-the-rest-api/frame-options/',
   '/docs/working-with-the-rest-api/frame-slider/',
-  // hook / oauth entry points ////
+  // hook / oauth entry points
   '/docs/working-with-the-rest-api/hook/',
   '/docs/working-with-the-rest-api/oauth/',
-  // helper managers ////
+  // helper managers
   '/docs/working-with-the-rest-api/helper/',
   '/docs/working-with-the-rest-api/helper-use-b24-helper/',
   '/docs/working-with-the-rest-api/helper-app-manager/',
@@ -56,23 +60,23 @@ const pages = [
   '/docs/working-with-the-rest-api/helper-payment-manager/',
   '/docs/working-with-the-rest-api/helper-license-manager/',
   '/docs/working-with-the-rest-api/helper-options-manager/',
-  // pull client ////
+  // pull client
   '/docs/working-with-the-rest-api/pull/',
-  // core types ////
+  // core types
   '/docs/working-with-the-rest-api/core-result/',
   '/docs/working-with-the-rest-api/core-ajax-result/',
   '/docs/working-with-the-rest-api/core-http/',
   '/docs/working-with-the-rest-api/core-lang-list/',
   '/docs/working-with-the-rest-api/core-request-id-generator/',
-  // tools ////
+  // tools
   '/docs/working-with-the-rest-api/tools-browser/',
   '/docs/working-with-the-rest-api/tools-text/',
   '/docs/working-with-the-rest-api/tools-type/',
   '/docs/working-with-the-rest-api/tools-use-formatters/',
-  // types ////
+  // types
   '/docs/working-with-the-rest-api/types-iresult/',
   '/docs/working-with-the-rest-api/types-type-b24/',
-  // telemetry / error codes ////
+  // telemetry / error codes
   '/docs/working-with-the-rest-api/telemetry/',
   '/docs/working-with-the-rest-api/error-codes/',
   // endregion ////

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -14,6 +14,7 @@ const pages = [
   '/docs/getting-started/installation/umd/',
   '/docs/getting-started/migration/v1/',
   '/docs/getting-started/ai/llms-txt/',
+  '/docs/getting-started/ai/skills/',
   // endregion ////
   // region working-with-the-rest-api ////
   '/docs/working-with-the-rest-api/',
@@ -43,6 +44,37 @@ const pages = [
   '/docs/working-with-the-rest-api/frame-placement/',
   '/docs/working-with-the-rest-api/frame-options/',
   '/docs/working-with-the-rest-api/frame-slider/',
+  // hook / oauth entry points ////
+  '/docs/working-with-the-rest-api/hook/',
+  '/docs/working-with-the-rest-api/oauth/',
+  // helper managers ////
+  '/docs/working-with-the-rest-api/helper/',
+  '/docs/working-with-the-rest-api/helper-use-b24-helper/',
+  '/docs/working-with-the-rest-api/helper-app-manager/',
+  '/docs/working-with-the-rest-api/helper-profile-manager/',
+  '/docs/working-with-the-rest-api/helper-currency-manager/',
+  '/docs/working-with-the-rest-api/helper-payment-manager/',
+  '/docs/working-with-the-rest-api/helper-license-manager/',
+  '/docs/working-with-the-rest-api/helper-options-manager/',
+  // pull client ////
+  '/docs/working-with-the-rest-api/pull/',
+  // core types ////
+  '/docs/working-with-the-rest-api/core-result/',
+  '/docs/working-with-the-rest-api/core-ajax-result/',
+  '/docs/working-with-the-rest-api/core-http/',
+  '/docs/working-with-the-rest-api/core-lang-list/',
+  '/docs/working-with-the-rest-api/core-request-id-generator/',
+  // tools ////
+  '/docs/working-with-the-rest-api/tools-browser/',
+  '/docs/working-with-the-rest-api/tools-text/',
+  '/docs/working-with-the-rest-api/tools-type/',
+  '/docs/working-with-the-rest-api/tools-use-formatters/',
+  // types ////
+  '/docs/working-with-the-rest-api/types-iresult/',
+  '/docs/working-with-the-rest-api/types-type-b24/',
+  // telemetry / error codes ////
+  '/docs/working-with-the-rest-api/telemetry/',
+  '/docs/working-with-the-rest-api/error-codes/',
   // endregion ////
   // region examples ////
   '/docs/examples/',
@@ -62,7 +94,10 @@ const pages = [
   '/docs/examples/web-search-llm/',
   '/docs/examples/error-handling/',
   '/docs/examples/event-registration/',
-  '/docs/examples/oauth-install/'
+  '/docs/examples/oauth-install/',
+  '/docs/examples/entity-list/',
+  '/docs/examples/app-installation-wizard/',
+  '/docs/examples/node-hook-company-export/'
   // endregion ////
 ]
 
@@ -333,14 +368,14 @@ export default defineNuxtConfig({
         contentFilters: [
           { field: 'path', operator: 'LIKE', value: '/docs/working-with-the-rest-api/%' }
         ]
+      },
+      {
+        title: 'Examples',
+        contentCollection: 'docs',
+        contentFilters: [
+          { field: 'path', operator: 'LIKE', value: '/docs/examples/%' }
+        ]
       }
-      // {
-      //   title: 'Examples',
-      //   contentCollection: 'docs',
-      //   contentFilters: [
-      //     { field: 'path', operator: 'LIKE', value: '/docs/examples/%' }
-      //   ]
-      // }
     ],
     notes: [
       'The content is automatically generated from the same source as the official documentation.'


### PR DESCRIPTION
## The bug

`docs/nuxt.config.ts` has a **hand-maintained `pages` array** that drives the `/raw/<page>.md` prerender (Nitro `prerender.routes`). `crawlLinks: true` only discovers **HTML** pages — it does not generate the raw-markdown routes — and the deploy is a static `docs:generate`. So any page added to the filesystem but forgotten in `pages[]` has **no `/raw` route and 404s** for agents/LLMs requesting markdown (the repo's advertised consumption path via `Vary: Accept` + `/raw`).

The v1.2.0 reference pages ("29 new pages" per the CHANGELOG) were never added to the list — **28 published pages** were 404ing on the raw path.

## The fix

Added all 28 missing routes, grouped in the existing region structure:

- **24 reference pages** under `working-with-the-rest-api/`: `hook`, `oauth`, `helper` + 7 `helper-*` managers, `pull`, 5× `core-*`, 4× `tools-*` (`browser`/`text`/`type`/`use-formatters`), 2× `types-*` (`iresult`/`type-b24`), `telemetry`, `error-codes`
- `getting-started/ai/skills`
- **3 example showcases**: `entity-list`, `app-installation-wizard`, `node-hook-company-export`

Also **re-enabled the commented-out `Examples` section** in the `llms` config, so the 20 recipe pages are no longer absent from `llms.txt` (the other three sections were already on).

### Plain-language summary

The docs site keeps a manual list of pages to publish as raw markdown (the format AI tools read). That list had fallen behind — 28 real pages were missing, so a bot asking for their markdown got "404 not found". This adds the 28 back and switches the recipe examples on in `llms.txt`.

## Verification

- **Completeness:** a filesystem walk deriving each page's URL (the same numeric-prefix-stripping rule the site uses) now finds **0 pages absent** from `pages[]` — **81/81 covered** (was 53/81).
- `eslint docs/nuxt.config.ts` clean (no-trailing-comma style preserved).
- The authoritative prerender check is CI's **`docs-build`** job, which runs `pnpm run docs:generate` on PRs — it will fail if any of the 28 new routes doesn't resolve.

## Scope note

The **recurrence-prevention** (auto-generate `pages[]` from the filesystem, + a CI guard so this can't drift again) is deliberately **out of scope** — it's tracked in **#96**, which has its own undecided design choice (glob-in-config vs lint-check vs `docs:generate`-in-CI). This PR is the release-relevant route fix the issue asked for; it makes #96 the natural next step.

Closes #165

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_