### PR TITLE
docs(jsdoc) + types: fill @todo docs (#154) and type request-side filters (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+* **types:** new exported request-side filter/params types — `TypeFilterV2` (the `restApi:v2` prefix-operator object), `TypeFilterV3` (the `restApi:v3` array of triples / `FilterV3` builder groups), and the per-version `TypeCallParamsV2` / `TypeCallParamsV3`. The v2/v3 `call` / `callList` / `fetchList` / `callTail` / `fetchTail` / `aggregate` action options now type their `filter`, so a wrong-dialect filter is flagged in the IDE. Backward compatible — the permissive index signature is retained and v3 still accepts a v2-style object filter (#153).
+
+### Changed
+
+* **types:** `TypeHttp.ajaxClient` is now `AxiosInstance` instead of `AxiosInstance | any` (the union erased the type) (#153).
+
+### Docs
+
+* Filled the `@todo docs` JSDoc placeholders across the public surface — actions (v2/v3), the HTTP transports, `AjaxResult`, the limiter stack, the `B24Hook` / `B24Frame` / `B24OAuth` entry points, tools, and public types (#154).
+
 ### Deprecations
 
 * The legacy REST surface — the `AbstractB24` shortcuts (`callMethod`, `callListMethod`, `fetchListMethod`, `callBatch`, `callBatchByChunk`) and the `batchSize` const, the `AjaxResult` paging helpers (`isMore` / `hasMore` / `getNext` / `fetchNext` / `getTotal`), and `LoggerBrowser` / `LoggerType` — remains available in `2.x` (it works and emits a runtime deprecation warning) and is **scheduled for removal in `3.0.0`** (was previously mislabelled for `2.0.0`). Migrate to `b24.actions.v{2,3}.*.make(...)`, the list helpers, and `LoggerFactory` — see the [v2 → v3 migration guide](https://bitrix24.github.io/b24jssdk/docs/getting-started/migration/v3/). Tracked in #277.

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: CallListV2.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 2.'
 category: 'actions'
-audited: 2026-06-26
+audited: 2026-06-28
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: CallList

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallListV3.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 3.'
 category: 'actions'
-audited: 2026-06-26
+audited: 2026-06-28
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: CallList

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: FetchListV2.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 2 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-06-12
+audited: 2026-06-28
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: FetchList

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: FetchListV3.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 3 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-06-25
+audited: 2026-06-28
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: FetchList

--- a/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
+++ b/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
@@ -2,7 +2,7 @@
 title: Restrictions System
 description: 'The restrictions system provides a comprehensive mechanism for managing request frequency, operation execution time, and adaptive delays.'
 category: 'limiters'
-audited: 2026-06-18
+audited: 2026-06-28
 navigation.title: Limiters
 links:
   - label: Limiters

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -2,7 +2,7 @@
 title: Logging & Credential Redaction
 description: 'What the SDK redacts automatically before any request information enters the logger or an AjaxError, what it does not redact, and how to wire a custom logger via setLogger(...) without re-introducing credential leaks.'
 category: 'logging'
-audited: 2026-06-27
+audited: 2026-06-28
 navigation.title: Logging & Redaction
 links:
   - label: redact.ts (canonical key list)

--- a/docs/content/docs/99.examples/1.dashboard-deals-csv.md
+++ b/docs/content/docs/99.examples/1.dashboard-deals-csv.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Export deals to CSV'
 description: 'Stream every CRM deal that matches a date filter into a CSV file using a webhook and FetchListV2.'
-audited: 2026-06-20
+audited: 2026-06-28
 category: 'examples'
 navigation:
   title: Deals → CSV

--- a/docs/content/docs/99.examples/2.frame-app-skeleton.md
+++ b/docs/content/docs/99.examples/2.frame-app-skeleton.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Frame app skeleton'
 description: 'Minimum viable Bitrix24 iframe app: init handshake, set title, persist app state, open a slider, close cleanly.'
-audited: 2026-06-20
+audited: 2026-06-28
 category: 'examples'
 navigation:
   title: Frame app skeleton

--- a/docs/content/docs/99.examples/3.webhook-cli-node.md
+++ b/docs/content/docs/99.examples/3.webhook-cli-node.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Webhook CLI smoke test'
 description: 'A 30-line Node script that authenticates against a Bitrix24 portal via inbound webhook and prints the calling user — useful as the first thing you run after creating a webhook.'
-audited: 2026-06-20
+audited: 2026-06-28
 category: 'examples'
 navigation:
   title: Webhook CLI

--- a/docs/content/docs/99.examples/4.bulk-update-deals.md
+++ b/docs/content/docs/99.examples/4.bulk-update-deals.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Bulk update deals'
 description: 'Migrate thousands of CRM deals to a new stage using BatchByChunkV2 — automatic chunking, partial-error handling, and a single progress line.'
-audited: 2026-06-20
+audited: 2026-06-28
 category: 'examples'
 navigation:
   title: Bulk update

--- a/packages/jssdk/src/core/abstract-b24.ts
+++ b/packages/jssdk/src/core/abstract-b24.ts
@@ -14,7 +14,10 @@ import { ActionsManager } from './actions/manager'
 import { ToolsManager } from './tools/manager'
 
 /**
- * @todo docs
+ * Abstract base class for all SDK entry points (B24Frame, B24Hook, etc.).
+ * Owns the HTTP clients for REST API v2 and v3, the actions surface via {@link ActionsManager},
+ * and built-in tools via {@link ToolsManager}.
+ * Concrete subclasses must implement authentication and HTTP transport initialization.
  */
 export abstract class AbstractB24 implements TypeB24 {
   /**

--- a/packages/jssdk/src/core/actions/v2/batch-by-chunk.ts
+++ b/packages/jssdk/src/core/actions/v2/batch-by-chunk.ts
@@ -16,7 +16,10 @@ export type ActionBatchByChunkV2 = ActionOptions & {
 /**
  * Executes a batch request with automatic chunking for any number of commands. `restApi:v2`
  *
- * @todo add docs
+ * Splits an arbitrarily large command list into sequential chunks of up to 50 and sends each
+ * chunk as a separate v2 batch call, merging successful results into a flat array. Unlike
+ * `BatchV2`, there is no 50-command ceiling for the caller, but named commands are not supported
+ * because they cannot be reliably merged across chunk boundaries.
  */
 export class BatchByChunkV2 extends AbstractBatch {
   /**

--- a/packages/jssdk/src/core/actions/v2/batch.ts
+++ b/packages/jssdk/src/core/actions/v2/batch.ts
@@ -17,7 +17,10 @@ export type ActionBatchV2 = ActionOptions & {
  * Executes a batch request to the Bitrix24 REST API with a maximum number of commands of no more than 50. `restApi:v2`
  * Allows you to execute multiple requests in a single API call, significantly improving performance.
  *
- * @todo add docs
+ * Sends up to 50 commands in a single v2 batch HTTP call and returns their results together.
+ * Supports array, object, and named-command formats. Unlike `BatchByChunkV2`, it does not
+ * split large command sets automatically — callers must ensure the command count stays within
+ * the 50-command limit.
  */
 export class BatchV2 extends AbstractBatch {
   /**

--- a/packages/jssdk/src/core/actions/v2/call-list.ts
+++ b/packages/jssdk/src/core/actions/v2/call-list.ts
@@ -1,12 +1,12 @@
 import type { ActionOptions } from '../abstract-action'
-import type { TypeCallParams } from '../../../types/http'
+import type { TypeCallParams, TypeCallParamsV2 } from '../../../types/http'
 import type { AjaxResult } from '../../http/ajax-result'
 import { AbstractAction } from '../abstract-action'
 import { Result } from '../../result'
 
 export type ActionCallListV2 = ActionOptions & {
   method: string
-  params?: Omit<TypeCallParams, 'start' | 'order'>
+  params?: Omit<TypeCallParamsV2, 'start' | 'order'>
   idKey?: string
   cursorIdKey?: string
   customKeyForResult?: string
@@ -29,7 +29,7 @@ export class CallListV2 extends AbstractAction {
    *
    * @param {ActionCallListV2} options - parameters for executing the request.
    *     - `method: string` - The name of the REST API method that returns a list of data (for example: `crm.item.list`, `tasks.task.list`)
-   *     - `params?: Omit<TypeCallParams, 'start' | 'order'>` - Request parameters, excluding the `start` and `order` parameters,
+   *     - `params?: Omit<TypeCallParamsV2, 'start' | 'order'>` - Request parameters, excluding the `start` and `order` parameters,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
    *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value

--- a/packages/jssdk/src/core/actions/v2/call-list.ts
+++ b/packages/jssdk/src/core/actions/v2/call-list.ts
@@ -16,7 +16,10 @@ export type ActionCallListV2 = ActionOptions & {
 /**
  * Fast data retrieval without counting the total number of records. `restApi:v2`
  *
- * @todo add docs
+ * Iterates through all pages of a v2 list method using cursor-based pagination (ordering and
+ * filtering by the item id) and collects every item into a single array returned as a `Result`.
+ * Unlike `FetchListV2`, which yields pages one by one via an async generator, this class waits
+ * for all pages to finish and returns the complete dataset in one call.
  */
 export class CallListV2 extends AbstractAction {
   /**

--- a/packages/jssdk/src/core/actions/v2/call.ts
+++ b/packages/jssdk/src/core/actions/v2/call.ts
@@ -13,7 +13,9 @@ export type ActionCallV2 = ActionOptions & {
 /**
  * Calls the Bitrix24 REST API method `restApi:v2`
  *
- * @todo add docs
+ * Executes a single REST API request against the v2 HTTP client and returns the raw response.
+ * Unlike `CallListV2`, `FetchListV2`, `BatchV2`, or `BatchByChunkV2`, this class makes exactly
+ * one HTTP call and returns the result without any pagination or batching logic.
  */
 export class CallV2 extends AbstractAction {
   /**

--- a/packages/jssdk/src/core/actions/v2/call.ts
+++ b/packages/jssdk/src/core/actions/v2/call.ts
@@ -1,12 +1,12 @@
 import type { ActionOptions } from '../abstract-action'
-import type { TypeCallParams } from '../../../types/http'
+import type { TypeCallParamsV2 } from '../../../types/http'
 import type { AjaxResult } from '../../http/ajax-result'
 import { AbstractAction } from '../abstract-action'
 import { ApiVersion } from '../../../types/b24'
 
 export type ActionCallV2 = ActionOptions & {
   method: string
-  params?: TypeCallParams
+  params?: TypeCallParamsV2
   requestId?: string
 }
 
@@ -25,7 +25,7 @@ export class CallV2 extends AbstractAction {
    *
    * @param {ActionCallV2} options - parameters for executing the request.
    *     - `method: string` - REST API method name (eg: `crm.item.get`)
-   *     - `params?: TypeCallParams` - Parameters for calling the method.
+   *     - `params?: TypeCallParamsV2` - Parameters for calling the method.
    *     - `requestId?: string` - Unique request identifier for tracking. Used for query deduplication and debugging.
    *
    * @returns {Promise<AjaxResult<T>>} A promise that resolves to the result of an REST API call.

--- a/packages/jssdk/src/core/actions/v2/fetch-list.ts
+++ b/packages/jssdk/src/core/actions/v2/fetch-list.ts
@@ -1,12 +1,12 @@
 import type { ActionOptions } from '../abstract-action'
-import type { TypeCallParams } from '../../../types/http'
+import type { TypeCallParams, TypeCallParamsV2 } from '../../../types/http'
 import type { AjaxResult } from '../../http/ajax-result'
 import { AbstractAction } from '../abstract-action'
 import { SdkError } from '../../sdk-error'
 
 export type ActionFetchListV2 = ActionOptions & {
   method: string
-  params?: Omit<TypeCallParams, 'start' | 'order'>
+  params?: Omit<TypeCallParamsV2, 'start' | 'order'>
   idKey?: string
   cursorIdKey?: string
   customKeyForResult?: string
@@ -30,7 +30,7 @@ export class FetchListV2 extends AbstractAction {
    *
    * @param {ActionFetchListV2} options - parameters for executing the request.
    *     - `method: string` - The name of the REST API method that returns a list of data (for example: `crm.item.list`, `tasks.task.list`)
-   *     - `params?: Omit<TypeCallParams, 'start' | 'order'>` - Request parameters, excluding the `start` and `order` parameters,
+   *     - `params?: Omit<TypeCallParamsV2, 'start' | 'order'>` - Request parameters, excluding the `start` and `order` parameters,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
    *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value

--- a/packages/jssdk/src/core/actions/v2/fetch-list.ts
+++ b/packages/jssdk/src/core/actions/v2/fetch-list.ts
@@ -16,7 +16,10 @@ export type ActionFetchListV2 = ActionOptions & {
 /**
  * Calls a REST API list method and returns an async generator for efficient large data retrieval. `restApi:v2`
  *
- * @todo add docs
+ * Iterates through all pages of a v2 list method using cursor-based pagination and yields each
+ * page as an array, allowing callers to process records incrementally without holding the entire
+ * dataset in memory. Unlike `CallListV2`, which accumulates all pages before returning, this
+ * class exposes an `AsyncGenerator` so processing can begin as soon as the first page arrives.
  */
 export class FetchListV2 extends AbstractAction {
   /**

--- a/packages/jssdk/src/core/actions/v3/aggregate.ts
+++ b/packages/jssdk/src/core/actions/v3/aggregate.ts
@@ -1,5 +1,5 @@
 import type { ActionOptions } from '../abstract-action'
-import type { TypeCallParams } from '../../../types/http'
+import type { TypeCallParams, TypeCallParamsV3 } from '../../../types/http'
 import type { AjaxResult } from '../../http/ajax-result'
 import { AbstractAction } from '../abstract-action'
 import { Result } from '../../result'
@@ -31,7 +31,7 @@ export type AggregateResultV3 = Partial<Record<AggregateFunctionV3, Record<strin
 export type ActionAggregateV3 = ActionOptions & {
   method: string
   select: AggregateSelectV3
-  params?: Pick<TypeCallParams, 'filter'>
+  params?: Pick<TypeCallParamsV3, 'filter'>
   requestId?: string
 }
 

--- a/packages/jssdk/src/core/actions/v3/batch-by-chunk.ts
+++ b/packages/jssdk/src/core/actions/v3/batch-by-chunk.ts
@@ -16,7 +16,10 @@ export type ActionBatchByChunkV3 = ActionOptions & {
 /**
  * Executes a batch request with automatic chunking for any number of commands. `restApi:v3`
  *
- * @todo add docs
+ * Splits an arbitrarily large command list into sequential chunks of up to 50 and sends each
+ * chunk as a separate v3 batch call, merging successful results into a flat array. Unlike
+ * `BatchV3`, there is no 50-command ceiling for the caller, but named commands are not supported
+ * because they cannot be reliably merged across chunk boundaries.
  */
 export class BatchByChunkV3 extends AbstractBatch {
   /**

--- a/packages/jssdk/src/core/actions/v3/batch.ts
+++ b/packages/jssdk/src/core/actions/v3/batch.ts
@@ -17,7 +17,11 @@ export type ActionBatchV3 = ActionOptions & {
  * Executes a batch request to the Bitrix24 REST API with a maximum number of commands of no more than 50. `restApi:v3`
  * Allows you to execute multiple requests in a single API call, significantly improving performance.
  *
- * @todo add docs
+ * Sends up to 50 commands in a single v3 batch HTTP call and returns their results together.
+ * Supports array, object, and named-command formats. Unlike `BatchByChunkV3`, it does not split
+ * large command sets automatically — callers must keep the command count within the 50-command
+ * limit. Compared to `BatchV2`, it routes through the v3 endpoint without a client-side method
+ * allowlist.
  */
 export class BatchV3 extends AbstractBatch {
   /**

--- a/packages/jssdk/src/core/actions/v3/call-list.ts
+++ b/packages/jssdk/src/core/actions/v3/call-list.ts
@@ -1,12 +1,12 @@
 import type { ActionOptions } from '../abstract-action'
-import type { TypeCallParams } from '../../../types/http'
+import type { TypeCallParams, TypeCallParamsV3 } from '../../../types/http'
 import { AbstractAction } from '../abstract-action'
 import { Result } from '../../result'
 import { keysetPaginate, KeysetPaginationError } from './_keyset-paginate'
 
 export type ActionCallListV3 = ActionOptions & {
   method: string
-  params?: Omit<TypeCallParams, 'pagination' | 'order'>
+  params?: Omit<TypeCallParamsV3, 'pagination' | 'order'>
   idKey?: string
   cursorIdKey?: string
   customKeyForResult: string
@@ -31,7 +31,7 @@ export class CallListV3 extends AbstractAction {
    *
    * @param {ActionCallListV3} options - parameters for executing the request.
    *     - `method: string` - The name of the REST API method that returns a list of data (for example: `crm.item.list`, `tasks.task.list`)
-   *     - `params?: Omit<TypeCallParams, 'pagination' | 'order'>` - Request parameters, excluding the `pagination` and `order` parameters,
+   *     - `params?: Omit<TypeCallParamsV3, 'pagination' | 'order'>` - Request parameters, excluding the `pagination` and `order` parameters,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
    *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value

--- a/packages/jssdk/src/core/actions/v3/call-list.ts
+++ b/packages/jssdk/src/core/actions/v3/call-list.ts
@@ -19,7 +19,7 @@ export type ActionCallListV3 = ActionOptions & {
  *
  * Iterates through all pages of a v3 list method using keyset (cursor) pagination and collects
  * every item into a single array returned as a `Result`. Unlike the v2 counterpart `CallListV2`,
- * it uses v3-style array filter syntax and supports the `limit` option (up to 1000 per page).
+ * it uses v3-style array filter syntax and supports the `limit` option (the server enforces its own per-method maximum, commonly 1000).
  * Unlike `FetchListV3`, which streams pages via an async generator, this class returns the
  * complete dataset in one awaited call.
  */

--- a/packages/jssdk/src/core/actions/v3/call-list.ts
+++ b/packages/jssdk/src/core/actions/v3/call-list.ts
@@ -17,7 +17,11 @@ export type ActionCallListV3 = ActionOptions & {
 /**
  * Fast data retrieval without counting the total number of records. `restApi:v3`
  *
- * @todo add docs
+ * Iterates through all pages of a v3 list method using keyset (cursor) pagination and collects
+ * every item into a single array returned as a `Result`. Unlike the v2 counterpart `CallListV2`,
+ * it uses v3-style array filter syntax and supports the `limit` option (up to 1000 per page).
+ * Unlike `FetchListV3`, which streams pages via an async generator, this class returns the
+ * complete dataset in one awaited call.
  */
 export class CallListV3 extends AbstractAction {
   /**

--- a/packages/jssdk/src/core/actions/v3/call-tail.ts
+++ b/packages/jssdk/src/core/actions/v3/call-tail.ts
@@ -1,5 +1,5 @@
 import type { ActionOptions } from '../abstract-action'
-import type { TypeCallParams } from '../../../types/http'
+import type { TypeCallParams, TypeCallParamsV3 } from '../../../types/http'
 import { AbstractAction } from '../abstract-action'
 import { Result } from '../../result'
 import { SdkError } from '../../sdk-error'
@@ -7,7 +7,7 @@ import { keysetPaginate, KeysetPaginationError } from './_keyset-paginate'
 
 export type ActionCallTailV3 = ActionOptions & {
   method: string
-  params?: Omit<TypeCallParams, 'pagination' | 'order' | 'cursor'>
+  params?: Omit<TypeCallParamsV3, 'pagination' | 'order' | 'cursor'>
   cursorField?: string
   order?: 'ASC' | 'DESC' | 'asc' | 'desc' | string
   customKeyForResult?: string
@@ -33,7 +33,7 @@ export class CallTailV3 extends AbstractAction {
    *
    * @param {ActionCallTailV3} options - parameters for executing the request.
    *     - `method: string` - A REST API `tail` method name (for example: `main.eventlog.tail`).
-   *     - `params?: Omit<TypeCallParams, 'pagination' | 'order' | 'cursor'>` - Request parameters
+   *     - `params?: Omit<TypeCallParamsV3, 'pagination' | 'order' | 'cursor'>` - Request parameters
    *         (`filter`, `select`). `pagination`, `order` and `cursor` are managed by this helper.
    *         The cursor field must NOT be used in `filter`.
    *     - `cursorField?: string` - The DTO field that drives the cursor. Default is `id`.

--- a/packages/jssdk/src/core/actions/v3/call.ts
+++ b/packages/jssdk/src/core/actions/v3/call.ts
@@ -13,7 +13,10 @@ export type ActionCallV3 = ActionOptions & {
 /**
  * Calls the Bitrix24 REST API method `restApi:v3`
  *
- * @todo add docs
+ * Executes a single REST API request against the v3 HTTP client and returns the raw response.
+ * Unlike its v2 counterpart `CallV2`, it routes through the v3 endpoint without a client-side
+ * method allowlist — the server validates the method and returns `METHODNOTFOUNDEXCEPTION` for
+ * unknown ones. Like `CallV2`, it makes exactly one HTTP call with no pagination or batching.
  */
 export class CallV3 extends AbstractAction {
   /**

--- a/packages/jssdk/src/core/actions/v3/call.ts
+++ b/packages/jssdk/src/core/actions/v3/call.ts
@@ -1,12 +1,12 @@
 import type { ActionOptions } from '../abstract-action'
-import type { TypeCallParams } from '../../../types/http'
+import type { TypeCallParamsV3 } from '../../../types/http'
 import type { AjaxResult } from '../../http/ajax-result'
 import { AbstractAction } from '../abstract-action'
 import { ApiVersion } from '../../../types/b24'
 
 export type ActionCallV3 = ActionOptions & {
   method: string
-  params?: TypeCallParams
+  params?: TypeCallParamsV3
   requestId?: string
 }
 
@@ -26,7 +26,7 @@ export class CallV3 extends AbstractAction {
    *
    * @param {ActionCallV3} options - parameters for executing the request.
    *     - `method: string` - REST API method name (eg: `crm.item.get`)
-   *     - `params?: TypeCallParams` - Parameters for calling the method.
+   *     - `params?: TypeCallParamsV3` - Parameters for calling the method.
    *     - `requestId?: string` - Unique request identifier for tracking. Used for query deduplication and debugging.
    *
    * @returns {Promise<AjaxResult<T>>} A promise that resolves to the result of an REST API call.

--- a/packages/jssdk/src/core/actions/v3/fetch-list.ts
+++ b/packages/jssdk/src/core/actions/v3/fetch-list.ts
@@ -17,7 +17,12 @@ export type ActionFetchListV3 = ActionOptions & {
 /**
  * Calls a REST API list method and returns an async generator for efficient large data retrieval. `restApi:v3`
  *
- * @todo add docs
+ * Iterates through all pages of a v3 list method using keyset (cursor) pagination and yields
+ * each page as an array, allowing callers to process records incrementally without holding the
+ * entire dataset in memory. Unlike `CallListV3`, which accumulates all pages before returning,
+ * this class exposes an `AsyncGenerator` so processing can begin as soon as the first page
+ * arrives. Compared to `FetchListV2`, it uses v3-style array filter syntax and supports the
+ * `limit` option (up to 1000 per page).
  */
 export class FetchListV3 extends AbstractAction {
   /**

--- a/packages/jssdk/src/core/actions/v3/fetch-list.ts
+++ b/packages/jssdk/src/core/actions/v3/fetch-list.ts
@@ -1,12 +1,12 @@
 import type { ActionOptions } from '../abstract-action'
-import type { TypeCallParams } from '../../../types/http'
+import type { TypeCallParams, TypeCallParamsV3 } from '../../../types/http'
 import { AbstractAction } from '../abstract-action'
 import { SdkError } from '../../sdk-error'
 import { keysetPaginate, KeysetPaginationError } from './_keyset-paginate'
 
 export type ActionFetchListV3 = ActionOptions & {
   method: string
-  params?: Omit<TypeCallParams, 'pagination' | 'order'>
+  params?: Omit<TypeCallParamsV3, 'pagination' | 'order'>
   idKey?: string
   cursorIdKey?: string
   customKeyForResult: string
@@ -33,7 +33,7 @@ export class FetchListV3 extends AbstractAction {
    *
    * @param {ActionFetchListV3} options - parameters for executing the request.
    *     - `method: string` - The name of the REST API method that returns a list of data (for example: `crm.item.list`, `tasks.task.list`)
-   *     - `params?: Omit<TypeCallParams, 'pagination' | 'order'>` - Request parameters, excluding the `pagination` and `order` parameters,
+   *     - `params?: Omit<TypeCallParamsV3, 'pagination' | 'order'>` - Request parameters, excluding the `pagination` and `order` parameters,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.
    *     - `idKey?: string` - The name of the id field as it appears in each RESPONSE item; its value

--- a/packages/jssdk/src/core/actions/v3/fetch-tail.ts
+++ b/packages/jssdk/src/core/actions/v3/fetch-tail.ts
@@ -1,12 +1,12 @@
 import type { ActionOptions } from '../abstract-action'
-import type { TypeCallParams } from '../../../types/http'
+import type { TypeCallParams, TypeCallParamsV3 } from '../../../types/http'
 import { AbstractAction } from '../abstract-action'
 import { SdkError } from '../../sdk-error'
 import { keysetPaginate, KeysetPaginationError } from './_keyset-paginate'
 
 export type ActionFetchTailV3 = ActionOptions & {
   method: string
-  params?: Omit<TypeCallParams, 'pagination' | 'order' | 'cursor'>
+  params?: Omit<TypeCallParamsV3, 'pagination' | 'order' | 'cursor'>
   cursorField?: string
   order?: 'ASC' | 'DESC' | 'asc' | 'desc' | string
   customKeyForResult?: string
@@ -36,7 +36,7 @@ export class FetchTailV3 extends AbstractAction {
    *
    * @param {ActionFetchTailV3} options - parameters for executing the request.
    *     - `method: string` - A REST API `tail` method name (for example: `main.eventlog.tail`).
-   *     - `params?: Omit<TypeCallParams, 'pagination' | 'order' | 'cursor'>` - Request parameters.
+   *     - `params?: Omit<TypeCallParamsV3, 'pagination' | 'order' | 'cursor'>` - Request parameters.
    *         Use `filter` and `select` to control the selection. `pagination`, `order` and `cursor`
    *         are managed by this helper and must not be passed. The cursor field must NOT be used in `filter`.
    *     - `cursorField?: string` - The DTO field that drives the cursor. Must be monotonic and

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -47,11 +47,15 @@ export type TypePrepareParams = TypeCallParams & {
 }
 
 /**
- * Abstract Class for working with RestApi requests via http
+ * Abstract base class for all Bitrix24 REST API HTTP transports.
+ *
+ * Provides shared infrastructure used by {@link HttpV2} and {@link HttpV3}: Axios instance
+ * lifecycle, auth token management (including coalesced refresh on 401), rate/operating/adaptive
+ * limiting via {@link RestrictionManager}, request-id generation, structured logging with
+ * payload truncation, and request metrics. Concrete subclasses implement version-specific
+ * batch strategies.
  *
  * @link https://bitrix24.github.io/b24jssdk/
- *
- * @todo docs
  */
 export abstract class AbstractHttp implements TypeHttp {
   protected _clientAxios: AxiosInstance

--- a/packages/jssdk/src/core/http/ajax-result.ts
+++ b/packages/jssdk/src/core/http/ajax-result.ts
@@ -28,9 +28,13 @@ type ErrorData = {
 }
 
 /**
- * Result of request to Rest Api
+ * Typed result wrapper for a single Bitrix24 REST API response.
  *
- * @todo docs
+ * Extends {@link Result} with the raw HTTP status, the originating query
+ * (method, params, requestId), and the deserialized payload. On construction
+ * it inspects the payload for API-level error fields and populates the
+ * inherited error collection, so callers can branch on {@link isSuccess}
+ * without inspecting raw HTTP status codes.
  */
 export class AjaxResult<T = unknown> extends Result<Payload<T>> implements IResult<Payload<T>> {
   private readonly _status: number

--- a/packages/jssdk/src/core/http/limiters/adaptive-delayer.ts
+++ b/packages/jssdk/src/core/http/limiters/adaptive-delayer.ts
@@ -4,9 +4,14 @@ import type { LoggerInterface } from '../../../types/logger'
 import { LoggerFactory } from '../../../logger'
 
 /**
- * Adaptive delayer
+ * Inserts proactive delays based on observed server load.
  *
- * @todo docs
+ * Unlike hard limiters, `AdaptiveDelayer` never blocks a request outright —
+ * {@link canProceed} always returns `true`. Instead, {@link waitIfNeeded}
+ * calculates a back-off delay derived from the current operating-time
+ * consumption reported by {@link OperatingLimiter} and the configured
+ * {@link AdaptiveConfig}, smoothing request throughput before quota limits
+ * are actually hit.
  */
 export class AdaptiveDelayer implements ILimiter {
   #config: AdaptiveConfig

--- a/packages/jssdk/src/core/http/limiters/manager.ts
+++ b/packages/jssdk/src/core/http/limiters/manager.ts
@@ -6,9 +6,14 @@ import { OperatingLimiter } from './operating-limiter'
 import { AdaptiveDelayer } from './adaptive-delayer'
 
 /**
- * Delay Management Manager
+ * Central coordinator for all outbound request throttling.
  *
- * @todo docs
+ * Composes a {@link RateLimiter} (requests-per-second cap), an
+ * {@link OperatingLimiter} (Bitrix24 operating-time budget), and an
+ * {@link AdaptiveDelayer} (back-off based on observed server load) into a
+ * single façade consumed by {@link AbstractHttp}. Tracks aggregate stats
+ * (retries, consecutive errors, limit hits) and propagates a shared logger
+ * to all three sub-limiters.
  */
 export class RestrictionManager {
   #rateLimiter: RateLimiter

--- a/packages/jssdk/src/core/http/limiters/operating-limiter.ts
+++ b/packages/jssdk/src/core/http/limiters/operating-limiter.ts
@@ -16,9 +16,13 @@ interface OperatingStats {
 }
 
 /**
- * Operating limiting
+ * Enforces the Bitrix24 per-method operating-time budget.
  *
- * @todo docs
+ * Bitrix24 charges each REST call against a rolling 10-minute CPU-time
+ * quota (`operating` field in the response). This limiter tracks that
+ * quota per method and blocks further calls (via {@link ILimiter.canProceed})
+ * until the reset timestamp has passed, preventing `QUERY_LIMIT_EXCEEDED`
+ * errors caused by heavy requests exhausting the portal's operating budget.
  */
 export class OperatingLimiter implements ILimiter {
   #config: OperatingLimitConfig

--- a/packages/jssdk/src/core/http/v2.ts
+++ b/packages/jssdk/src/core/http/v2.ts
@@ -16,11 +16,14 @@ import { ProcessingAsObjectV2 } from '../interaction/batch/processing/v2/as-obje
 import { AjaxError } from './ajax-error'
 
 /**
- * Class for working with RestApi v2 requests via http
+ * HTTP transport for Bitrix24 REST API v2.
+ *
+ * Extends {@link AbstractHttp} with v2-specific batch execution: dispatches
+ * `batch` calls through {@link InteractionBatchV2} and selects either
+ * {@link ProcessingAsArrayV2} or {@link ProcessingAsObjectV2} depending on
+ * the shape of the commands argument.
  *
  * @link https://bitrix24.github.io/b24jssdk/
- *
- * @todo docs
  */
 export class HttpV2 extends AbstractHttp implements TypeHttp {
   constructor(

--- a/packages/jssdk/src/core/http/v3.ts
+++ b/packages/jssdk/src/core/http/v3.ts
@@ -17,12 +17,16 @@ import { ProcessingAsArrayV3 } from '../interaction/batch/processing/v3/as-array
 import { ProcessingAsObjectV3 } from '../interaction/batch/processing/v3/as-object'
 
 /**
- * Class for working with RestApi v3 requests via http
+ * HTTP transport for Bitrix24 REST API v3.
+ *
+ * Extends {@link AbstractHttp} with v3-specific batch execution: dispatches
+ * `batch` calls through {@link InteractionBatchV3} and selects either
+ * {@link ProcessingAsArrayV3} or {@link ProcessingAsObjectV3} depending on
+ * the shape of the commands argument. Use this transport when the target
+ * Bitrix24 portal supports the REST v3 protocol.
  *
  * @link https://bitrix24.github.io/b24jssdk/
  * @link https://apidocs.bitrix24.com/api-reference/rest-v3/index.html
- *
- * @todo docs
  */
 export class HttpV3 extends AbstractHttp implements TypeHttp {
   constructor(

--- a/packages/jssdk/src/core/interaction/batch/processing/v2/abstract-processing.ts
+++ b/packages/jssdk/src/core/interaction/batch/processing/v2/abstract-processing.ts
@@ -137,7 +137,8 @@ export abstract class AbstractProcessingV2 extends AbstractProcessing implements
          * However, `batch` is executed without retries, so there will be an immediate error.
          */
 
-        // @todo fix docs
+        // Errors are collected into the result rather than thrown, so all batch
+        // commands are processed even when individual ones fail.
         // @memo we not throw ajaxError
         this._processResponseError<T>(result, ajaxError, `${index}`)
         dataResult.set(index, data)

--- a/packages/jssdk/src/core/interaction/batch/processing/v3/abstract-processing.ts
+++ b/packages/jssdk/src/core/interaction/batch/processing/v3/abstract-processing.ts
@@ -125,7 +125,8 @@ export abstract class AbstractProcessingV3 extends AbstractProcessing implements
          * However, `batch` is executed without retries, so there will be an immediate error.
          */
 
-        // @todo fix docs
+        // Errors are collected into the result rather than thrown, so all batch
+        // commands are processed even when individual ones fail.
         // @memo we not throw ajaxError
         this._processResponseError<T>(result, ajaxError, `${commandIndex}`)
         dataResult.set(commandIndex, data)

--- a/packages/jssdk/src/core/interaction/batch/v3.ts
+++ b/packages/jssdk/src/core/interaction/batch/v3.ts
@@ -10,7 +10,7 @@ import { SdkError } from '../../sdk-error'
  */
 
 /**
- * @todo waite docs apiVer3
+ * Maximum number of commands allowed in a single batch request when using `restApi:v3`.
  */
 export const MAX_BATCH_COMMANDS_V3 = 50
 

--- a/packages/jssdk/src/core/tools/manager.ts
+++ b/packages/jssdk/src/core/tools/manager.ts
@@ -8,8 +8,9 @@ import { HealthCheck } from './healthcheck'
 const pingName = Symbol('ping')
 const healthCheckName = Symbol('healthCheck')
 /**
- * Some tools for TypeB24
- * @todo add docs
+ * Manages built-in diagnostic tools available on a {@link TypeB24} instance.
+ * Provides lazy-initialized access to {@link Ping} and {@link HealthCheck} tools,
+ * each identified by a unique symbol key stored in an internal map.
  */
 export class ToolsManager {
   protected _b24: TypeB24

--- a/packages/jssdk/src/frame/b24.ts
+++ b/packages/jssdk/src/frame/b24.ts
@@ -16,13 +16,21 @@ import { SliderManager } from './slider'
 import { PlacementManager } from './placement'
 
 /**
- * B24 Manager. Replacement api.bitrix24.com
+ * Bitrix24 client for applications embedded in an iframe (frame placement).
+ *
+ * Replaces the legacy `api.bitrix24.com` JS library. Initialise via the
+ * `initializeB24Frame()` factory, which performs the postMessage handshake
+ * with the parent Bitrix24 page and resolves once the app frame is ready.
+ *
+ * Key capabilities:
+ * - REST API calls (v2 & v3) with automatic token refresh on 401 responses.
+ * - Access to install/first-run flags (`isInstallMode`, `isFirstRun`).
+ * - UI helpers via `parent`, `dialog`, `slider`, and `placement` managers.
+ * - Per-app option storage through `options` manager.
  *
  * @link https://api.bitrix24.com/api/v1/
  * @link https://bitrix24.github.io/b24jssdk/docs/frame/
  * @see /bitrix/js/rest/applayout.js
- *
- * @todo add docs
  */
 export class B24Frame extends AbstractB24 implements TypeB24 {
   #isInstallMode: boolean = false

--- a/packages/jssdk/src/hook/b24.ts
+++ b/packages/jssdk/src/hook/b24.ts
@@ -18,7 +18,7 @@ import { versionManager } from '../core/version-manager'
  * @example
  * ```ts
  * const b24 = B24Hook.fromWebhookUrl('https://your_domain.bitrix24.com/rest/1/abc123xyz/')
- * const result = await b24.callMethod('user.current')
+ * const result = await b24.actions.v2.call.make({ method: 'user.current' })
  * ```
  *
  * @link https://bitrix24.github.io/b24jssdk/docs/hook/

--- a/packages/jssdk/src/hook/b24.ts
+++ b/packages/jssdk/src/hook/b24.ts
@@ -8,11 +8,20 @@ import { AuthHookManager } from './auth'
 import { versionManager } from '../core/version-manager'
 
 /**
- * B24.Hook Manager.
+ * Server-side Bitrix24 client based on an inbound webhook URL.
+ *
+ * Use this class to make REST API calls from a backend service using a
+ * pre-configured webhook. The webhook URL embeds a secret access key and
+ * therefore **must never be used in browser or mobile code** — instantiating
+ * `B24Hook` automatically enables a client-side warning for every HTTP call.
+ *
+ * @example
+ * ```ts
+ * const b24 = B24Hook.fromWebhookUrl('https://your_domain.bitrix24.com/rest/1/abc123xyz/')
+ * const result = await b24.callMethod('user.current')
+ * ```
  *
  * @link https://bitrix24.github.io/b24jssdk/docs/hook/
- *
- * @todo docs
  */
 export class B24Hook extends AbstractB24 implements TypeB24 {
   readonly #authHookManager: AuthHookManager
@@ -78,11 +87,20 @@ export class B24Hook extends AbstractB24 implements TypeB24 {
 
   // region Tools ////
   /**
-   * Init Webhook from url
-   *   - ver2 `https://your_domain.bitrix24.com/rest/{id}/{webhook}`
-   *   - ver3 `https://your_domain.bitrix24.com/rest/api/{id}/{webhook}`
+   * Creates a `B24Hook` instance from a webhook URL.
    *
-   * @todo docs
+   * Accepts both REST API v2 and v3 webhook formats:
+   *   - v2: `https://your_domain.bitrix24.com/rest/{userId}/{secret}`
+   *   - v3: `https://your_domain.bitrix24.com/rest/api/{userId}/{secret}`
+   *
+   * Validates that the URL uses HTTPS, has the correct path structure, and
+   * contains a numeric user ID. Throws a descriptive `Error` on any violation
+   * without echoing the URL (which contains the secret).
+   *
+   * @param url - Full webhook URL as shown in the Bitrix24 admin panel.
+   * @param options - Optional restriction parameters (rate limits, etc.).
+   * @returns A ready-to-use `B24Hook` instance.
+   * @throws {Error} If the URL is empty, not HTTPS, or has an invalid format.
    */
   public static fromWebhookUrl(
     url: string,

--- a/packages/jssdk/src/oauth/b24.ts
+++ b/packages/jssdk/src/oauth/b24.ts
@@ -18,7 +18,7 @@ import { versionManager } from '../core/version-manager'
  * @example
  * ```ts
  * const b24 = new B24OAuth(authOptions, { clientId: '...', clientSecret: '...' })
- * const result = await b24.callMethod('crm.lead.list')
+ * const result = await b24.actions.v2.call.make({ method: 'crm.lead.list' })
  * ```
  *
  * @link https://apidocs.bitrix24.com/settings/oauth/index.html
@@ -54,9 +54,8 @@ export class B24OAuth extends AbstractB24 implements TypeB24 {
 
   /**
    * Used to initialize information about the current user.
-   *
-   * @todo test this
    */
+  // TODO: add integration-test coverage for the admin-flag fetch
   public async initIsAdmin(requestId?: string): Promise<void> {
     const method = 'profile'
 

--- a/packages/jssdk/src/oauth/b24.ts
+++ b/packages/jssdk/src/oauth/b24.ts
@@ -8,12 +8,21 @@ import { AuthOAuthManager } from './auth'
 import { versionManager } from '../core/version-manager'
 
 /**
- * B24.OAuth Manager
+ * Server-side Bitrix24 client for OAuth 2.0 applications (local and distributed).
+ *
+ * Manages access- and refresh-token lifecycle: the underlying `AuthOAuthManager`
+ * automatically refreshes the access token when it expires, using the supplied
+ * `oAuthSecret` (client ID + client secret). Like `B24Hook`, this class is
+ * **server-side only** — OAuth secrets must not be exposed in browser code.
+ *
+ * @example
+ * ```ts
+ * const b24 = new B24OAuth(authOptions, { clientId: '...', clientSecret: '...' })
+ * const result = await b24.callMethod('crm.lead.list')
+ * ```
  *
  * @link https://apidocs.bitrix24.com/settings/oauth/index.html
  * @link https://bitrix24.github.io/b24jssdk/docs/oauth/
- *
- * @todo add docs
  */
 export class B24OAuth extends AbstractB24 implements TypeB24 {
   readonly #authOAuthManager: AuthOAuthManager

--- a/packages/jssdk/src/tools/index.ts
+++ b/packages/jssdk/src/tools/index.ts
@@ -1,5 +1,5 @@
 /**
- * @todo add docs
+ * Returns a new object containing only the specified keys from `data`.
  */
 export function pick<Data extends object, Keys extends keyof Data>(data: Data, keys: Keys[]): Pick<Data, Keys> {
   const result = {} as Pick<Data, Keys>
@@ -12,7 +12,7 @@ export function pick<Data extends object, Keys extends keyof Data>(data: Data, k
 }
 
 /**
- * @todo add docs
+ * Returns a shallow copy of `data` with the specified keys removed.
  */
 export function omit<Data extends object, Keys extends keyof Data>(data: Data, keys: Keys[]): Omit<Data, Keys> {
   const result = { ...data }
@@ -26,14 +26,14 @@ export function omit<Data extends object, Keys extends keyof Data>(data: Data, k
 }
 
 /**
- * @todo add docs
+ * Type guard that returns `true` when `item` is an array of arrays rather than a flat array.
  */
 export function isArrayOfArray<A>(item: A[] | A[][]): item is A[][] {
   return Array.isArray(item[0])
 }
 
 /**
- * @todo add docs
+ * Returns the enum member whose value equals `value`, or `undefined` if no match is found.
  *
  * @example
  * const result = getEnumValue(EnumBizprocDocumentType, 'CCrmDocumentSmartOrder')

--- a/packages/jssdk/src/types/b24.ts
+++ b/packages/jssdk/src/types/b24.ts
@@ -8,7 +8,8 @@ import type { ActionsManager } from '../core/actions/manager'
 import type { ToolsManager } from '../core/tools/manager'
 
 /**
- * @todo docs
+ * Core types for the Bitrix24 REST API client: API version enumeration, batch call options,
+ * and the main B24 client interface exposing HTTP, auth, tools, and actions managers.
  */
 
 export enum ApiVersion {

--- a/packages/jssdk/src/types/b24.ts
+++ b/packages/jssdk/src/types/b24.ts
@@ -1,3 +1,9 @@
+/**
+ * Core types for the Bitrix24 REST API client: API version enumeration, batch call options,
+ * and the main B24 client interface exposing HTTP, auth, tools, and actions managers.
+ *
+ * @module
+ */
 import type { LoggerInterface } from './logger'
 import type { AjaxResult } from '../core/http/ajax-result'
 import type { Result } from '../core/result'
@@ -6,11 +12,6 @@ import type { AuthActions } from './auth'
 import type { RestrictionParams } from './limiters'
 import type { ActionsManager } from '../core/actions/manager'
 import type { ToolsManager } from '../core/tools/manager'
-
-/**
- * Core types for the Bitrix24 REST API client: API version enumeration, batch call options,
- * and the main B24 client interface exposing HTTP, auth, tools, and actions managers.
- */
 
 export enum ApiVersion {
   v3 = 'v3',

--- a/packages/jssdk/src/types/bizproc/activity/index.ts
+++ b/packages/jssdk/src/types/bizproc/activity/index.ts
@@ -1,9 +1,9 @@
 /**
- * Data Types and Object Structure in the REST API bizproc activity and robot
+ * Data Types and Object Structure in the REST API bizproc activity and robot.
+ * Covers handler parameter shapes, property type enumerations, and descriptor interfaces used
+ * when registering or handling custom workflow activities and robots via the REST API.
  * @link https://apidocs.bitrix24.com/api-reference/bizproc/bizproc-activity/index.html
  * @link https://apidocs.bitrix24.com/api-reference/bizproc/bizproc-robot/index.html
- *
- * @todo add docs
  */
 import type { BoolString } from '../../common'
 import type { HandlerAuthParams } from '../../handler'

--- a/packages/jssdk/src/types/bizproc/index.ts
+++ b/packages/jssdk/src/types/bizproc/index.ts
@@ -1,8 +1,9 @@
 /**
- * Data Types and Object Structure in the REST API bizproc
+ * Data Types and Object Structure in the REST API bizproc.
+ * Provides enumerations for Bitrix24 edition variants, bizproc document base types, and CRM
+ * document types used when registering activities/robots or starting business-process workflows.
  * @link https://apidocs.bitrix24.com/api-reference/bizproc/bizproc-activity/bizproc-activity-add.html
  * @link https://apidocs.bitrix24.com/api-reference/bizproc/bizproc-robot/bizproc-robot-add.html
- * @todo add docs
  */
 import { EnumCrmEntityTypeId } from '../crm'
 

--- a/packages/jssdk/src/types/crm/entity-type.ts
+++ b/packages/jssdk/src/types/crm/entity-type.ts
@@ -42,7 +42,8 @@ export enum EnumCrmEntityTypeShort {
 }
 
 /**
- * @todo add docs
+ * Converts a numeric CRM entity type ID to its corresponding short string code.
+ * Returns `EnumCrmEntityTypeShort.undefined` when the ID has no matching entry.
  */
 export function getEnumCrmEntityTypeShort(id: EnumCrmEntityTypeId): EnumCrmEntityTypeShort {
   const key = EnumCrmEntityTypeId[id] as keyof typeof EnumCrmEntityTypeShort

--- a/packages/jssdk/src/types/event/index.ts
+++ b/packages/jssdk/src/types/event/index.ts
@@ -1,7 +1,8 @@
 /**
- * Data Types and Object Structure in the REST API event handler
+ * Data Types and Object Structure in the REST API event handler.
+ * Defines parameter shapes for incoming Bitrix24 event notifications, including
+ * app-install events and auth payloads delivered to registered event handler endpoints.
  * @link https://apidocs.bitrix24.com/api-reference/events/index.html
- * @todo add docs
  */
 import type { BoolString } from '../common'
 import type { HandlerAuthParams } from '../handler'

--- a/packages/jssdk/src/types/handler.ts
+++ b/packages/jssdk/src/types/handler.ts
@@ -1,6 +1,6 @@
 /**
- * Special cases of data passed to handlers
- * @todo add docs
+ * Types for authentication and OAuth token data passed to Bitrix24 REST API event handlers.
+ * `HandlerAuthParams` contains the full auth context provided with every incoming event request.
  */
 
 export interface HandlerAuthParams {

--- a/packages/jssdk/src/types/http.ts
+++ b/packages/jssdk/src/types/http.ts
@@ -4,6 +4,7 @@ import type { AjaxResult } from '../core/http/ajax-result'
 import type { PayloadTime } from './payloads'
 import type { RestrictionParams, RestrictionManagerStats } from './limiters'
 import type { ApiVersion } from './b24'
+import type { FilterV3Group } from '../tools/filter-v3'
 import type { AxiosInstance } from 'axios'
 
 /**
@@ -20,9 +21,10 @@ export type TypeFilterV2 = Record<string, unknown>
 /**
  * `restApi:v3` filter — an array of `[field, operator, value]` triples (joined
  * with AND at the top level), e.g. `[['id', '>', 100], ['stageId', '=', 'NEW']]`.
- * Build it ergonomically with {@link FilterV3}.
+ * Nested AND/OR/NOT groups are allowed too, so the output of the `FilterV3`
+ * builder (`FilterV3.build(...)`) assigns directly.
  */
-export type TypeFilterV3 = Array<[string, string, unknown]>
+export type TypeFilterV3 = Array<[string, string, unknown] | FilterV3Group>
 
 export type TypeCallParams = {
   order?: Record<string, 'ASC' | 'DESC' | 'asc' | 'desc' | string>
@@ -74,12 +76,14 @@ export type TypeCallParamsV2 = Omit<TypeCallParams, 'filter' | 'pagination' | 'c
 
 /**
  * Per-version specialisation of {@link TypeCallParams} that types the request-side
- * `filter` for `restApi:v3` (array of triples) and drops the v2-only `start`
- * field. The permissive `[key: string]: any` index signature is retained, so
- * existing call sites keep compiling.
+ * `filter` for `restApi:v3` and drops the v2-only `start` field. The preferred
+ * v3 shape is the array of triples / groups ({@link TypeFilterV3}); the v2-style
+ * object ({@link TypeFilterV2}) is still accepted for backward compatibility.
+ * The permissive `[key: string]: any` index signature is retained, so existing
+ * call sites keep compiling.
  */
 export type TypeCallParamsV3 = Omit<TypeCallParams, 'filter' | 'start'> & {
-  filter?: TypeFilterV3
+  filter?: TypeFilterV3 | TypeFilterV2
 }
 
 // region Batch interface ////

--- a/packages/jssdk/src/types/http.ts
+++ b/packages/jssdk/src/types/http.ts
@@ -11,6 +11,19 @@ import type { AxiosInstance } from 'axios'
  * pagination for both v2 and v3), batch command formats, and the core `TypeHttp` client interface.
  */
 
+/**
+ * `restApi:v2` filter — a prefix-operator dialect keyed by field, where the
+ * operator is encoded in the key, e.g. `{ '>id': 100, '%NAME': 'Iv' }`.
+ */
+export type TypeFilterV2 = Record<string, unknown>
+
+/**
+ * `restApi:v3` filter — an array of `[field, operator, value]` triples (joined
+ * with AND at the top level), e.g. `[['id', '>', 100], ['stageId', '=', 'NEW']]`.
+ * Build it ergonomically with {@link FilterV3}.
+ */
+export type TypeFilterV3 = Array<[string, string, unknown]>
+
 export type TypeCallParams = {
   order?: Record<string, 'ASC' | 'DESC' | 'asc' | 'desc' | string>
   filter?: any
@@ -47,6 +60,26 @@ export type TypeCallParams = {
     limit?: number
   }
   [key: string]: any
+}
+
+/**
+ * Per-version specialisation of {@link TypeCallParams} that types the request-side
+ * `filter` for `restApi:v2` (prefix-operator object) and drops the v3-only
+ * `pagination` / `cursor` fields. The permissive `[key: string]: any` index
+ * signature is retained, so existing call sites keep compiling.
+ */
+export type TypeCallParamsV2 = Omit<TypeCallParams, 'filter' | 'pagination' | 'cursor'> & {
+  filter?: TypeFilterV2
+}
+
+/**
+ * Per-version specialisation of {@link TypeCallParams} that types the request-side
+ * `filter` for `restApi:v3` (array of triples) and drops the v2-only `start`
+ * field. The permissive `[key: string]: any` index signature is retained, so
+ * existing call sites keep compiling.
+ */
+export type TypeCallParamsV3 = Omit<TypeCallParams, 'filter' | 'start'> & {
+  filter?: TypeFilterV3
 }
 
 // region Batch interface ////
@@ -122,7 +155,7 @@ export interface IRequestIdGenerator {
  */
 export type TypeHttp = {
   apiVersion: ApiVersion
-  ajaxClient: AxiosInstance | any
+  ajaxClient: AxiosInstance
 
   setLogger(logger: LoggerInterface): void
   getLogger(): LoggerInterface

--- a/packages/jssdk/src/types/http.ts
+++ b/packages/jssdk/src/types/http.ts
@@ -7,7 +7,8 @@ import type { ApiVersion } from './b24'
 import type { AxiosInstance } from 'axios'
 
 /**
- * @todo fix docs
+ * Types for HTTP communication with the Bitrix24 REST API: call parameters (filtering, ordering,
+ * pagination for both v2 and v3), batch command formats, and the core `TypeHttp` client interface.
  */
 
 export type TypeCallParams = {
@@ -81,7 +82,8 @@ export type BatchCommandV3 = {
 
 export type CommandTuple<M extends string = string, P = undefined | TypeCallParams> = [M, P?]
 /**
- * @todo add docs - api v3 only use this ??
+ * Object form of a batch command. The `as`, `parallel`, and `params.cursor` / `params.pagination`
+ * fields are supported in API v3 only; `params.start` is the v2 equivalent for offset pagination.
  */
 export interface CommandObject<M extends string = string, P = undefined | TypeCallParams> { method: M, params?: P, as?: string, parallel?: boolean }
 export type CommandUniversal<M extends string = string, P = undefined | TypeCallParams>

--- a/packages/jssdk/src/types/limiters.ts
+++ b/packages/jssdk/src/types/limiters.ts
@@ -1,6 +1,7 @@
 import type { LoggerInterface } from './logger'
 /**
- * @todo docs
+ * Types and interfaces for configuring rate-limiting and adaptive throttling of REST API requests.
+ * These settings control the operating time window, per-window limits, and adaptive pause behaviour.
  */
 
 /**

--- a/test/integration/core/call-params-types.unit.spec.ts
+++ b/test/integration/core/call-params-types.unit.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Type-level contract for the request-side filter typing added in #153.
+ * Uses Vitest's `expectTypeOf` — no runtime behaviour, just compile-time pins:
+ *  - v2 filter is the prefix-operator object dialect;
+ *  - v3 filter accepts the array of triples AND the `FilterV3` builder output
+ *    (which may include AND/OR/NOT groups);
+ *  - v3 still accepts a v2-style object for backward compatibility.
+ * Portal-free (jsSdk:unit).
+ */
+import { describe, it, expectTypeOf } from 'vitest'
+import type { TypeCallParamsV2, TypeCallParamsV3 } from '../../../packages/jssdk/src/types/http'
+import { FilterV3 as F } from '../../../packages/jssdk/src/tools/filter-v3'
+
+describe('#153 request-side filter typing', () => {
+  it('v2 accepts the prefix-operator object filter', () => {
+    const params: TypeCallParamsV2 = { filter: { '>id': 100, '%NAME': 'Iv' } }
+    expectTypeOf(params.filter).toMatchTypeOf<Record<string, unknown> | undefined>()
+  })
+
+  it('v3 accepts an array of triples', () => {
+    const params: TypeCallParamsV3 = { filter: [['id', '>', 100], ['stageId', '=', 'NEW']] }
+    expectTypeOf(params).toMatchTypeOf<{ filter?: unknown }>()
+  })
+
+  it('v3 accepts FilterV3.build() output, including groups', () => {
+    const built = F.build(F.eq('status', 'NEW'), F.or(F.in('id', [1, 2]), F.gt('id', 100)))
+    const params: TypeCallParamsV3 = { filter: built }
+    expectTypeOf(params.filter).not.toBeNever()
+  })
+
+  it('v3 still accepts a v2-style object filter (backward compatible)', () => {
+    const params: TypeCallParamsV3 = { filter: { '>id': 100 } }
+    expectTypeOf(params.filter).not.toBeNever()
+  })
+})


### PR DESCRIPTION
Implements **#154** (JSDoc) and the **non-breaking slice of #153** (request-side typing). Reviewed from five angles (docs, TS, tests, security, semver); findings addressed in a follow-up commit.

## #154 — JSDoc on the public surface

Replaced the ~40 `@todo docs` / `@todo add docs` placeholders with accurate, behaviour-based JSDoc across: actions (v2/v3 `call` / `callList` / `fetchList` / `batch` / `batchByChunk`), the HTTP transports (`AbstractHttp`, `HttpV2`, `HttpV3`), `AjaxResult`, the limiter stack (`RestrictionManager`, `OperatingLimiter`, `AdaptiveDelayer`), the entry points (`B24Hook`, `B24Frame`, `B24OAuth`), `ToolsManager`, and public types. Comments only — no code changes.

## #153 — type the request-side filter (non-breaking)

- New exported types in `types/http.ts`:
  - `TypeFilterV2` — the `restApi:v2` prefix-operator object (`{ '>id': 100 }`).
  - `TypeFilterV3` — the `restApi:v3` array of `[field, op, value]` triples **and** `FilterV3` builder groups (AND/OR/NOT), so `FilterV3.build(...)` assigns directly.
  - `TypeCallParamsV2` / `TypeCallParamsV3` — per-version specialisations that type `filter` and drop the other version's pagination field.
- Wired into the public v2/v3 `call` / `callList` / `fetchList` / `callTail` / `fetchTail` / `aggregate` option types, so a wrong-dialect filter is flagged at compile time.
- **Backward compatible:** the permissive `[key: string]: any` index signature is retained and v3 `filter` still accepts a v2-style object — existing callers don't break. Internal call sites keep the base `TypeCallParams`.
- `TypeHttp.ajaxClient`: `AxiosInstance | any` → `AxiosInstance` (the union erased the type).

The **breaking** remainder of #153 (`Result<T = any>` → `unknown`, removing the `[key: string]: any` catch-all, typing `params?: any`) is deferred to `3.0.0` — tracked in **#279**.

## Review fixes applied

- `TypeFilterV3` accepts builder groups, not just bare triples (TS reviewer — critical).
- v3 `filter` stays backward compatible via the object union (CTO/TS reviewers flagged array-only as breaking).
- `B24Hook` / `B24OAuth` `@example` blocks no longer use the deprecated `callMethod()` — they use `actions.v2.call.make()` (docs reviewer — critical).
- Converted a public `@todo test this` to an inline TODO; relocated the `types/b24.ts` module comment above imports.

## Verification

- `pnpm --filter ./packages/jssdk typecheck` — passes.
- `pnpm vitest run --project jsSdk:unit` — 267 passed (incl. 4 new type-level cases pinning the filter contract).
- `eslint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011EPfX3sufHdSvhdMz8BJPg)_