### PR TITLE
ci(docs): two anti-drift guards — #96 filesystem-driven page list, #216 v3 action/method check

### DIFF
--- a/.github/contributing/documentation.md
+++ b/.github/contributing/documentation.md
@@ -157,6 +157,8 @@ console.log(result.getData().result)
 
 > Compile-checked example: [`documentation-b24hook-example.ts`](../../test/some-code-from-docs/contributing/documentation-b24hook-example.ts)
 
+> **CI guard:** the `docs-lint` job runs [`scripts/check-v3-method-refs.mjs`](../../scripts/check-v3-method-refs.mjs), which blocks examples that call a non-existent `actions.v3.*` action or a v3 method missing from the SDK whitelist. For a deliberate "this throws" / anti-pattern snippet, opt the fence out by putting `<!-- v3-check-ignore: reason -->` on the line directly above it. (Separate from `// @check-ignore`, which skips the `docs:typecheck-blocks` TypeScript pass.)
+
 ### Steps
 
 ```md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Check guide internal links (AGENTS.md + .github/contributing)
         run: node scripts/md-internal-links.mjs
 
+      - name: Check v3 action/method references (docs + skills)
+        run: node scripts/check-v3-method-refs.mjs
+
       - name: Test docs-lint scripts
         run: node --test "scripts/__tests__/**/*.test.mjs"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,11 @@ jobs:
       - name: Check guide internal links (AGENTS.md + .github/contributing)
         run: node scripts/md-internal-links.mjs
 
-      - name: Check v3 action/method references (docs + skills)
-        run: node scripts/check-v3-method-refs.mjs
-
       - name: Test docs-lint scripts
         run: node --test "scripts/__tests__/**/*.test.mjs"
+
+      - name: Check v3 action/method references (docs + skills)
+        run: node scripts/check-v3-method-refs.mjs
 
       - name: Lint GitHub Actions workflows (actionlint)
         # Catches workflow mistakes (bad expressions, job/needs wiring, shell

--- a/docs/content/docs/2.working-with-the-rest-api/6.errors.md
+++ b/docs/content/docs/2.working-with-the-rest-api/6.errors.md
@@ -135,7 +135,7 @@ catch (error) {
 import { AjaxError, SdkError } from '@bitrix24/b24jssdk'
 
 try {
-  await $b24.actions.v3.call.make({ method: 'crm.deal.get', params: { id: 1 } })
+  await $b24.actions.v3.call.make({ method: 'tasks.task.get', params: { id: 1 } })
 }
 catch (error) {
   if (error instanceof AjaxError) {

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -1,109 +1,44 @@
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
 import { createResolver } from '@nuxt/kit'
 import pkg from '../package.json'
 import { withoutTrailingSlash } from 'ufo'
 
 const { resolve } = createResolver(import.meta.url)
 
-// Hand-maintained — keep in sync with docs/content/docs/**. A page absent here has
-// no /raw/<page>.md route and 404s for LLM/agent consumers (crawlLinks only finds
-// HTML). TODO(#96): replace with a filesystem-driven generator + CI guard so this
-// can't silently drift again (it has now drifted twice — see #95, #165).
-const pages = [
-  // region getting-started ////
-  '/docs/getting-started/',
-  '/docs/getting-started/installation/vue/',
-  '/docs/getting-started/installation/nuxt/',
-  '/docs/getting-started/installation/react/',
-  '/docs/getting-started/installation/nodejs/',
-  '/docs/getting-started/installation/umd/',
-  '/docs/getting-started/migration/v1/',
-  '/docs/getting-started/ai/llms-txt/',
-  '/docs/getting-started/ai/skills/',
-  // endregion ////
-  // region working-with-the-rest-api ////
-  '/docs/working-with-the-rest-api/',
-  '/docs/working-with-the-rest-api/call-rest-api-ver2/',
-  '/docs/working-with-the-rest-api/call-rest-api-ver3/',
-  '/docs/working-with-the-rest-api/call-list-rest-api-ver2/',
-  '/docs/working-with-the-rest-api/call-list-rest-api-ver3/',
-  '/docs/working-with-the-rest-api/fetch-list-rest-api-ver2/',
-  '/docs/working-with-the-rest-api/fetch-list-rest-api-ver3/',
-  '/docs/working-with-the-rest-api/batch-rest-api-ver2/',
-  '/docs/working-with-the-rest-api/batch-rest-api-ver3/',
-  '/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver2/',
-  '/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver3/',
-  '/docs/working-with-the-rest-api/choosing-the-right-method/',
-  '/docs/working-with-the-rest-api/errors/',
-  '/docs/working-with-the-rest-api/tools-health-check/',
-  '/docs/working-with-the-rest-api/tools-ping/',
-  '/docs/working-with-the-rest-api/logger/',
-  '/docs/working-with-the-rest-api/logger-telegram/',
-  '/docs/working-with-the-rest-api/limiters/',
-  '/docs/working-with-the-rest-api/logging/',
-  '/docs/working-with-the-rest-api/frame/',
-  '/docs/working-with-the-rest-api/frame-auth/',
-  '/docs/working-with-the-rest-api/frame-dialog/',
-  '/docs/working-with-the-rest-api/frame-initialize-b24-frame/',
-  '/docs/working-with-the-rest-api/frame-parent/',
-  '/docs/working-with-the-rest-api/frame-placement/',
-  '/docs/working-with-the-rest-api/frame-options/',
-  '/docs/working-with-the-rest-api/frame-slider/',
-  // hook / oauth entry points
-  '/docs/working-with-the-rest-api/hook/',
-  '/docs/working-with-the-rest-api/oauth/',
-  // helper managers
-  '/docs/working-with-the-rest-api/helper/',
-  '/docs/working-with-the-rest-api/helper-use-b24-helper/',
-  '/docs/working-with-the-rest-api/helper-app-manager/',
-  '/docs/working-with-the-rest-api/helper-profile-manager/',
-  '/docs/working-with-the-rest-api/helper-currency-manager/',
-  '/docs/working-with-the-rest-api/helper-payment-manager/',
-  '/docs/working-with-the-rest-api/helper-license-manager/',
-  '/docs/working-with-the-rest-api/helper-options-manager/',
-  // pull client
-  '/docs/working-with-the-rest-api/pull/',
-  // core types
-  '/docs/working-with-the-rest-api/core-result/',
-  '/docs/working-with-the-rest-api/core-ajax-result/',
-  '/docs/working-with-the-rest-api/core-http/',
-  '/docs/working-with-the-rest-api/core-lang-list/',
-  '/docs/working-with-the-rest-api/core-request-id-generator/',
-  // tools
-  '/docs/working-with-the-rest-api/tools-browser/',
-  '/docs/working-with-the-rest-api/tools-text/',
-  '/docs/working-with-the-rest-api/tools-type/',
-  '/docs/working-with-the-rest-api/tools-use-formatters/',
-  // types
-  '/docs/working-with-the-rest-api/types-iresult/',
-  '/docs/working-with-the-rest-api/types-type-b24/',
-  // telemetry / error codes
-  '/docs/working-with-the-rest-api/telemetry/',
-  '/docs/working-with-the-rest-api/error-codes/',
-  // endregion ////
-  // region examples ////
-  '/docs/examples/',
-  '/docs/examples/dashboard-deals-csv/',
-  '/docs/examples/frame-app-skeleton/',
-  '/docs/examples/webhook-cli-node/',
-  '/docs/examples/bulk-update-deals/',
-  '/docs/examples/pull-subscribe-frame/',
-  '/docs/examples/crm-analytics/',
-  '/docs/examples/mass-messaging/',
-  '/docs/examples/task-automation/',
-  '/docs/examples/erp-sync/',
-  '/docs/examples/disk-files/',
-  '/docs/examples/telegram-bot/',
-  '/docs/examples/webhook-handler/',
-  '/docs/examples/ai-assistant/',
-  '/docs/examples/web-search-llm/',
-  '/docs/examples/error-handling/',
-  '/docs/examples/event-registration/',
-  '/docs/examples/oauth-install/',
-  '/docs/examples/entity-list/',
-  '/docs/examples/app-installation-wizard/',
-  '/docs/examples/node-hook-company-export/'
-  // endregion ////
-]
+// Prerender list is derived from the filesystem (#96) so a new page can't be
+// forgotten and silently 404 on the /raw/<page>.md path (crawlLinks only finds
+// HTML). Each content page becomes one route, slugged the way Nuxt Content builds
+// the URL: strip the `NN.` nav-order prefix from every path segment, and map a
+// directory's `index` file to the directory route. The list was hand-maintained
+// before and drifted twice (#95, #165).
+function buildDocsPages(): string[] {
+  const root = resolve('content/docs')
+  const walk = (dir: string): string[] =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        return walk(full)
+      }
+      return entry.name.endsWith('.md') ? [full] : []
+    })
+  return walk(root)
+    .map((file) => {
+      const segments = file
+        .slice(root.length + 1)
+        .replace(/\.md$/, '')
+        .split(/[/\\]/)
+        .map(segment => segment.replace(/^\d+\./, ''))
+      if (segments.at(-1) === 'index') {
+        segments.pop()
+      }
+      const path = segments.length > 0 ? `${segments.join('/')}/` : ''
+      return `/docs/${path}`
+    })
+    .sort()
+}
+
+const pages = buildDocsPages()
 
 /**
  * @memo need add for iframe examples

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "lint:fix": "eslint . --fix",
     "lint:md": "markdownlint-cli2 \"AGENTS.md\" \".github/contributing/*.md\"",
     "lint:md-links": "node scripts/md-internal-links.mjs",
+    "lint:v3-refs": "node scripts/check-v3-method-refs.mjs",
     "docs:lint-pages": "node scripts/docs-lint.mjs",
     "docs:lint-pages:strict": "node scripts/docs-lint.mjs --strict",
     "docs:lint-links": "node scripts/docs-link-check.mjs",

--- a/scripts/__tests__/check-v3-method-refs.test.mjs
+++ b/scripts/__tests__/check-v3-method-refs.test.mjs
@@ -16,7 +16,7 @@ const SCRIPT = resolve(__dirname, '..', 'check-v3-method-refs.mjs')
 
 const WHITELIST_SRC = [
   'class VersionManager {',
-  '  #supportMethods = [',
+  '  this.#supportMethods = [',
   '    \'/tasks.task.get\', // done',
   '    \'/tasks.task.add\',',
   '    // \'/profile\' // wait — commented out, must NOT count',
@@ -119,6 +119,35 @@ test('a non-whitelisted method passed to v2 (not v3) is ignored', () => {
     'docs/content/docs/v2.md': [
       '```ts',
       'await $b24.actions.v2.call.make({ method: \'crm.deal.add\', params: {} })',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root)
+    assert.equal(r.status, 0, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+  })
+})
+
+test('a commented-out whitelist entry does not count as supported', () => {
+  withFixture({
+    'docs/content/docs/profile.md': [
+      '```ts',
+      'await $b24.actions.v3.call.make({ method: \'profile\' })',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root)
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /profile/)
+  })
+})
+
+test('v3-check-ignore with a blank line before the fence still suppresses', () => {
+  withFixture({
+    'docs/content/docs/ignore-gap.md': [
+      '<!-- v3-check-ignore: deliberate throw -->',
+      '',
+      '```ts',
+      'await $b24.actions.v3.call.make({ method: \'crm.deal.add\' })',
       '```'
     ].join('\n')
   }, (root) => {

--- a/scripts/__tests__/check-v3-method-refs.test.mjs
+++ b/scripts/__tests__/check-v3-method-refs.test.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// Fixture tests for scripts/check-v3-method-refs.mjs.
+//
+// Run with: node --test scripts/__tests__/check-v3-method-refs.test.mjs
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SCRIPT = resolve(__dirname, '..', 'check-v3-method-refs.mjs')
+
+const WHITELIST_SRC = [
+  'class VersionManager {',
+  '  #supportMethods = [',
+  '    \'/tasks.task.get\', // done',
+  '    \'/tasks.task.add\',',
+  '    // \'/profile\' // wait — commented out, must NOT count',
+  '  ]',
+  '}'
+].join('\n')
+
+function writeFile(root, relPath, content) {
+  const file = join(root, ...relPath.split('/'))
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, content.endsWith('\n') ? content : `${content}\n`, 'utf8')
+}
+
+function withFixture(files, run) {
+  const root = mkdtempSync(join(tmpdir(), 'v3-refs-'))
+  try {
+    writeFile(root, 'packages/jssdk/src/core/version-manager.ts', WHITELIST_SRC)
+    // The script reads README-AI.md and walks docs/content/docs + skills; make
+    // sure they all exist even when a test only populates one of them.
+    writeFile(root, 'packages/jssdk/README-AI.md', '# AI surface\n')
+    mkdirSync(join(root, 'docs', 'content', 'docs'), { recursive: true })
+    mkdirSync(join(root, 'skills'), { recursive: true })
+    for (const [relPath, content] of Object.entries(files)) {
+      writeFile(root, relPath, content)
+    }
+    return run(root)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function runCheck(root) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    env: { ...process.env, V3_CHECK_ROOT: root },
+    encoding: 'utf8'
+  })
+}
+
+test('clean: real actions, whitelisted method, placeholder, and an ignored anti-pattern all pass', () => {
+  withFixture({
+    'docs/content/docs/ok.md': [
+      '# OK',
+      '',
+      'Use `actions.v3.call.make` and the `actions.v3.{call,callList,fetchList}` family.',
+      '',
+      '```ts',
+      'await $b24.actions.v3.call.make({ method: \'tasks.task.get\', params: { id: 1 } })',
+      'await $b24.actions.v3.call.make({ method: \'some.method\' })',
+      '```',
+      '',
+      '<!-- v3-check-ignore: deliberate "this throws" example -->',
+      '```ts',
+      'await $b24.actions.v3.call.make({ method: \'crm.deal.add\' })',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root)
+    assert.equal(r.status, 0, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+    assert.match(r.stdout, /0 problem/)
+  })
+})
+
+test('phantom v3 action (dotted) is flagged', () => {
+  withFixture({
+    'skills/b24jssdk-rest/SKILL.md': 'For v3 counts use `actions.v3.aggregate.make`.\n'
+  }, (root) => {
+    const r = runCheck(root)
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /non-existent v3 action "actions\.v3\.aggregate"/)
+  })
+})
+
+test('phantom v3 action inside a {a,b,c} list is flagged', () => {
+  withFixture({
+    'docs/content/docs/filter.md': 'Used by `actions.v3.{call,callList,aggregate}.make(...)`.\n'
+  }, (root) => {
+    const r = runCheck(root)
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /non-existent v3 action "aggregate"/)
+  })
+})
+
+test('non-whitelisted method in a v3 ts fence is flagged', () => {
+  withFixture({
+    'docs/content/docs/bad.md': [
+      '```ts',
+      'await $b24.actions.v3.call.make({ method: \'crm.deal.add\', params: {} })',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root)
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /crm\.deal\.add/)
+    assert.match(r.stdout, /not on the version-manager v3 whitelist/)
+  })
+})
+
+test('a non-whitelisted method passed to v2 (not v3) is ignored', () => {
+  withFixture({
+    'docs/content/docs/v2.md': [
+      '```ts',
+      'await $b24.actions.v2.call.make({ method: \'crm.deal.add\', params: {} })',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root)
+    assert.equal(r.status, 0, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+  })
+})

--- a/scripts/check-v3-method-refs.mjs
+++ b/scripts/check-v3-method-refs.mjs
@@ -20,6 +20,16 @@
  *      a fence opts it out — for deliberate "this throws" / anti-pattern examples.
  *
  * The allowlist is parsed straight from the source so it can never go stale.
+ *
+ * Known scope limits (low-risk today; tighten if the docs grow — tracked as a
+ * follow-up):
+ *   - only call/callList/fetchList are method-checked; batch/batchByChunk take
+ *     nested call arrays (not a top-level `method:`), so their methods aren't
+ *     validated here.
+ *   - the method is matched within ~400 chars of its `.make({`, so a method placed
+ *     after a very long `params` block could be missed.
+ *   - method names in prose / inline code aren't checked (only fenced TS); phantom
+ *     actions (layer 1) are checked everywhere.
  */
 
 import { readFileSync, readdirSync } from 'node:fs'
@@ -36,13 +46,19 @@ const REAL_ACTIONS = [...V3_ACTIONS].join(' / ')
 // Illustrative, non-real method names that legitimately appear in snippets.
 const PLACEHOLDER = /^(?:some|your|my|the|example|any)\.|[<>…*]/
 
+// Parse the v3 allowlist straight from source — no build needed, so this runs in
+// the dist-free docs-lint CI job. Assumptions (true today): `#supportMethods` is a
+// single array literal of `'/method'` string literals, closed by a `]` on its own
+// line. A shared exported allowlist would be sturdier — see the follow-up.
 function loadWhitelist() {
   const src = readFileSync(join(ROOT, 'packages/jssdk/src/core/version-manager.ts'), 'utf8')
   const start = src.indexOf('#supportMethods = [')
   if (start === -1) {
     throw new Error('check-v3-method-refs: could not find #supportMethods in version-manager.ts')
   }
-  const block = src.slice(start, src.indexOf(']', start))
+  const rest = src.slice(start)
+  const close = rest.search(/\n[ \t]*\]/) // closing bracket on its own line, not a `]` inside a comment/value
+  const block = close === -1 ? rest : rest.slice(0, close)
   const methods = new Set()
   for (const line of block.split('\n')) {
     const code = line.replace(/\/\/.*$/, '') // drop line comments (commented-out entries + `// done`)

--- a/scripts/check-v3-method-refs.mjs
+++ b/scripts/check-v3-method-refs.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+/**
+ * Guards docs / skills / README-AI against drifting from the SDK's real v3 surface (#216).
+ *
+ * Two layers, both pure static text analysis (no build or portal needed):
+ *
+ *   1. Phantom v3 actions. `ActionsManagerV3` exposes only
+ *      call / callList / fetchList / batch / batchByChunk. Any other
+ *      `actions.v3.<x>` — e.g. the `actions.v3.aggregate` that #164 had to walk
+ *      back — resolves to `undefined` at runtime, so it is flagged wherever it
+ *      appears (dotted or in a `{a,b,c}` list), in prose or code.
+ *
+ *   2. v3 method whitelist conformance. Inside ```ts / ```typescript fences,
+ *      every method passed to a v3 `call`/`callList`/`fetchList` `.make()` must be
+ *      on the version-manager v3 allowlist (`#supportMethods`) — otherwise the
+ *      snippet throws `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3` before any HTTP
+ *      request (the #163 class). Obvious placeholders (`some.*`, `your.*`,
+ *      `<method>`, …) are skipped, and a `v3-check-ignore` marker on the line above
+ *      a fence opts it out — for deliberate "this throws" / anti-pattern examples.
+ *
+ * The allowlist is parsed straight from the source so it can never go stale.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, resolve, dirname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = process.env.V3_CHECK_ROOT
+  ? resolve(process.env.V3_CHECK_ROOT)
+  : resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+const V3_ACTIONS = new Set(['call', 'callList', 'fetchList', 'batch', 'batchByChunk'])
+const REAL_ACTIONS = [...V3_ACTIONS].join(' / ')
+
+// Illustrative, non-real method names that legitimately appear in snippets.
+const PLACEHOLDER = /^(?:some|your|my|the|example|any)\.|[<>…*]/
+
+function loadWhitelist() {
+  const src = readFileSync(join(ROOT, 'packages/jssdk/src/core/version-manager.ts'), 'utf8')
+  const start = src.indexOf('#supportMethods = [')
+  if (start === -1) {
+    throw new Error('check-v3-method-refs: could not find #supportMethods in version-manager.ts')
+  }
+  const block = src.slice(start, src.indexOf(']', start))
+  const methods = new Set()
+  for (const line of block.split('\n')) {
+    const code = line.replace(/\/\/.*$/, '') // drop line comments (commented-out entries + `// done`)
+    const m = code.match(/'([^']+)'/)
+    if (m) {
+      methods.add(m[1].replace(/^\//, ''))
+    }
+  }
+  return methods
+}
+
+function markdownFiles() {
+  const files = [join(ROOT, 'packages', 'jssdk', 'README-AI.md')]
+  for (const base of ['docs/content/docs', 'skills']) {
+    const dir = join(ROOT, ...base.split('/'))
+    const walk = (current) => {
+      for (const entry of readdirSync(current, { withFileTypes: true })) {
+        const full = join(current, entry.name)
+        if (entry.isDirectory()) {
+          walk(full)
+        } else if (entry.name.endsWith('.md')) {
+          files.push(full)
+        }
+      }
+    }
+    walk(dir)
+  }
+  return files
+}
+
+const whitelist = loadWhitelist()
+let problems = 0
+
+function fail(file, message) {
+  console.log(`\x1B[31mV3-DRIFT\x1B[0m ${relative(ROOT, file)}: ${message}`)
+  problems += 1
+}
+
+function checkPhantomActions(file, body) {
+  for (const m of body.matchAll(/actions\.v3\.([a-zA-Z]\w*)/g)) {
+    if (!V3_ACTIONS.has(m[1])) {
+      fail(file, `references non-existent v3 action "actions.v3.${m[1]}" — real actions are ${REAL_ACTIONS}`)
+    }
+  }
+  for (const m of body.matchAll(/actions\.v3\.\{([^}]*)\}/g)) {
+    for (const name of m[1].split(',').map(s => s.trim()).filter(Boolean)) {
+      if (!V3_ACTIONS.has(name)) {
+        fail(file, `references non-existent v3 action "${name}" in actions.v3.{${m[1]}}`)
+      }
+    }
+  }
+}
+
+// Yield the body of every ```ts / ```typescript fence, skipping a fence when the
+// nearest non-empty line above it carries a `v3-check-ignore` marker.
+function tsFences(body) {
+  const lines = body.replace(/\r\n/g, '\n').split('\n')
+  const blocks = []
+  let inFence = false
+  let fenceLen = 0
+  let buffer = []
+  let skip = false
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (!inFence) {
+      const open = line.match(/^(`{3,})(?:ts|typescript)\b/)
+      if (!open) {
+        continue
+      }
+      inFence = true
+      fenceLen = open[1].length
+      buffer = []
+      let prev = i - 1
+      while (prev >= 0 && lines[prev].trim() === '') {
+        prev -= 1
+      }
+      skip = prev >= 0 && lines[prev].includes('v3-check-ignore')
+      continue
+    }
+    const close = line.match(/^(`{3,})\s*$/)
+    if (close && close[1].length >= fenceLen) {
+      if (!skip) {
+        blocks.push(buffer.join('\n'))
+      }
+      inFence = false
+      buffer = []
+      continue
+    }
+    buffer.push(line)
+  }
+  return blocks
+}
+
+const V3_METHOD_CALL = /actions\.v3\.(call|callList|fetchList)\.make\s*\(\s*\{[\s\S]{0,400}?method:\s*['"]([^'"]+)['"]/g
+
+function checkMethods(file, body) {
+  for (const code of tsFences(body)) {
+    for (const m of code.matchAll(V3_METHOD_CALL)) {
+      const method = m[2]
+      if (PLACEHOLDER.test(method) || whitelist.has(method)) {
+        continue
+      }
+      fail(file, `v3 ${m[1]}.make uses method "${method}", which is not on the version-manager v3 whitelist (add a \`v3-check-ignore\` marker above the fence if this is a deliberate anti-pattern example)`)
+    }
+  }
+}
+
+for (const file of markdownFiles()) {
+  const body = readFileSync(file, 'utf8')
+  checkPhantomActions(file, body)
+  checkMethods(file, body)
+}
+
+console.log(`\ncheck-v3-method-refs: ${problems} problem(s) across docs, skills, README-AI`)
+process.exit(problems > 0 ? 1 : 0)


### PR DESCRIPTION
## Two anti-drift guards for the docs/AI-facing surface

The last several PRs hand-fixed *drift* — published docs/skills lagging the code (#163, #164, #165). These two issues make the machine catch it instead. One commit per issue.

| Commit | Issue | What |
|---|---|---|
| `docs(site)` | **#96** | Replace the hand-maintained `pages` prerender array in `docs/nuxt.config.ts` with `buildDocsPages()`, which walks `docs/content/docs/**` and derives each `/raw` route the way Nuxt Content builds the URL. A new page is now picked up **automatically** — it can't be forgotten and silently 404 (the drift that caused #95 and #165). |
| `ci(docs/skills)` | **#216** | A static check (`scripts/check-v3-method-refs.mjs`) wired into the `docs-lint` CI job: **(1)** flags any non-existent `actions.v3.*` action (the #164 phantom-`aggregate` class → runtime `TypeError`), and **(2)** inside ` ```ts ` fences, asserts every method on a v3 `call`/`callList`/`fetchList` `.make()` is on the `version-manager` whitelist (the #163 class → `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`). |

### Plain-language summary

1. **#96** — the docs site used a *manual list* of which pages to publish; if you added a page and forgot the list, it 404'd. Now the list is built from the folder automatically, so there's nothing to forget.
2. **#216** — a CI check that refuses to let the docs/skills mention a v3 API that doesn't exist, or call a v3 method the SDK can't route. It reads the real action set and the real whitelist from the source, so it can't go stale.

### The guard earned its keep immediately 🎯

While verifying #216, it caught a **real** latent bug: the v3 variant of the error-handling example in `6.errors.md` called `crm.deal.get` — not v3-routable, so it would throw the "not supported in v3" `SdkError` *before any HTTP request*, defeating the page's own AjaxError-vs-SdkError lesson. Fixed to `tasks.task.get` in this PR.

## Verification

- **#96:** the generated route list is **identical** to the previous 81 hand-maintained routes (0 added, 0 lost — diffed against `main`). `eslint` clean. CI's `docs-build` job runs `docs:generate`, which prerenders the derived routes — a bad slug still fails the build.
- **#216:** guard reports **0 problems** on the repo (after the `6.errors.md` fix). 5-case fixture test (`scripts/__tests__/check-v3-method-refs.test.mjs`) covers phantom actions (dotted + brace), non-whitelisted method, the `v3-check-ignore` escape hatch, and v2-is-ignored. Full suite green: `eslint` 0 errors, `docs:lint:test` **42/42**.
- Design notes: #96 supersedes the manual list (the `TODO(#96)` from #218 is resolved); #216 deliberately scopes method-conformance to ` ```ts ` fences and skips placeholders, so prose anti-patterns and `some.method` snippets don't false-positive.

Closes #96. Closes #216.

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_