### PR TITLE
feat(jssdk): add CommonJS support via dual ESM/CJS exports

### DIFF
--- a/.github/contributing/maintenance.md
+++ b/.github/contributing/maintenance.md
@@ -116,7 +116,7 @@ If a VibeCode endpoint has no Bitrix24 REST equivalent (AI Router, web search, i
 
 ## 4. Skill update conventions
 
-- Keep TypeScript / ESM style throughout. No `fetch + X-Api-Key` examples in the SDK skills (except the documented AI-add-on pattern in `b24jssdk-vibecode`).
+- Keep TypeScript / ESM style throughout (a skill-authoring convention — the package itself also ships CommonJS, but skills target TypeScript / ESM). No `fetch + X-Api-Key` examples in the SDK skills (except the documented AI-add-on pattern in `b24jssdk-vibecode`).
 - Use `$b24.actions.v{2,3}.*.make({ method, params, requestId? })` everywhere. **Do NOT** introduce `b24.callMethod(...)` or `b24.callBatch(...)` — they're `@deprecated` for 2.0.0.
 - Do NOT add MongoDB-style filter operators (`$gt`, `$ne`, `$contains`) anywhere in the b24jssdk skill set.
 - Use `EnumCrmEntityTypeId` from `@bitrix24/b24jssdk` over numeric literals.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,20 @@ jobs:
       - name: Build (jssdk)
         run: pnpm --filter ./packages/jssdk build
 
+      - name: Validate package exports (publint + arethetypeswrong + runtime resolution)
+        # Guards the dual ESM/CJS exports contract (#256): publint checks the
+        # exports map / files, arethetypeswrong checks types resolve correctly
+        # per module system, and the two node one-liners assert the built
+        # package actually resolves and exposes B24Hook under both require() and
+        # import — catching a regression in dist/umd/package.json or the
+        # exports conditions that the type-only tools would miss.
+        working-directory: packages/jssdk
+        run: |
+          npx --yes publint@0.3.21
+          npx --yes @arethetypeswrong/cli@0.18.4 --pack .
+          node -e "const m = require('@bitrix24/b24jssdk'); if (typeof m.B24Hook !== 'function') { console.error('CJS require did not expose B24Hook'); process.exit(1) } console.log('CJS require OK')"
+          node --input-type=module -e "const m = await import('@bitrix24/b24jssdk'); if (typeof m.B24Hook !== 'function') { console.error('ESM import did not expose B24Hook'); process.exit(1) } console.log('ESM import OK')"
+
       - name: Build (jssdk-nuxt)
         # Requires packages/jssdk-nuxt/.nuxt/tsconfig.json (from artifact) to resolve
         # tsconfig "extends". jssdk must be built first so @bitrix24/b24jssdk resolves.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file is the single source of truth for AI coding agents and human contribut
 
 `@bitrix24/b24jssdk` is a JS/TS SDK for the Bitrix24 REST API. It is a pnpm 11 monorepo that ships:
 
-- a framework-agnostic core SDK (`packages/jssdk`, published as `@bitrix24/b24jssdk`, ESM + UMD only since v0.4.0),
+- a framework-agnostic core SDK (`packages/jssdk`, published as `@bitrix24/b24jssdk`, shipping ESM, CommonJS, and UMD; ESM is the recommended entry point),
 - a thin Nuxt module wrapper (`packages/jssdk-nuxt`),
 - a public docs site (`docs/`, deployed to GitHub Pages),
 - manual smoke playgrounds (`playgrounds/cli`, `playgrounds/nuxt`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Features
+
+* **package:** add CommonJS support so the package can be consumed with `require('@bitrix24/b24jssdk')` (and from `tsx`-driven Node projects), in addition to ESM and UMD — previously a CommonJS / non-`import` resolver failed with `ERR_PACKAGE_PATH_NOT_EXPORTED`. `exports` now carries `require`/`default` conditions (with CJS-flavored `.d.cts` types), the build emits `dist/umd/package.json` (`{"type":"commonjs"}`) and `dist/umd/index.d.cts`, and `main` points at the UMD/CJS entry while `module` stays on ESM. ESM remains the recommended entry point; the CommonJS path resolves to the UMD bundle, which inlines its dependencies (a dedicated CJS build with external deps is planned). Verified end-to-end (`require`, `import`, `tsx`, TypeScript `node16`/`nodenext`/`bundler`, `publint`, `@arethetypeswrong/cli`) (#256)
+
 ### Bug Fixes
 
 * **pull:** `PullClient.destroy()` now fully tears the client down — removes its `beforeunload` / `offline` / `online` window listeners, cancels all seven pending timers (including the self-rescheduling `pull.watch.extend` watch loop), and no longer schedules a reconnect on teardown. A destroyed client is inert: `updateWatch` / `scheduleReconnect` / `onOnline` / `connect` and every timer-arming path bail out, and `start()` rejects with `PULL_DISPOSED`. Previously only the check interval was cleared, so timers and window listeners survived `destroy()` and the client kept firing background REST and could reconnect after an explicit teardown — accumulating across SPA/Nuxt `destroyB24Helper()` cycles (#141)

--- a/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
+++ b/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
@@ -11,7 +11,11 @@ We are still updating this page. Some data may be missing here — we will compl
 ## Add to a Node.js project
 
 ::note
-**`ESM` is the recommended module format.** `CommonJS` is also supported — you can `require('@bitrix24/b24jssdk')` from a CommonJS project (or run it with `tsx`). A `UMD` build is shipped as well for `<script>` usage in the browser.
+**`ESM` is the recommended module format.** `CommonJS` is also supported — you can `require('@bitrix24/b24jssdk')` from a CommonJS project (TypeScript files run directly with `ts-node` / `tsx` work too). A `UMD` build is shipped for `<script>` usage in the browser.
+::
+
+::warning
+The `CommonJS` entry resolves to the `UMD` bundle, which **inlines** its dependencies (`axios`, `luxon`, `qs-esm`). That means a `require()` consumer runs the bundled copy of `axios` rather than the one in their own `node_modules`, so `npm audit` will not flag a future `axios` advisory inside the SDK bundle until a new SDK version is published. The `ESM` entry keeps these dependencies external. A dedicated CommonJS build with external dependencies is planned.
 ::
 
 Before you begin, make sure you have the latest version of Node.js installed.
@@ -63,6 +67,10 @@ const { LoggerFactory } = require('@bitrix24/b24jssdk')
 ```
 
 ### Init
+
+::note
+The examples below use `ESM` `import` syntax. In a CommonJS project, replace each `import { X } from '@bitrix24/b24jssdk'` with `const { X } = require('@bitrix24/b24jssdk')`.
+::
 
 :::tabs
 

--- a/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
+++ b/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
@@ -11,7 +11,7 @@ We are still updating this page. Some data may be missing here — we will compl
 ## Add to a Node.js project
 
 ::note
-Since version `0.4.0` CommonJs is not supported. Only `ESM` and `UMD`.
+**`ESM` is the recommended module format.** `CommonJS` is also supported — you can `require('@bitrix24/b24jssdk')` from a CommonJS project (or run it with `tsx`). A `UMD` build is shipped as well for `<script>` usage in the browser.
 ::
 
 Before you begin, make sure you have the latest version of Node.js installed.
@@ -48,10 +48,18 @@ bun add @bitrix24/b24jssdk
 
 ### Import
 
-Import the library into your project:
+Import the library into your project.
+
+ESM (recommended):
 
 ```ts
 import { LoggerFactory } from '@bitrix24/b24jssdk'
+```
+
+CommonJS:
+
+```js
+const { LoggerFactory } = require('@bitrix24/b24jssdk')
 ```
 
 ### Init

--- a/docs/content/docs/1.getting-started/2.installation/5.umd.md
+++ b/docs/content/docs/1.getting-started/2.installation/5.umd.md
@@ -1,14 +1,14 @@
 ---
 title: UMD
 description: 'Guide for using UMD version Bitrix24 JS SDK in you applications.'
-audited: 2026-05-05
+audited: 2026-06-24
 links:
   - label: Build config (UMD output)
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/build.config.ts
 ---
 
-## Add to you project
+## Add to your project
 
 ::steps{level="3"}
 

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -2,7 +2,7 @@
 title: Logging & Credential Redaction
 description: 'What the SDK redacts automatically before any request information enters the logger or an AjaxError, what it does not redact, and how to wire a custom logger via setLogger(...) without re-introducing credential leaks.'
 category: 'logging'
-audited: 2026-06-22
+audited: 2026-06-24
 navigation.title: Logging & Redaction
 links:
   - label: redact.ts (canonical key list)

--- a/packages/jssdk/README-AI.md
+++ b/packages/jssdk/README-AI.md
@@ -518,6 +518,7 @@ try {
 
 - UMD: window.B24Js global; load via unpkg CDN; use inside Bitrix24 iframe
 - ESM: import from '@bitrix24/b24jssdk'; works in browsers with bundlers and in Node (server-side) for B24Hook
+- CommonJS: const { B24Hook } = require('@bitrix24/b24jssdk'); works in Node.js CJS projects (resolves to the UMD bundle, which inlines deps)
 
 
 ## Caveats and constraints

--- a/packages/jssdk/README-AI.md
+++ b/packages/jssdk/README-AI.md
@@ -27,7 +27,7 @@ Core building blocks:
 - UI managers: parent, slider, dialog, placement, options, auth
 - Helpers: B24HelperManager and useB24Helper hook; Pull client
 
-Note: since v0.4.0 the package ships ESM and UMD only (no CommonJS).
+Note: the package ships ESM, CommonJS, and UMD builds. ESM is the recommended entry point; CommonJS is supported via `require('@bitrix24/b24jssdk')`, and the UMD build is for `<script>` usage in the browser.
 
 ## Deprecation notice — read before generating code
 

--- a/packages/jssdk/README.md
+++ b/packages/jssdk/README.md
@@ -2,4 +2,6 @@
 
 JS SDK for using Bitrix24 REST API in local, production applications or via webhooks
 
+The package ships **ESM**, **CommonJS**, and **UMD** builds. ESM is the recommended entry point (`import { B24Hook } from '@bitrix24/b24jssdk'`); CommonJS is supported too (`const { B24Hook } = require('@bitrix24/b24jssdk')`), and the UMD build is for `<script>` usage in the browser.
+
 Find more details in the [documentation](https://bitrix24.github.io/b24jssdk/)

--- a/packages/jssdk/build.config.ts
+++ b/packages/jssdk/build.config.ts
@@ -1,3 +1,5 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
 import type { ModuleFormat } from 'rollup'
 import type { BuildConfig } from 'unbuild'
 import { defineBuildConfig } from 'unbuild'
@@ -135,19 +137,36 @@ function initConfig(formatTypeParam: string): BuildConfig {
             ctx.pkg.dependencies = {}
             ctx.options.dependencies = []
           },
-          // The root package is `"type": "module"`, so a bare `.js` file in
-          // `dist/umd` would be parsed as ESM and the UMD/CJS wrapper would
-          // export nothing under `require()`. Emitting a local
-          // `package.json` with `"type": "commonjs"` marks this directory as
-          // CommonJS so `require('@bitrix24/b24jssdk')` resolves correctly.
+          // CommonJS is served from the UMD bundle (a separate first-class CJS
+          // build with external deps is tracked as a follow-up). Two things are
+          // needed so `require('@bitrix24/b24jssdk')` resolves cleanly:
+          //
+          // 1. `dist/umd/package.json` with `"type": "commonjs"`. The root
+          //    package is `"type": "module"`, so a bare `.js` file in `dist/umd`
+          //    would otherwise be parsed as ESM and the UMD/CJS wrapper would
+          //    export nothing under `require()`.
+          // 2. `dist/umd/index.d.cts`. Without a CJS-flavored declaration, a
+          //    `require()` consumer under node16/nodenext gets the ESM `.d.ts`
+          //    describing a CommonJS module ("Masquerading as ESM" in
+          //    @arethetypeswrong/cli). The ESM build emits a single
+          //    self-contained `index.d.ts` (no relative re-exports), so it is
+          //    valid as a `.d.cts` describing the UMD bundle's named exports.
           async 'build:done'(ctx) {
-            const { writeFile, mkdir } = await import('node:fs/promises')
-            const { resolve } = await import('node:path')
             const umdDir = resolve(ctx.options.outDir)
             await mkdir(umdDir, { recursive: true })
             await writeFile(
               resolve(umdDir, 'package.json'),
               `${JSON.stringify({ type: 'commonjs' }, null, 2)}\n`
+            )
+            const esmDts = await readFile(
+              resolve(umdDir, '../esm/index.d.ts'),
+              'utf8'
+            )
+            await writeFile(
+              resolve(umdDir, 'index.d.cts'),
+              // Drop the ESM declaration-map pointer — there is no matching map
+              // for the .cts copy, and it is irrelevant to type resolution.
+              esmDts.replace(/\n\/\/# sourceMappingURL=.*$/m, '\n')
             )
           }
         }

--- a/packages/jssdk/build.config.ts
+++ b/packages/jssdk/build.config.ts
@@ -134,6 +134,21 @@ function initConfig(formatTypeParam: string): BuildConfig {
           async 'build:prepare'(ctx) {
             ctx.pkg.dependencies = {}
             ctx.options.dependencies = []
+          },
+          // The root package is `"type": "module"`, so a bare `.js` file in
+          // `dist/umd` would be parsed as ESM and the UMD/CJS wrapper would
+          // export nothing under `require()`. Emitting a local
+          // `package.json` with `"type": "commonjs"` marks this directory as
+          // CommonJS so `require('@bitrix24/b24jssdk')` resolves correctly.
+          async 'build:done'(ctx) {
+            const { writeFile, mkdir } = await import('node:fs/promises')
+            const { resolve } = await import('node:path')
+            const umdDir = resolve(ctx.options.outDir)
+            await mkdir(umdDir, { recursive: true })
+            await writeFile(
+              resolve(umdDir, 'package.json'),
+              `${JSON.stringify({ type: 'commonjs' }, null, 2)}\n`
+            )
           }
         }
       } as BuildConfig

--- a/packages/jssdk/package.json
+++ b/packages/jssdk/package.json
@@ -28,15 +28,21 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.mjs",
-      "require": "./dist/umd/index.js",
-      "default": "./dist/umd/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/umd/index.d.cts",
+        "default": "./dist/umd/index.js"
+      },
+      "default": "./dist/esm/index.mjs"
     },
     "./package.json": "./package.json"
   },
   "main": "./dist/umd/index.js",
   "module": "./dist/esm/index.mjs",
+  "types": "./dist/esm/index.d.ts",
   "typesVersions": {
     "*": { ".": ["./dist/esm/index.d.ts"] }
   },

--- a/packages/jssdk/package.json
+++ b/packages/jssdk/package.json
@@ -29,11 +29,13 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.mjs"
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/umd/index.js",
+      "default": "./dist/umd/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/esm/index.mjs",
+  "main": "./dist/umd/index.js",
   "module": "./dist/esm/index.mjs",
   "typesVersions": {
     "*": { ".": ["./dist/esm/index.d.ts"] }


### PR DESCRIPTION
Closes #256.

## What & why

The package was intentionally **ESM + UMD only** (documented since `v0.4.0`). This PR **adds CommonJS as a supported module format** — ESM stays the recommended entry point — so the package can be consumed with `require('@bitrix24/b24jssdk')` and from `tsx`-driven Node projects (a common setup for server-side bots/integrations), which previously hit `ERR_PACKAGE_PATH_NOT_EXPORTED` at resolution time.

This is an enhancement, not a regression fix: nothing about ESM changes, and the UMD bundle that powers CJS was already produced by the build — it just wasn't wired into `exports`.

## Changes

- **`packages/jssdk/package.json`** — add `require` + `default` conditions to `exports` (→ `./dist/umd/index.js`); `main` → UMD (CJS entry), `module` stays on the ESM bundle. ESM (`import`) is listed first, so it's preferred whenever the resolver supports it.
- **`packages/jssdk/build.config.ts`** — emit `dist/umd/package.json` with `{"type":"commonjs"}` on `build:done`. The root package is `"type":"module"`, which would otherwise make Node parse the UMD `.js` as ESM, so the UMD wrapper would export nothing under `require()`.
- **Docs** — `4.nodejs.md`, `README.md`, `README-AI.md`, `AGENTS.md`: ESM remains recommended; document that CommonJS is now supported via `require()`, and drop the stale "ESM + UMD only" wording.

## Verification

Reviewed across 5 independent lenses (packaging, build hook, consumer runtime, dual-package hazard, docs). Verified end-to-end against the packed `npm pack` tarball:

- `require('@bitrix24/b24jssdk')` → 94 named exports; `B24Hook`/`B24Frame` are functions.
- `import { B24Hook } from '@bitrix24/b24jssdk'` → unchanged, works.
- `tsx` (require + import) → resolves.
- TypeScript resolution under `bundler` / `node16` / `nodenext` → clean.
- Negative control with the old import-only `exports` reproduces the original error, confirming the new conditions are load-bearing.

## Follow-ups (not in this PR)

- Bump version + `CHANGELOG.md` entry for the release that ships this.
- Add `@arethetypeswrong/cli` / `publint` to CI to guard the `exports` map against future regressions.
- Emit a dedicated `dist/umd/index.d.cts` only if a meaningful default export is ever added (not needed today — verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lyze1Nje7fZLWE1KpCyxVx)_