### PR TITLE
docs: b24sdk-examples tag-pinning convention (#120) + CHANGELOG cross-link to logging page (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@
 * **README:** full rewrite — badges, three entry points (`B24Hook` / `B24Frame` / `B24OAuth`), Quick Start (#114)
 * **cookbook:** 5 cookbook recipes + REST page lint + `audited:` freshness contract (#36)
 * **examples landing:** refresh `/docs/examples` to list all 20 recipes — Cookbook (5) / Extended catalogue (12) / UI showcases (3) (#116)
-* **logging:** document credential redaction in HTTP layer (#67), log-archive audit patterns + logging hygiene cross-link (#75)
+* **logging:** document credential redaction in HTTP layer (#67), log-archive audit patterns + logging hygiene cross-link (#75) — see [/docs/working-with-the-rest-api/logging/](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/logging/) (#52)
 * **examples (code align):** align inline TS examples with v1.1.0 / v1.1.1 type changes (#37)
 * **homepage:** examples nav cleanup, top-nav entry, cookbook + extended-catalogue sections (#104), card hover polish (#107), vite optimizeDeps + homepage improvements (#115)
 * **prerender / 404:** register 12 recipe pages in prerender list (#95), resolve remaining `docs:generate` failures (#99), absolute paths in examples index (#101), GitHub Pages 404 for trailing-slash URLs (#100)

--- a/docs/content/docs/99.examples/0.index.md
+++ b/docs/content/docs/99.examples/0.index.md
@@ -204,3 +204,5 @@ All runnable examples live in two places:
 ## Contributing
 
 Found a missing recipe? Open an issue in [bitrix24/b24jssdk](https://github.com/bitrix24/b24jssdk/issues). Pull requests against the SDK-native recipes go to this repository (under `skills/b24jssdk-recipes/examples/`); pull requests against the UI showcases go to [bitrix24/b24sdk-examples](https://github.com/bitrix24/b24sdk-examples).
+
+When deep-linking into `b24sdk-examples`, target a tag (`/tree/<tag>/…` or `/blob/<tag>/…`) rather than a branch (`/tree/main/…`). A tag is immutable, so the link keeps pointing at the exact code it was written against: it can't silently break when that repo refactors its tree, and — more importantly — it bounds supply-chain exposure if the external repo is ever renamed, transferred, or taken over. The repository has not cut a release tag yet, so existing deep links still point at `main`; pin them to a tag once one exists.


### PR DESCRIPTION
Two small docs/reference-hygiene issues, bundled.

## #120 — pin `b24sdk-examples` cross-repo links
The external `bitrix24/b24sdk-examples` repo has **no release tags** (verified: `/tags` and `/releases` are both empty), so the three `/tree/main/…` deep links **can't** be pinned to a tag yet. Instead of inventing a tag, this documents the convention in the examples index: deep-link to a tag (`/tree/<tag>/…` or `/blob/<tag>/…`), not a branch — a tag is immutable, so it survives refactors **and bounds supply-chain exposure if that repo is ever renamed, transferred, or taken over** (the risk the issue was filed for). The 3 existing deep links stay on `main` until a tag exists.

**#120 stays open** as the tracker to pin those links once `b24sdk-examples` cuts its first tag (per reviewer recommendation — the pinning acceptance criterion is structurally unmeetable today). The optional CI canary is deferred.

## #72 — CHANGELOG cross-link to the logging page
The logging docs page (`78.logging.md`, slug `/docs/working-with-the-rest-api/logging/`) actually shipped in **v1.2.0** — which the CHANGELOG already lists. So rather than a stray `[Unreleased]` bullet that would re-announce released work as new (caught by two reviewers), the existing v1.2.0 `logging` entry now carries the clickable page slug, house-style. #53's migration guide was folded into the logging page (PR #75), so no missing page is referenced.

## Verification (standard 5-reviewer cycle)
- `docs:lint-pages:strict` 0/0, `docs:lint-links` 0 broken, `lint:md` clean (CHANGELOG isn't in that glob; verified well-formed by eye).
- **Reviewer MUST-FIX applied:** the `#72` bullet was initially placed under `[Unreleased]`, mis-representing v1.2.0-shipped work as new → moved to amend the real v1.2.0 entry with a clickable link. **Security/accuracy fixes applied:** convention note strengthened to name the takeover/rename risk (not just refactor breakage) and to show the `/blob/<tag>/` analogue.
- No-tags premise independently re-verified by two reviewers.

Follow-ups (noted): pin the 3 deep links + add the CI canary once a tag exists (#120); backfill `[Unreleased] → Docs` coverage for the recently merged docs work (#73/#77/#82/#63/#105/#266/#272) — separate from #72's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6MQtPUx9MZjXY2rbLZhbv)_