### PR TITLE
fix(ci): smoke-retry nightly uses the existing NUXT_BITRIX24_TEST_WEBHOOK_URL secret (#47 follow-up)

### DIFF
--- a/.github/workflows/smoke-retry.yml
+++ b/.github/workflows/smoke-retry.yml
@@ -2,10 +2,13 @@ name: smoke-retry
 
 # Live smoke tests for the retry-policy fix (PR #45 / issues #44, #46), driven by
 # the playgrounds/cli `smoke-retry` command. They need a real portal, so the
-# workflow is gated on the `B24_HOOK` repository secret (a webhook URL) and runs
-# only on a nightly schedule + manual dispatch — never on PRs (forks have no
-# secret). Enable it by adding a `B24_HOOK` secret under
-# Settings -> Secrets and variables -> Actions. See playgrounds/cli/README.md.
+# workflow maps the existing `NUXT_BITRIX24_TEST_WEBHOOK_URL` repository secret (a
+# webhook URL — the same value local dev puts in `B24_HOOK`) onto the `B24_HOOK`
+# env var the CLI reads, and runs only on a nightly schedule + manual dispatch —
+# never on PRs (forks have no secret). It skips with a warning if the secret is
+# unset. The `NUXT_*` prefix is a misnomer (the secret is consumed SDK-wide, not
+# Nuxt-only); renaming it to `B24_HOOK` is a possible follow-up. See
+# playgrounds/cli/README.md.
 
 on:
   schedule:
@@ -31,13 +34,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Check B24_HOOK secret is present
+      - name: Check the webhook secret is present
         id: guard
         env:
-          B24_HOOK: ${{ secrets.B24_HOOK }}
+          B24_HOOK: ${{ secrets.NUXT_BITRIX24_TEST_WEBHOOK_URL }}
         run: |
           if [ -z "${B24_HOOK}" ]; then
-            echo "::warning::B24_HOOK secret is not set — add it under Settings -> Secrets and variables -> Actions to enable the live smoke tests. Skipping this run."
+            echo "::warning::NUXT_BITRIX24_TEST_WEBHOOK_URL secret is not set — add it under Settings -> Secrets and variables -> Actions to enable the live smoke tests. Skipping this run."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -69,7 +72,7 @@ jobs:
       - name: Run smoke-retry scenarios
         if: steps.guard.outputs.skip == 'false'
         env:
-          B24_HOOK: ${{ secrets.B24_HOOK }}
+          B24_HOOK: ${{ secrets.NUXT_BITRIX24_TEST_WEBHOOK_URL }}
           # `inputs.*` is empty on a schedule run, so fall back to the nightly defaults.
           SCENARIO: ${{ inputs.scenario || 'all' }}
           TOTAL: ${{ inputs.total || '200' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ pnpm vitest run --project jsSdk:unit -t "<test name>"
 
 **CI runs `jsSdk:unit` automatically** (`pnpm run package-jssdk:test:run-unit`) — no portal needed. `jsSdk:integration` and `jsSdk:underLoad` are your local-only responsibility — make sure the relevant test filter is green against a real portal before pushing.
 
-A nightly **[`smoke-retry.yml`](.github/workflows/smoke-retry.yml)** workflow runs the `playgrounds/cli` retry-policy smoke scenarios against a live portal. It is gated on a `B24_HOOK` **repository secret** (a webhook URL — *Settings → Secrets and variables → Actions*) and skips with a warning when that secret is absent; it never runs on pull requests. See [playgrounds/cli/README.md](playgrounds/cli/README.md#running-in-ci-nightly).
+A nightly **[`smoke-retry.yml`](.github/workflows/smoke-retry.yml)** workflow runs the `playgrounds/cli` retry-policy smoke scenarios against a live portal. It reuses the existing `NUXT_BITRIX24_TEST_WEBHOOK_URL` **repository secret** (a webhook URL), mapping it onto the `B24_HOOK` env var the CLI reads — so no new secret is needed; it skips with a warning when that secret is absent and never runs on pull requests. It fails (non-zero exit) on a definitive PR #45 regression. See [playgrounds/cli/README.md](playgrounds/cli/README.md#running-in-ci-nightly).
 
 ### Releasing
 

--- a/playgrounds/cli/README.md
+++ b/playgrounds/cli/README.md
@@ -347,10 +347,7 @@ pnpm --filter @bitrix24/b24jssdk-cli dev smoke-retry --scenario=all --taskId=201
 
 ### Running in CI (nightly)
 
-[`.github/workflows/smoke-retry.yml`](../../.github/workflows/smoke-retry.yml) runs these scenarios on a nightly schedule (and on manual **Run workflow** dispatch) against a real portal. It is gated on a **`B24_HOOK` repository secret** — the same webhook URL the local `.env` uses:
-
-1. In the GitHub repo: **Settings → Secrets and variables → Actions → New repository secret**.
-2. Name `B24_HOOK`, value `https://<portal>/rest/<userId>/<secret>/`.
+[`.github/workflows/smoke-retry.yml`](../../.github/workflows/smoke-retry.yml) runs these scenarios on a nightly schedule (and on manual **Run workflow** dispatch) against a real portal. It reuses the repository's existing **`NUXT_BITRIX24_TEST_WEBHOOK_URL`** secret (a webhook URL — the same value local dev puts in `B24_HOOK`), mapping it onto the `B24_HOOK` env var the CLI reads, so **no new secret is needed**. (The `NUXT_*` prefix is a misnomer — the secret is consumed SDK-wide; renaming it to `B24_HOOK` is a possible follow-up.)
 
 Without that secret the workflow logs a warning and skips (it never runs on pull requests, so forks are unaffected). The full trace is published as the `smoke-retry-log` artifact. Trigger an ad-hoc run from **Actions → smoke-retry → Run workflow** and pick a `scenario`.
 


### PR DESCRIPTION
## What

Follow-up correction to PR-2 (#274). The `smoke-retry` nightly referenced `secrets.B24_HOOK`, which is **not** a configured secret — so it would have **always skipped**.

The #47 body documents the actual secret: *"The repository already has the GitHub Actions secret `NUXT_BITRIX24_TEST_WEBHOOK_URL` configured (set up by @IgorShevchik)"* and recommends mapping it onto the `B24_HOOK` env var the CLI reads. (A review lens flagged this; I wrongly dismissed it after grepping repo *files* — secrets don't live in code. My mistake.)

## Fix

- `smoke-retry.yml`: `B24_HOOK: ${{ secrets.NUXT_BITRIX24_TEST_WEBHOOK_URL }}` in the guard + smoke steps (the CLI still reads `B24_HOOK`; only the source changes). Guard message + header comment updated.
- `playgrounds/cli/README.md` + `AGENTS.md`: the nightly **reuses the existing** `NUXT_BITRIX24_TEST_WEBHOOK_URL` secret — **no new secret needed**. Noted the `NUXT_*` prefix is a misnomer (the secret is consumed SDK-wide) and a rename is a possible follow-up (issue's option ii).

## Verification

`actionlint` 0 · `lint:md` 0 · `lint:md-links` 0 broken · no stray `secrets.B24_HOOK` remains.

Refs #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAcohwiBENjmcHrL5Kc47X)_