### PR TITLE
fix(pull): PullClient.destroy() now removes listeners, cancels all timers, and stops the watch loop (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* **pull:** `PullClient.destroy()` now fully tears the client down — removes its `beforeunload` / `offline` / `online` window listeners, cancels all seven pending timers (including the self-rescheduling `pull.watch.extend` watch loop), and no longer schedules a reconnect on teardown. A destroyed client is inert: `updateWatch` / `scheduleReconnect` / `onOnline` / `connect` and every timer-arming path bail out, and `start()` rejects with `PULL_DISPOSED`. Previously only the check interval was cleared, so timers and window listeners survived `destroy()` and the client kept firing background REST and could reconnect after an explicit teardown — accumulating across SPA/Nuxt `destroyB24Helper()` cycles (#141)
+
 ### Security
 
 * **ci:** an ESLint `no-restricted-syntax` guard scoped to `packages/jssdk/src/core/http/**` now forbids passing a URL- or credential-shaped variable into a logger context object, blocking the #39/#40 webhook-secret-leak class at lint time — defence-in-depth alongside the existing runtime redaction test (#42)

--- a/docs/content/docs/2.working-with-the-rest-api/60.pull.md
+++ b/docs/content/docs/2.working-with-the-rest-api/60.pull.md
@@ -81,7 +81,7 @@ await init()
 setInterval(emitPing, 5000)
 ```
 
-When the host component unmounts, call `destroyB24Helper()` — that closes the WebSocket and clears all subscriptions.
+When the host component unmounts, call `destroyB24Helper()` — that fully tears the Pull client down: closes the WebSocket, clears all subscriptions, removes its window listeners, and cancels all pending timers.
 
 ## API via `B24HelperManager`
 

--- a/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
+++ b/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
@@ -45,6 +45,8 @@ These codes propagate through the promise rejection path. Wrap your calls in `tr
 | `allowed_only_intranet_user` | Endpoint requires an intranet user. |
 | `NOT_FOUND` | Resource does not exist. |
 | `INVALID_ARG_VALUE` | One of the arguments has a value Bitrix24 rejected. |
+| `PULL_DISABLED` | `PullClient.start()` — Push & Pull server is disabled on the portal. |
+| `PULL_DISPOSED` | `PullClient.start()` called after `destroy()` — create a new instance. |
 
 ## Soft Errors (returned in `AjaxResult`)
 

--- a/packages/jssdk/src/pullClient/client.ts
+++ b/packages/jssdk/src/pullClient/client.ts
@@ -243,6 +243,12 @@ export class PullClient implements ConnectorParent {
     return this._logger
   }
 
+  /**
+   * Terminal teardown: removes the window listeners, cancels every pending timer,
+   * persists the session for a quick re-init, and disconnects. Irreversible — a
+   * destroyed client schedules no further work and `start()` rejects with
+   * `PULL_DISPOSED`; create a new instance to reconnect.
+   */
   destroy(): void {
     this._disposed = true
 
@@ -260,6 +266,10 @@ export class PullClient implements ConnectorParent {
   }
 
   private init(): void {
+    if (this._disposed) {
+      return
+    }
+
     this._connectors.webSocket = new WebSocketConnector({
       parent: this,
       onOpen: this.onWebSocketOpen.bind(this),
@@ -536,7 +546,11 @@ export class PullClient implements ConnectorParent {
   }
 
   /**
+   * Connects the client and begins receiving events.
+   *
    * @param config
+   * @throws Rejects with `{ ex: { error: 'PULL_DISPOSED' } }` when called after
+   *   `destroy()` — a destroyed client cannot be restarted; create a new instance.
    */
   public async start(
     config:
@@ -641,6 +655,10 @@ export class PullClient implements ConnectorParent {
     disconnectCode: number | CloseReasons = CloseReasons.NORMAL_CLOSURE,
     disconnectReason: string = 'manual restart'
   ): void {
+    if (this._disposed) {
+      return
+    }
+
     if (this._restartTimeout) {
       clearTimeout(this._restartTimeout)
       this._restartTimeout = null
@@ -1739,6 +1757,10 @@ export class PullClient implements ConnectorParent {
   }
 
   private startCheckConfig(): void {
+    if (this._disposed) {
+      return
+    }
+
     if (this._checkInterval) {
       clearInterval(this._checkInterval)
       this._checkInterval = null
@@ -1916,6 +1938,10 @@ export class PullClient implements ConnectorParent {
   }
 
   private scheduleRestoreWebSocketConnection(): void {
+    if (this._disposed) {
+      return
+    }
+
     this.logToConsole(
       `Pull: scheduling restoration of websocket connection in ${RESTORE_WEBSOCKET_TIMEOUT} seconds`
     )
@@ -1967,6 +1993,10 @@ export class PullClient implements ConnectorParent {
     disconnectReason: string,
     restartDelay: number = 0
   ): void {
+    if (this._disposed) {
+      return
+    }
+
     if (this._restartTimeout) {
       clearTimeout(this._restartTimeout)
       this._restartTimeout = null
@@ -2460,6 +2490,9 @@ export class PullClient implements ConnectorParent {
 
   // region Events.Status /////
   private onOffline(): void {
+    if (this._disposed) {
+      return
+    }
     this.disconnect(CloseReasons.NORMAL_CLOSURE, 'offline')
   }
 
@@ -2510,6 +2543,10 @@ export class PullClient implements ConnectorParent {
    * @param delay
    */
   private sendPullStatusDelayed(status: PullStatus, delay: number): void {
+    if (this._disposed) {
+      return
+    }
+
     if (this._offlineTimeout) {
       clearTimeout(this._offlineTimeout)
       this._offlineTimeout = null
@@ -2624,6 +2661,10 @@ export class PullClient implements ConnectorParent {
   }
 
   private updatePingWaitTimeout(): void {
+    if (this._disposed) {
+      return
+    }
+
     if (this._pingWaitTimeout) {
       clearTimeout(this._pingWaitTimeout)
       this._pingWaitTimeout = null
@@ -2645,7 +2686,7 @@ export class PullClient implements ConnectorParent {
 
   private onPingTimeout(): void {
     this._pingWaitTimeout = null
-    if (!this._enabled || !this.isConnected()) {
+    if (this._disposed || !this._enabled || !this.isConnected()) {
       return
     }
 

--- a/packages/jssdk/src/pullClient/client.ts
+++ b/packages/jssdk/src/pullClient/client.ts
@@ -111,10 +111,17 @@ export class PullClient implements ConnectorParent {
   // manual stop workaround ////
   private _isManualDisconnect: boolean = false
 
+  // set once destroy() has run; gates reconnect / watch / online so a torn-down
+  // client never schedules new work (#141) ////
+  private _disposed: boolean = false
+
   private _loggingEnabled: boolean = false
 
-  // bound event handlers ////
+  // bound event handlers, stored so they can be removed in destroy() (#141) ////
   private _onPingTimeoutHandler: () => void
+  private _onBeforeUnloadHandler: () => void
+  private _onOfflineHandler: () => void
+  private _onOnlineHandler: () => void
 
   // [userId] => array of callbacks
   private _userStatusCallbacks: Record<number, UserStatusCallback[]> = {}
@@ -216,6 +223,9 @@ export class PullClient implements ConnectorParent {
 
     // bound event handlers ////
     this._onPingTimeoutHandler = this.onPingTimeout.bind(this)
+    this._onBeforeUnloadHandler = this.onBeforeUnload.bind(this)
+    this._onOfflineHandler = this.onOffline.bind(this)
+    this._onOnlineHandler = this.onOnline.bind(this)
   }
 
   setLogger(logger: LoggerInterface): void {
@@ -234,9 +244,19 @@ export class PullClient implements ConnectorParent {
   }
 
   destroy(): void {
+    this._disposed = true
+
     this.stop(CloseReasons.NORMAL_CLOSURE, 'manual stop')
 
-    this.onBeforeUnload()
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('beforeunload', this._onBeforeUnloadHandler)
+      window.removeEventListener('offline', this._onOfflineHandler)
+      window.removeEventListener('online', this._onOnlineHandler)
+    }
+
+    // Save the session for a quick re-init, but — unlike onBeforeUnload — do NOT
+    // schedule a reconnect: the client is being torn down (#141).
+    this.persistSession()
   }
 
   private init(): void {
@@ -260,9 +280,11 @@ export class PullClient implements ConnectorParent {
       ? ConnectionType.WebSocket
       : ConnectionType.LongPolling
 
-    window.addEventListener('beforeunload', this.onBeforeUnload.bind(this))
-    window.addEventListener('offline', this.onOffline.bind(this))
-    window.addEventListener('online', this.onOnline.bind(this))
+    if (typeof window !== 'undefined') {
+      window.addEventListener('beforeunload', this._onBeforeUnloadHandler)
+      window.addEventListener('offline', this._onOfflineHandler)
+      window.addEventListener('online', this._onOnlineHandler)
+    }
 
     /**
      * @memo Not use under Node.js
@@ -523,6 +545,15 @@ export class PullClient implements ConnectorParent {
         skipReconnectToLastSession?: boolean
       }) = null
   ): Promise<boolean> {
+    if (this._disposed) {
+      return Promise.reject({
+        ex: {
+          error: 'PULL_DISPOSED',
+          error_description: 'PullClient has been destroyed; create a new instance'
+        }
+      })
+    }
+
     let allowConfigCaching = true
 
     if (this.isConnected()) {
@@ -664,6 +695,36 @@ export class PullClient implements ConnectorParent {
     this.disconnect(disconnectCode, disconnectReason)
 
     this.stopCheckConfig()
+
+    this.clearAllTimers()
+  }
+
+  // Cancel every pending timer so a stopped/destroyed client leaves nothing
+  // running. Previously only _checkInterval was cleared, so the other six timers
+  // (including the self-rescheduling watch-extend) survived teardown (#141).
+  private clearAllTimers(): void {
+    for (const timer of [
+      this._reconnectTimeout,
+      this._restartTimeout,
+      this._restoreWebSocketTimeout,
+      this._offlineTimeout,
+      this._watchUpdateTimeout,
+      this._pingWaitTimeout
+    ]) {
+      if (timer) {
+        clearTimeout(timer)
+      }
+    }
+    if (this._checkInterval) {
+      clearInterval(this._checkInterval)
+    }
+    this._reconnectTimeout = null
+    this._restartTimeout = null
+    this._restoreWebSocketTimeout = null
+    this._offlineTimeout = null
+    this._watchUpdateTimeout = null
+    this._pingWaitTimeout = null
+    this._checkInterval = null
   }
 
   public reconnect(
@@ -1808,7 +1869,7 @@ export class PullClient implements ConnectorParent {
    * @param connectionDelay
    */
   private scheduleReconnect(connectionDelay: number = 0): void {
-    if (!this._enabled) {
+    if (this._disposed || !this._enabled) {
       return
     }
 
@@ -1873,7 +1934,7 @@ export class PullClient implements ConnectorParent {
    * @returns {Promise}
    */
   private async connect(): Promise<void> {
-    if (!this._enabled) {
+    if (this._disposed || !this._enabled) {
       return Promise.reject()
     }
     if (this.connector?.connected) {
@@ -2403,6 +2464,9 @@ export class PullClient implements ConnectorParent {
   }
 
   private onOnline(): void {
+    if (this._disposed) {
+      return
+    }
     this.connect().catch((error) => {
       this.getLogger().error('onOnline', { error })
     })
@@ -2411,6 +2475,15 @@ export class PullClient implements ConnectorParent {
   private onBeforeUnload(): void {
     this._unloading = true
 
+    this.persistSession()
+
+    this.scheduleReconnect(15)
+  }
+
+  // Persist the current session (with a short TTL) so a quick reload / re-init can
+  // resume it. Shared by onBeforeUnload and destroy() — destroy() saves WITHOUT
+  // scheduling a reconnect (#141).
+  private persistSession(): void {
     const session = Type.clone(this.session)
     session.ttl = Date.now() + LS_SESSION_CACHE_TIME * 1000
     if (this._storage) {
@@ -2427,8 +2500,6 @@ export class PullClient implements ConnectorParent {
         )
       }
     }
-
-    this.scheduleReconnect(15)
   }
 
   // endregion ////
@@ -2492,6 +2563,10 @@ export class PullClient implements ConnectorParent {
    * @param force
    */
   private updateWatch(force: boolean = false): void {
+    if (this._disposed) {
+      return
+    }
+
     if (this._watchUpdateTimeout) {
       clearTimeout(this._watchUpdateTimeout)
       this._watchUpdateTimeout = null

--- a/test/integration/pull/pull-client-teardown.unit.spec.ts
+++ b/test/integration/pull/pull-client-teardown.unit.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for PullClient teardown (#141). Pure lifecycle logic, no portal — runs
+ * in the `jsSdk:unit` CI project. Verifies that destroy():
+ *   - removes the window listeners init() registered (they used to leak),
+ *   - cancels every pending timer (only _checkInterval used to be cleared),
+ *   - leaves the client disposed so reconnect / watch / online no longer reschedule,
+ * and that start() refuses to resurrect a destroyed instance.
+ *
+ * The unit project runs under Node (no DOM), so we install a minimal `window` stub
+ * that records add/removeEventListener calls. No WebSocket/localStorage on it, so
+ * the client picks long-polling and skips storage — keeping construction portal-free.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { PullClient } from '../../../packages/jssdk/src/pullClient/client'
+import type { TypeB24 } from '../../../packages/jssdk/src/types/b24'
+
+type Listener = (...args: any[]) => void
+
+interface WindowStub {
+  added: Map<string, Set<Listener>>
+  removed: Array<{ type: string, handler: Listener }>
+  addEventListener: (type: string, handler: Listener) => void
+  removeEventListener: (type: string, handler: Listener) => void
+}
+
+function installWindowStub(): WindowStub {
+  const added = new Map<string, Set<Listener>>()
+  const removed: Array<{ type: string, handler: Listener }> = []
+  const stub: WindowStub = {
+    added,
+    removed,
+    addEventListener(type, handler) {
+      if (!added.has(type)) {
+        added.set(type, new Set())
+      }
+      added.get(type)!.add(handler)
+    },
+    removeEventListener(type, handler) {
+      removed.push({ type, handler })
+      added.get(type)?.delete(handler)
+    }
+  }
+  ;(globalThis as any).window = stub
+  ;(globalThis as any).document = { location: { href: 'https://test.local/' } }
+  // The long-polling connector lazily creates an XHR (even to abort it on
+  // disconnect); Node has none, so provide a no-op stub.
+  ;(globalThis as any).XMLHttpRequest = class {
+    responseType = ''
+    onreadystatechange: Listener | null = null
+    open() {}
+    send() {}
+    abort() {}
+    setRequestHeader() {}
+    addEventListener() {}
+    removeEventListener() {}
+  }
+  return stub
+}
+
+function createClient(): PullClient {
+  return new PullClient({
+    b24: {} as unknown as TypeB24,
+    userId: 42,
+    serverEnabled: true,
+    skipStorageInit: true,
+    skipCheckRevision: true
+  })
+}
+
+const WINDOW_EVENTS = ['beforeunload', 'offline', 'online']
+const TIMER_FIELDS = [
+  '_reconnectTimeout',
+  '_restartTimeout',
+  '_restoreWebSocketTimeout',
+  '_checkInterval',
+  '_offlineTimeout',
+  '_watchUpdateTimeout',
+  '_pingWaitTimeout'
+]
+
+describe('PullClient teardown (#141)', () => {
+  let windowStub: WindowStub
+
+  beforeEach(() => {
+    windowStub = installWindowStub()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    delete (globalThis as any).window
+    delete (globalThis as any).document
+    delete (globalThis as any).XMLHttpRequest
+  })
+
+  it('removes every window listener it registered, on destroy()', () => {
+    const client = createClient()
+    const internal = client as any
+    internal.init()
+
+    for (const type of WINDOW_EVENTS) {
+      expect(windowStub.added.get(type)?.size ?? 0, `listener added for ${type}`).toBe(1)
+    }
+
+    client.destroy()
+
+    for (const type of WINDOW_EVENTS) {
+      expect(windowStub.added.get(type)?.size ?? 0, `listener removed for ${type}`).toBe(0)
+    }
+    expect(windowStub.removed.map(entry => entry.type).sort()).toEqual([...WINDOW_EVENTS].sort())
+  })
+
+  it('cancels every pending timer on destroy()', () => {
+    const client = createClient()
+    const internal = client as any
+    internal.init()
+
+    // Arm representative timers: the self-rescheduling watch-extend and a reconnect.
+    internal.updateWatch(true)
+    internal.scheduleReconnect(5)
+    expect(internal._watchUpdateTimeout).not.toBeNull()
+    expect(internal._reconnectTimeout).not.toBeNull()
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+    client.destroy()
+
+    for (const field of TIMER_FIELDS) {
+      expect(internal[field], `${field} cleared`).toBeNull()
+    }
+    expect(vi.getTimerCount()).toBe(0)
+    expect(internal._disposed).toBe(true)
+  })
+
+  it('does not reschedule watch / reconnect / online after destroy()', () => {
+    const client = createClient()
+    const internal = client as any
+    internal.init()
+    client.destroy()
+
+    // A disposed client must treat these as no-ops.
+    internal.updateWatch()
+    internal.scheduleReconnect(5)
+    internal.onOnline()
+
+    expect(internal._watchUpdateTimeout).toBeNull()
+    expect(internal._reconnectTimeout).toBeNull()
+    expect(vi.getTimerCount()).toBe(0)
+
+    // …and letting plenty of time pass schedules nothing new.
+    vi.advanceTimersByTime(60 * 60 * 1000)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('start() rejects on a disposed client instead of re-initialising', async () => {
+    const client = createClient()
+    client.destroy()
+    await expect(client.start()).rejects.toMatchObject({ ex: { error: 'PULL_DISPOSED' } })
+  })
+})

--- a/test/integration/pull/pull-client-teardown.unit.spec.ts
+++ b/test/integration/pull/pull-client-teardown.unit.spec.ts
@@ -115,12 +115,15 @@ describe('PullClient teardown (#141)', () => {
     const internal = client as any
     internal.init()
 
-    // Arm representative timers: the self-rescheduling watch-extend and a reconnect.
+    // Arm six of the seven timer-arming paths (the 7th, _offlineTimeout, needs a
+    // PullStatus). clearAllTimers() must cancel every one.
     internal.updateWatch(true)
     internal.scheduleReconnect(5)
-    expect(internal._watchUpdateTimeout).not.toBeNull()
-    expect(internal._reconnectTimeout).not.toBeNull()
-    expect(vi.getTimerCount()).toBeGreaterThan(0)
+    internal.scheduleRestart(1000, 'test', 5)
+    internal.scheduleRestoreWebSocketConnection()
+    internal.startCheckConfig()
+    internal.updatePingWaitTimeout()
+    expect(vi.getTimerCount()).toBeGreaterThanOrEqual(6)
 
     client.destroy()
 
@@ -155,5 +158,40 @@ describe('PullClient teardown (#141)', () => {
     const client = createClient()
     client.destroy()
     await expect(client.start()).rejects.toMatchObject({ ex: { error: 'PULL_DISPOSED' } })
+  })
+
+  it('a disposed client re-arms no timers and re-registers no listeners', () => {
+    const client = createClient()
+    const internal = client as any
+    internal.init()
+    client.destroy()
+
+    // Every timer-arming path — and init() — must no-op once disposed, even if a
+    // late connector callback reaches them after clearAllTimers() ran.
+    internal.updateWatch(true)
+    internal.scheduleReconnect(5)
+    internal.scheduleRestart(1000, 'test', 5)
+    internal.scheduleRestoreWebSocketConnection()
+    internal.startCheckConfig()
+    internal.updatePingWaitTimeout()
+    internal.onOnline()
+    internal.init()
+
+    expect(vi.getTimerCount()).toBe(0)
+    for (const field of TIMER_FIELDS) {
+      expect(internal[field], `${field} stays null`).toBeNull()
+    }
+    for (const type of WINDOW_EVENTS) {
+      expect(windowStub.added.get(type)?.size ?? 0, `no ${type} listener re-registered`).toBe(0)
+    }
+  })
+
+  it('destroy() is safe with no window (SSR/Node teardown)', () => {
+    const client = createClient()
+    const internal = client as any
+    internal.init()
+    delete (globalThis as any).window
+    expect(() => client.destroy()).not.toThrow()
+    expect(internal._disposed).toBe(true)
   })
 })


### PR DESCRIPTION
## The bug (#141, severity: high)

`PullClient.destroy()` didn't actually tear the client down, so every
`useB24Helper().destroyB24Helper()` cycle in an SPA/Nuxt app accumulated window
listeners, zombie reconnects, and background REST traffic:

- **Listeners leaked.** `init()` added `beforeunload`/`offline`/`online` via fresh
  `this.onX.bind(this)` — never stored, never removed (there was no
  `removeEventListener` anywhere). After `destroy()`, the live `online` handler even
  reconnected a dead client.
- **`destroy()` scheduled a reconnect.** It called `onBeforeUnload()`, which ends in
  `scheduleReconnect(15)` — gated only by `_enabled` (which destroy never cleared).
- **Timers survived.** `stop()`/`destroy()` cleared only `_checkInterval`; the other
  six timers (`_reconnectTimeout`, `_restartTimeout`, `_restoreWebSocketTimeout`,
  `_offlineTimeout`, `_watchUpdateTimeout`, `_pingWaitTimeout`) kept running.
- **`updateWatch()` rescheduled itself forever** in every branch, firing
  `pull.watch.extend` every ~29 min for the life of the page — even after destroy.

### Plain-language summary

When a Nuxt/Vue app tore down the Bitrix24 helper, the push/pull client kept
half-running in the background: it left browser event handlers attached, kept
firing a "keep my subscriptions alive" REST call every half hour, and could even
reconnect itself after being told to stop. Over repeated mount/unmount cycles that
piles up. This makes teardown actually tear down.

## The fix

- Bind the three window handlers **once** into fields; **remove them in `destroy()`**
  (both add and remove guarded by `typeof window`, so SSR/Node import is safe).
- Add a **`_disposed`** flag, set at the top of `destroy()`, checked in
  `updateWatch` / `scheduleReconnect` / `onOnline` / `connect` / `start` — a
  torn-down client schedules nothing and `start()` rejects `PULL_DISPOSED` instead
  of resurrecting a half-initialised instance.
- Add **`clearAllTimers()`** (called from `stop()`) that cancels all seven timers.
- Split the session save out of `onBeforeUnload()` into `persistSession()`;
  `destroy()` saves the session for a quick re-init but **no longer reconnects**.

## Verification

- New **portal-free unit tests** (`test/integration/pull/pull-client-teardown.unit.spec.ts`, `jsSdk:unit`): listeners removed on destroy, all timers cancelled + `_disposed` set, no rescheduling of watch/reconnect/online after destroy (advancing fake timers schedules nothing), and `start()` rejects on a disposed client. **87/87 unit tests pass.**
- `tsc --noEmit` clean · `eslint` clean.

### Scope note
The window listeners now have a `typeof window` guard, but `PullClient` is still
browser-only by construction (e.g. the constructor reads `document.location`, and
the connectors use `XMLHttpRequest`/`WebSocket`). Making the whole client
Node-safe is a separate concern — out of scope here. (The issue's "in Node it keeps
the event loop alive" is really the browser SPA case; the leak is the same either
way.)

Closes #141

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_