### PR TITLE
ci(docs-lint): two preventive link guards — #117 frontmatter source links, #102 relative content links

### DIFF
--- a/.github/contributing/documentation.md
+++ b/.github/contributing/documentation.md
@@ -71,7 +71,9 @@ links:
 | `restApiVersion` | for action pages | `rest-api-ver2` or `rest-api-ver3` — drives the `::rest-api-version-only` filter |
 | `links` | yes for API pages | Each entry points to the source file backing this page. Always include the primary class plus `Result`/`AjaxResult`/`AjaxError`/`SdkError` when relevant |
 
-The `links` block is how readers (and agents) jump from a doc page to the implementation. **Keep these links accurate** — every page in `2.working-with-the-rest-api/` already follows this pattern, copy from the closest existing page.
+The `links` block is how readers (and agents) jump from a doc page to the implementation. **Keep these links accurate** — every page in `2.working-with-the-rest-api/` already follows this pattern, copy from the closest existing page. CI enforces this: a `blob/main/` target in `links:` whose file no longer exists fails the `docs-lint` job (#117).
+
+**In-page links must be site-absolute.** Link to another doc page with an absolute route (`[Call v3](/docs/working-with-the-rest-api/call-rest-api-ver3/)`), never a relative `./` or `../` path — relative links silently fail to resolve in Nuxt Content and are rejected by CI (#102).
 
 ## Page Structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * **ci(docs):** add `markdownlint` + an internal-link check over `AGENTS.md` and `.github/contributing/*.md` (permissive config; a renamed/moved link target now fails CI). The link check immediately caught 7 stale `../../.claude/skills/*` links, repointed to `skills/*` (#54)
 * **dx:** `contributing:typecheck` and `docs:typecheck-blocks` now fail with an actionable "run `pnpm run dev:prepare`" message instead of a cryptic `TS2307` when the SDK types haven't been built yet (#109)
 * **test(contributing):** compile-check the high-value contributing-guide snippets — the `LoggerFactory.forcedLog` four-arg deprecation pattern, the `B24Hook` quick-start, and the public `Result` type — each with a "Compile-checked example" footnote so drift turns red in CI (#108)
+* **ci(docs):** `docs-lint` now errors on a frontmatter `links:` `blob/main/` target whose file is missing (catches renamed/deleted source links — #117), and `docs-link-check` rejects relative `./`/`../` links in `docs/content/docs/` — internal cross-page links must be site-absolute `/docs/…` (#102)
 
 ## [1.3.0](https://github.com/bitrix24/b24jssdk/compare/v1.2.0...v1.3.0) (2026-06-16)
 

--- a/scripts/__tests__/docs-link-check.test.mjs
+++ b/scripts/__tests__/docs-link-check.test.mjs
@@ -179,5 +179,7 @@ test('docs-link-check: a relative ./ or ../ link is rejected (#102)', () => {
     const r = runDocsLinkCheck(root)
     assert.equal(r.status, 1, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
     assert.match(r.stdout, /relative link/)
+    assert.match(r.stdout, /\.\.\/guide\/intro/)
+    assert.match(r.stdout, /\.\/sibling/)
   })
 })

--- a/scripts/__tests__/docs-link-check.test.mjs
+++ b/scripts/__tests__/docs-link-check.test.mjs
@@ -163,3 +163,21 @@ test('docs-link-check: missing heading fragment exits 1', () => {
     assert.match(r.stdout, /missing-section/)
   })
 })
+
+test('docs-link-check: a relative ./ or ../ link is rejected (#102)', () => {
+  withFixture((root) => {
+    writePage(root, '0.index.md', [
+      '---',
+      'title: Home',
+      '---',
+      '',
+      '# Home',
+      '',
+      'A [relative up](../guide/intro/) and a [dot-slash](./sibling/) link.'
+    ])
+
+    const r = runDocsLinkCheck(root)
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+    assert.match(r.stdout, /relative link/)
+  })
+})

--- a/scripts/__tests__/docs-lint.test.mjs
+++ b/scripts/__tests__/docs-lint.test.mjs
@@ -16,7 +16,7 @@ import { spawnSync } from 'node:child_process'
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { parseFrontmatter, walkMarkdownFiles, isFreshnessTrackedSource } from '../_docs-utils.mjs'
-import { checkAuditFreshness } from '../docs-lint.mjs'
+import { checkAuditFreshness, checkFrontmatterLinkTargets } from '../docs-lint.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..', '..')
@@ -143,6 +143,39 @@ test('checkAuditFreshness: a .md source never ages a page; a .ts source does', (
   assert.equal(warns.length, 1)
   assert.match(warns[0], /result\.ts/)
   assert.doesNotMatch(warns[0], /SKILL\.md/)
+})
+
+// ── checkFrontmatterLinkTargets (#117) ───────────────────────────────────
+
+test('checkFrontmatterLinkTargets: errors on a blob/main link whose file is gone', () => {
+  const frontmatter = {
+    links: [
+      'label: Live\nto: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/result.ts',
+      'label: Gone\nto: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/deleted.ts'
+    ]
+  }
+  const errs = []
+  checkFrontmatterLinkTargets('page.md', frontmatter, {
+    exists: localPath => localPath.endsWith('result.ts'),
+    error: (_file, msg) => errs.push(msg)
+  })
+  assert.equal(errs.length, 1)
+  assert.match(errs[0], /deleted\.ts/)
+})
+
+test('checkFrontmatterLinkTargets: external and tree/ links are not checked', () => {
+  const frontmatter = {
+    links: [
+      'label: Ext\nto: https://example.com/whatever',
+      'label: Dir\nto: https://github.com/bitrix24/b24jssdk/tree/main/packages'
+    ]
+  }
+  const errs = []
+  checkFrontmatterLinkTargets('page.md', frontmatter, {
+    exists: () => false,
+    error: (_file, msg) => errs.push(msg)
+  })
+  assert.equal(errs.length, 0)
 })
 
 // ── docs-lint --strict end-to-end ────────────────────────────────────────

--- a/scripts/docs-link-check.mjs
+++ b/scripts/docs-link-check.mjs
@@ -116,6 +116,16 @@ function extractInternalLinksFromBody(body) {
   return out
 }
 
+function extractRelativeLinksFromBody(body) {
+  // Nuxt Content internal links must be site-absolute (/docs/…). A ./ or ../
+  // relative target silently fails to resolve at build time. (#102)
+  const re = /\]\((\.\.?\/[^\s)"]*)\)/g
+  const out = []
+  let m
+  while ((m = re.exec(body)) !== null) out.push(m[1])
+  return out
+}
+
 function extractInternalLinksFromLinksArray(linksArray) {
   // The frontmatter `links:` array is parsed into raw entry strings like
   // "label: Foo\niconName: GitHubIcon\nto: /docs/foo/". Pull each `to:` line
@@ -168,6 +178,10 @@ function main() {
           `broken fragment in link "${link}" — "#${fragment}" is not a heading on ${targetUrl}`
         )
       }
+    }
+
+    for (const rel of extractRelativeLinksFromBody(body)) {
+      logError(file, `relative link "${rel}" — docs links must be site-absolute (/docs/…), not ./ or ../`)
     }
   }
 

--- a/scripts/docs-link-check.mjs
+++ b/scripts/docs-link-check.mjs
@@ -119,6 +119,9 @@ function extractInternalLinksFromBody(body) {
 function extractRelativeLinksFromBody(body) {
   // Nuxt Content internal links must be site-absolute (/docs/…). A ./ or ../
   // relative target silently fails to resolve at build time. (#102)
+  // Like extractInternalLinksFromBody, this does NOT strip fenced code, so a
+  // markdown link with a relative target shown inside a ```code``` example would
+  // be flagged too — fine today (no such examples); revisit if one is ever needed.
   const re = /\]\((\.\.?\/[^\s)"]*)\)/g
   const out = []
   let m

--- a/scripts/docs-lint.mjs
+++ b/scripts/docs-lint.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync, statSync } from 'node:fs'
+import { readFileSync, statSync, existsSync } from 'node:fs'
 import { join, resolve, relative, dirname } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { execFileSync } from 'node:child_process'
@@ -142,6 +142,19 @@ export function checkAuditFreshness(file, frontmatter, deps = {}) {
   }
 }
 
+// Frontmatter `links:` point at the source files a page documents. A renamed or
+// deleted target leaves a dead pointer that neither tsc nor the snippet checks
+// catch — error on any blob/main link whose file no longer exists (#117).
+export function checkFrontmatterLinkTargets(file, frontmatter, deps = {}) {
+  const exists = deps.exists || (localPath => existsSync(join(REPO_ROOT, localPath)))
+  const error = deps.error || ((f, m) => log('error', f, m))
+  for (const localPath of extractGithubLinkPaths(frontmatter.links || [])) {
+    if (!exists(localPath)) {
+      error(file, `frontmatter links: target "${localPath}" does not exist in the repo`)
+    }
+  }
+}
+
 // Threshold above which the number of @check-ignore markers triggers a warning.
 // The current baseline is 38 (as of v1.1.3). Raise deliberately when new
 // opt-outs are added; do not let this number creep up silently.
@@ -170,6 +183,7 @@ function main() {
       }
     }
     checkAuditFreshness(file, frontmatter)
+    checkFrontmatterLinkTargets(file, frontmatter)
   }
 
   const ignoreCount = countCheckIgnoreMarkers(files)


### PR DESCRIPTION
## Two preventive docs-link guards (quick-wins batch)

Both extend the docs-lint link-checking from #54/#216. One commit per issue. Both have a **clean baseline** (zero current violations — verified by a repo-wide scan), so they're purely preventive: they fail CI the day a *new* drift is introduced.

| Commit | Issue | What |
|---|---|---|
| `ci(docs-lint)` | **#117** | `docs-lint.mjs` now **errors on a frontmatter `links:` target that doesn't exist** in the repo. The `links:` block is the canonical pointer from a doc page to the source it documents; when a target is renamed/deleted the link silently rots (neither `tsc` nor the snippet-compile pass sees it, and the audit-freshness check skipped missing files). `tree/` and external links are ignored. |
| `ci(docs-lint)` | **#102** | `docs-link-check.mjs` now **rejects relative `./` / `../` markdown links** in `docs/content/docs`. Nuxt Content internal links must be site-absolute (`/docs/…`); a relative target silently fails to resolve at build time. |

### Plain-language summary

Two CI checks that catch broken documentation links *before* merge: (1) if a page says "the source is at `…/foo.ts`" and that file no longer exists, CI fails; (2) if a doc page uses a `./relative` link (which the docs site can't resolve) instead of an absolute `/docs/…` one, CI fails. Neither fires on the current docs — they're guardrails for the future.

## Verification

- `docs-lint.mjs --strict` and `docs-link-check.mjs` both **0 errors / 0 warnings** on the real docs tree (clean baseline confirmed).
- New tests: `checkFrontmatterLinkTargets` unit-tested via the deps seam (gone file → error; external/`tree/` → ignored); a fixture test for the relative-link rejection. Full docs-lint suite **47/47**. `eslint` clean.

Closes #117. Closes #102.

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_