### PR TITLE
fix(http): retry error-code preservation + getStats/headers/query-immutability (#143, #144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Bug Fixes
 
 * **pull:** `PullClient.destroy()` now fully tears the client down — removes its `beforeunload` / `offline` / `online` window listeners, cancels all seven pending timers (including the self-rescheduling `pull.watch.extend` watch loop), and no longer schedules a reconnect on teardown. A destroyed client is inert: `updateWatch` / `scheduleReconnect` / `onOnline` / `connect` and every timer-arming path bail out, and `start()` rejects with `PULL_DISPOSED`. Previously only the check interval was cleared, so timers and window listeners survived `destroy()` and the client kept firing background REST and could reconnect after an explicit teardown — accumulating across SPA/Nuxt `destroyB24Helper()` cycles (#141)
+* **http:** on retry exhaustion the SDK now surfaces the underlying error with its **real code** (e.g. `QUERY_LIMIT_EXCEEDED`) — thrown for hard codes, returned in the `AjaxResult` for soft codes — instead of the generic `JSSDK_CALL_ALL_ATTEMPTS_EXHAUSTED`, and the final attempt no longer sleeps a full backoff before giving up. `JSSDK_CALL_ALL_ATTEMPTS_EXHAUSTED` is now thrown only for the degenerate `maxRetries < 1` config. Behaviour change: code that caught `JSSDK_CALL_ALL_ATTEMPTS_EXHAUSTED` on rate-limit / transient exhaustion now catches the real code (#143)
+* **http:** `getStats().totalRequests` now returns the actual request count (was wired to `totalDuration`) and `reset()` zeroes it; the HTTP client constructor no longer wipes caller-supplied headers (incl. the SDK `User-Agent`) when `options` is passed; and `AjaxResult.getNext()` no longer mutates the previous page's `getQuery().params` (#144)
 
 ### Security
 

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: CallV2.make
 description: 'A method for making Bitrix24 REST API version 2 calls.'
 category: 'actions'
-audited: 2026-06-17
+audited: 2026-06-18
 restApiVersion: 'rest-api-ver2'
 navigation.title: Call
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallV3.make
 description: 'Method for making Bitrix24 REST API version 3 calls.'
 category: 'actions'
-audited: 2026-06-17
+audited: 2026-06-18
 restApiVersion: 'rest-api-ver3'
 navigation.title: Call
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: BatchV2.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 2. Allows executing up to 50 commands in a single API call.'
 category: 'actions'
-audited: 2026-06-17
+audited: 2026-06-18
 restApiVersion: 'rest-api-ver2'
 navigation.title: Batch
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3. Allows executing up to 50 commands in a single API call.'
 category: 'actions'
-audited: 2026-06-17
+audited: 2026-06-18
 restApiVersion: 'rest-api-ver3'
 navigation.title: Batch
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV2.make
 description: 'Method for executing batch requests with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-06-17
+audited: 2026-06-18
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3 with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-06-17
+audited: 2026-06-18
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/6.errors.md
+++ b/docs/content/docs/2.working-with-the-rest-api/6.errors.md
@@ -3,7 +3,7 @@ title: Error codes and handling
 description: 'Reference for SdkError and AjaxError codes raised by the SDK, plus the Bitrix24 REST error codes that surface through them.'
 navigation:
   title: Errors
-audited: 2026-06-17
+audited: 2026-06-18
 links:
   - label: SdkError
     iconName: GitHubIcon
@@ -76,7 +76,7 @@ Codes are stable strings — match on them, don't parse messages.
 | `JSSDK_INTERACTION_BATCH_ROW_FAIL` | 500 | batch row parser | A single batch row could not be parsed. |
 | `JSSDK_INVALID_PARAMS` | 400 | HTTP transport | The shape of `params` was rejected before the request was sent. |
 | `JSSDK_PARAMS_TOO_LARGE` | 413 | HTTP transport | Serialized request body exceeded the size limit. Split the call. |
-| `JSSDK_CALL_ALL_ATTEMPTS_EXHAUSTED` | 500 | HTTP transport | Retries (default 3, configurable via `RestrictionParams.maxRetries`) exhausted before the call succeeded. |
+| `JSSDK_CALL_ALL_ATTEMPTS_EXHAUSTED` | 500 | HTTP transport | Degenerate config only (`maxRetries < 1`, no attempt made). On normal retry exhaustion the underlying error's real code is surfaced instead. |
 | `JSSDK_UNKNOWN_ERROR` | 500 | various | Fallback when no more specific code applies. |
 | `JSSDK_INTERNAL_ERROR` | 500 | `SdkError.fromException` | Default code when wrapping an unknown exception. |
 | `JSSDK_INTERNAL_AJAX_ERROR` | 500 | `AjaxError.fromException` | Default code when wrapping an unknown HTTP error. |
@@ -235,7 +235,7 @@ catch (error) {
 | `expired_token`, `invalid_token` (401) | Yes — the SDK auto-refreshes the token and retries once on every entry point. |
 | `AUTHORIZE_ERROR`, `WRONG_AUTH_TYPE` (403) | No — needs human intervention (re-auth, fix scopes). |
 | `ERROR_METHOD_NOT_FOUND`, `INVALID_REQUEST` | No — request is malformed; retrying gives the same error. |
-| Network / 5xx without a specific code | Yes — but only via `JSSDK_CALL_ALL_ATTEMPTS_EXHAUSTED` boundary; bump `restrictionParams.maxRetries` if you need more attempts. |
+| Network / 5xx without a specific code | Yes — the limiter retries up to `maxRetries`; on final failure the underlying error (its real code) is surfaced. Bump `restrictionParams.maxRetries` if you need more attempts. |
 
 ## See also
 

--- a/docs/content/docs/2.working-with-the-rest-api/70.core-ajax-result.md
+++ b/docs/content/docs/2.working-with-the-rest-api/70.core-ajax-result.md
@@ -83,7 +83,7 @@ getStatus(): number
 getQuery(): Readonly<AjaxQuery>
 ```
 
-`getTotal` returns `0`{lang="ts-type"} on unsuccessful results. `AjaxQuery`{lang="ts-type"} captures `{ method, params, requestId }`.
+`getTotal` returns `0`{lang="ts-type"} on unsuccessful results. `AjaxQuery`{lang="ts-type"} captures `{ method, params, requestId }`; the returned object and its `params` are stable — calling `getNext()` does not mutate them.
 
 ## Error Handling
 

--- a/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
+++ b/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
@@ -2,7 +2,7 @@
 title: Restrictions System
 description: 'The restrictions system provides a comprehensive mechanism for managing request frequency, operation execution time, and adaptive delays.'
 category: 'limiters'
-audited: 2026-06-11
+audited: 2026-06-18
 navigation.title: Limiters
 links:
   - label: Limiters

--- a/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
+++ b/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
@@ -339,7 +339,7 @@ When the server takes longer than the axios timeout, this sequence plays out:
 3. `REQUEST_TIMEOUT` is treated as a transient error → SDK retries.
 4. The server, unaware that the client gave up, finishes the first request and
    **persists a document**. Then it accepts the retry and persists **another**.
-5. After `maxRetries` attempts the SDK throws `JSSDK_CALL_ALL_ATTEMPTS_EXHAUSTED`
+5. After `maxRetries` attempts the SDK throws the underlying error (its real code)
    and the caller is left with 2-3 duplicates in CRM.
 
 The same risk applies to every non-idempotent method: `crm.deal.add`,

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -2,7 +2,7 @@
 title: Logging & Credential Redaction
 description: 'What the SDK redacts automatically before any request information enters the logger or an AjaxError, what it does not redact, and how to wire a custom logger via setLogger(...) without re-introducing credential leaks.'
 category: 'logging'
-audited: 2026-06-17
+audited: 2026-06-18
 navigation.title: Logging & Redaction
 links:
   - label: redact.ts (canonical key list)

--- a/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
+++ b/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
@@ -73,7 +73,7 @@ These are not in the catalog above — they are detected by the [`RestrictionMan
 - HTTP 429 / `OPERATION_TIME_LIMIT` — operating limit.
 - Any other transient code → exponential backoff with jitter.
 
-After `maxRetries` (default `3`) the SDK gives up and throws `JSSDK_CALL_ALL_ATTEMPTS_EXHAUSTED`.
+After `maxRetries` (default `3`) the SDK gives up and surfaces the underlying error with its real code (e.g. `QUERY_LIMIT_EXCEEDED`) — thrown for hard codes, or returned in the `AjaxResult` for soft codes.
 
 ::caution
 Currently `NETWORK_ERROR` and `REQUEST_TIMEOUT` are **not** in the hard list, which means non-idempotent calls (e.g. `crm.documentgenerator.document.add`) can be retried after a server-side timeout and create duplicates. If you hit this, consider wrapping the call in a manual idempotency key on your side.

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -327,6 +327,9 @@ export abstract class AbstractHttp implements TypeHttp {
       }
     }
 
+    // Unreachable on normal exhaustion — the final attempt throws `lastError` (its
+    // real code) above. Only reached when maxRetries < 1: the loop never runs and
+    // there is no lastError to surface. (#143)
     throw new AjaxError({
       code: 'JSSDK_CALL_ALL_ATTEMPTS_EXHAUSTED',
       description: 'All attempts exhausted',

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -90,13 +90,15 @@ export abstract class AbstractHttp implements TypeHttp {
     this._requestIdGenerator = new RequestIdGenerator()
 
     this._clientAxios = axios.create({
-      headers: {
-        ...defaultHeaders,
-        ...(options ? (options as any).headers : {})
-      },
       timeout: 30_000,
       timeoutErrorMessage: 'Request timeout exceeded',
-      ...(options && { ...options, headers: undefined })
+      ...(options ?? {}),
+      // headers last so the merged default + caller headers aren't wiped by an
+      // `options.headers` (or the previous `headers: undefined`) spread (#144).
+      headers: {
+        ...defaultHeaders,
+        ...((options as any)?.headers ?? {})
+      }
     })
 
     /**
@@ -153,7 +155,7 @@ export abstract class AbstractHttp implements TypeHttp {
   } {
     return {
       ...this._restrictionManager.getStats(),
-      totalRequests: this._metrics.totalDuration,
+      totalRequests: this._metrics.totalRequests,
       successfulRequests: this._metrics.successfulRequests,
       failedRequests: this._metrics.failedRequests,
       totalDuration: this._metrics.totalDuration,
@@ -166,7 +168,7 @@ export abstract class AbstractHttp implements TypeHttp {
    * @inheritDoc
    */
   public async reset(): Promise<void> {
-    this._metrics.totalDuration = 0
+    this._metrics.totalRequests = 0
     this._metrics.successfulRequests = 0
     this._metrics.failedRequests = 0
     this._metrics.totalDuration = 0
@@ -296,7 +298,7 @@ export abstract class AbstractHttp implements TypeHttp {
         // Log the results
         this._logFailedRequest(requestId, method, attempt + 1, maxRetries, lastError)
 
-        if (attempt < maxRetries) {
+        if (attempt + 1 < maxRetries) {
           const waitTime = await this._restrictionManager.handleError(requestId, method, params, lastError, attempt)
           // We don't repeat if waitTime === 0
           if (waitTime > 0) {

--- a/packages/jssdk/src/core/http/ajax-result.ts
+++ b/packages/jssdk/src/core/http/ajax-result.ts
@@ -247,14 +247,16 @@ export class AjaxResult<T = unknown> extends Result<Payload<T>> implements IResu
   }
 
   #buildNextPageQuery(): AjaxQuery {
-    const result = { ...this._query }
-
     const payload = this._data as { next?: number }
     const nextValue = 'next' in payload ? payload.next : undefined
 
-    result.params.start = Text.toInteger(Text.toInteger(nextValue))
-
-    return result
+    // Fresh params object — the previous shallow `{ ...this._query }` shared the
+    // params reference and wrote `start` back into the frozen _query, so the
+    // previous result's getQuery().params silently changed after getNext() (#144).
+    return {
+      ...this._query,
+      params: { ...this._query.params, start: Text.toInteger(nextValue) }
+    }
   }
 
   // Immutable API

--- a/test/integration/core/http-fixes.unit.spec.ts
+++ b/test/integration/core/http-fixes.unit.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the HTTP-layer correctness fixes (#143, #144). Pure logic — no
+ * portal — so they run in the jsSdk:unit project. HttpV2 is constructed with a
+ * stub AuthActions; no real request is made (the transport-touching methods are
+ * overridden), so this stays portal-free.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { HttpV2 } from '../../../packages/jssdk/src/core/http/v2'
+import { AjaxError } from '../../../packages/jssdk/src/core/http/ajax-error'
+import type { AuthActions } from '../../../packages/jssdk/src/types/auth'
+
+function makeHttp(restrictionParams: Record<string, unknown> = {}): HttpV2 {
+  return new HttpV2({} as unknown as AuthActions, null, restrictionParams)
+}
+
+describe('HTTP layer fixes (#143, #144)', () => {
+  it('#144: getStats() reports totalRequests (not totalDuration), and reset() clears it', async () => {
+    const http = makeHttp()
+    const metrics = (http as any)._metrics
+    metrics.totalRequests = 7
+    metrics.totalDuration = 12_345
+    metrics.successfulRequests = 5
+    metrics.failedRequests = 2
+
+    const stats = http.getStats()
+    expect(stats.totalRequests).toBe(7) // was wired to totalDuration before the fix
+    expect(stats.totalDuration).toBe(12_345)
+
+    await http.reset()
+    expect((http as any)._metrics.totalRequests).toBe(0) // reset used to skip this field
+    expect((http as any)._metrics.totalDuration).toBe(0)
+  })
+
+  it('#144: the SDK User-Agent and a caller-supplied header both survive construction', () => {
+    const http = new HttpV2(
+      {} as unknown as AuthActions,
+      { headers: { 'X-Test-Header': 'kept' } }
+    )
+    const headers = JSON.stringify((http as any)._clientAxios.defaults.headers)
+    // Before the fix, the `headers: undefined` spread wiped both.
+    expect(headers).toContain('X-Test-Header')
+    expect(headers).toContain('User-Agent')
+  })
+
+  it('#143: the final retryable attempt throws the real error code, not the generic exhausted one', async () => {
+    const http = makeHttp({ maxRetries: 2 })
+    const realError = new AjaxError({
+      code: 'TEST_HARD_ERROR', // not in BUILT_IN_SOFT_ERROR_CODES → takes the throw path
+      description: 'still failing on the last attempt',
+      status: 503,
+      requestInfo: { method: 'x', params: {}, requestId: 'r' },
+      originalError: null
+    })
+
+    ;(http as any)._executeSingleCall = vi.fn().mockRejectedValue(realError)
+    const rm = (http as any)._restrictionManager
+    rm.applyOperatingLimits = vi.fn().mockResolvedValue(undefined)
+    rm.handleError = vi.fn().mockResolvedValue(5) // waitTime > 0 — the old code would sleep then throw the generic code
+    rm.waiteDelay = vi.fn().mockResolvedValue(undefined)
+
+    await expect(http.call('x', {})).rejects.toMatchObject({ code: 'TEST_HARD_ERROR' })
+    // The last attempt must NOT enter the retry branch.
+    expect(rm.handleError).toHaveBeenCalledTimes(1)
+    expect(rm.waiteDelay).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/integration/core/http-fixes.unit.spec.ts
+++ b/test/integration/core/http-fixes.unit.spec.ts
@@ -6,8 +6,11 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import { HttpV2 } from '../../../packages/jssdk/src/core/http/v2'
+import { AjaxResult } from '../../../packages/jssdk/src/core/http/ajax-result'
 import { AjaxError } from '../../../packages/jssdk/src/core/http/ajax-error'
+import { ApiVersion } from '../../../packages/jssdk/src/types/b24'
 import type { AuthActions } from '../../../packages/jssdk/src/types/auth'
+import type { TypeHttp } from '../../../packages/jssdk/src/types/http'
 
 function makeHttp(restrictionParams: Record<string, unknown> = {}): HttpV2 {
   return new HttpV2({} as unknown as AuthActions, null, restrictionParams)
@@ -62,5 +65,52 @@ describe('HTTP layer fixes (#143, #144)', () => {
     // The last attempt must NOT enter the retry branch.
     expect(rm.handleError).toHaveBeenCalledTimes(1)
     expect(rm.waiteDelay).toHaveBeenCalledTimes(1)
+  })
+
+  it('#143: maxRetries=1 makes a single attempt and throws the real error without retrying', async () => {
+    const http = makeHttp({ maxRetries: 1 })
+    const realError = new AjaxError({
+      code: 'TEST_HARD_ERROR_SINGLE',
+      description: 'failed on the only attempt',
+      status: 503,
+      requestInfo: { method: 'x', params: {}, requestId: 'r' },
+      originalError: null
+    })
+
+    ;(http as any)._executeSingleCall = vi.fn().mockRejectedValue(realError)
+    const rm = (http as any)._restrictionManager
+    rm.applyOperatingLimits = vi.fn().mockResolvedValue(undefined)
+    rm.handleError = vi.fn().mockResolvedValue(5)
+    rm.waiteDelay = vi.fn().mockResolvedValue(undefined)
+
+    await expect(http.call('x', {})).rejects.toMatchObject({ code: 'TEST_HARD_ERROR_SINGLE' })
+    expect(rm.handleError).not.toHaveBeenCalled() // single attempt → no retry branch entered
+  })
+
+  it('#144: getNext() does not mutate the original query params', async () => {
+    const result = new AjaxResult({
+      answer: { result: [], next: 50, total: 100, time: {} as any },
+      query: { method: 'crm.contact.list', params: { filter: { TYPE: 1 } }, requestId: 'r1' },
+      status: 200
+    })
+
+    const capturedParams: Array<Record<string, unknown>> = []
+    const mockHttp = {
+      apiVersion: ApiVersion.v2,
+      call: vi.fn((_method: string, params: Record<string, unknown>) => {
+        capturedParams.push(params)
+        return Promise.resolve(new AjaxResult({
+          answer: { result: [], time: {} as any },
+          query: { method: 'crm.contact.list', params, requestId: 'r2' },
+          status: 200
+        }))
+      })
+    } as unknown as TypeHttp
+
+    const originalParams = result.getQuery().params as Record<string, unknown>
+    await result.getNext(mockHttp)
+
+    expect(originalParams.start).toBeUndefined() // the previous page's query is untouched
+    expect(capturedParams[0].start).toBe(50) // the next request gets the cursor
   })
 })


### PR DESCRIPTION
## Two HTTP-layer correctness bugs from the 2026-06-09 audit

Pure-logic fixes, no portal needed.

### #143 — retry loop discards the real error code (and over-sleeps)

Inside `for (attempt = 0; attempt < maxRetries; attempt++)`, the guard `if (attempt < maxRetries)` was **always true**. So on the *final* retryable attempt the code still computed a backoff, **slept the full `waitTime`**, `continue`d, fell out of the loop, and threw the generic `JSSDK_CALL_ALL_ATTEMPTS_EXHAUSTED` — throwing away `lastError.code` (e.g. `QUERY_LIMIT_EXCEEDED`) and bypassing the `softErrorCodes` contract.

**Fix:** `attempt + 1 < maxRetries`. The last attempt now skips the retry/sleep branch and falls through to throw the **real** `lastError` (or soft-return it via `exceptionCodeForSoft`).

### #144 — bundle of small HTTP correctness fixes

- **Metrics:** `getStats()` reported `totalRequests` as `totalDuration`, and `reset()` set `totalDuration` to 0 *twice* while never clearing `totalRequests`. Both numbers in the public `getStats()` contract (used for limiter tuning) were wrong.
- **Header wipe:** the `axios.create({ …, ...(options && { ...options, headers: undefined }) })` spread wiped the merged default+caller headers (incl. the SDK `User-Agent`) whenever `options` was non-null. Headers are now built **last** and merged explicitly.
- **Immutability:** `AjaxResult.#buildNextPageQuery()` shallow-copied the query and wrote `start` back through the *shared* `params` reference, so after `getNext()` the previous result's `getQuery().params` silently changed (despite the class advertising an immutable API). Now returns a fresh `params` object (and drops a double `Text.toInteger`).

### Plain-language summary

Three small but real correctness bugs in the request layer: a rate-limited call that failed on its last try threw a useless generic error (and wasted up to 30s sleeping first) instead of the actual error code; the request-stats counters reported the wrong numbers; custom headers could get silently dropped; and paging through a list quietly corrupted the previous page's saved query. All fixed.

## Verification

- New **portal-free unit tests** (`test/integration/core/http-fixes.unit.spec.ts`, `jsSdk:unit`): the retry path throws the real code (`TEST_HARD_ERROR`, not the generic one) and the last attempt doesn't enter the retry branch; `getStats()`/`reset()` report/clear `totalRequests`; caller header + `User-Agent` both survive construction. **92/92 unit tests pass.**
- `tsc --noEmit` clean · `eslint` clean.
- The `#buildNextPageQuery` fix is verified by inspection (it's a `#private` method; exercising it via `getNext()` needs a live transport).

## Scope note

The third audit bug, **#145** (soft-error batch `AjaxResult` crashes `prepareResponse` with a raw `TypeError`), was **split into its own PR** — it needs a type-correct error-`Result` short-circuit in `HttpV2/V3.batch` plus a batch-flow test, so it's cleaner standalone.

Closes #143. Closes #144.

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_