### PR TITLE
security(auth): timeout-bounded frame refreshAuth + non-enumerable SdkError.originalError (#189)

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: CallV2.make
 description: 'A method for making Bitrix24 REST API version 2 calls.'
 category: 'actions'
-audited: 2026-07-01
+audited: 2026-07-02
 restApiVersion: 'rest-api-ver2'
 navigation.title: Call
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallV3.make
 description: 'Method for making Bitrix24 REST API version 3 calls.'
 category: 'actions'
-audited: 2026-07-01
+audited: 2026-07-02
 restApiVersion: 'rest-api-ver3'
 navigation.title: Call
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: CallListV2.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 2.'
 category: 'actions'
-audited: 2026-07-01
+audited: 2026-07-02
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: CallList

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallListV3.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 3.'
 category: 'actions'
-audited: 2026-07-01
+audited: 2026-07-02
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: CallList

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: FetchListV2.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 2 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-07-01
+audited: 2026-07-02
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: FetchList

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: FetchListV3.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 3 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-07-01
+audited: 2026-07-02
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: FetchList

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: BatchV2.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 2. Allows executing up to 50 commands in a single API call.'
 category: 'actions'
-audited: 2026-07-01
+audited: 2026-07-02
 restApiVersion: 'rest-api-ver2'
 navigation.title: Batch
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3. Allows executing up to 50 commands in a single API call.'
 category: 'actions'
-audited: 2026-07-01
+audited: 2026-07-02
 restApiVersion: 'rest-api-ver3'
 navigation.title: Batch
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV2.make
 description: 'Method for executing batch requests with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-07-01
+audited: 2026-07-02
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3 with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-07-01
+audited: 2026-07-02
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/6.errors.md
+++ b/docs/content/docs/2.working-with-the-rest-api/6.errors.md
@@ -3,7 +3,7 @@ title: Error codes and handling
 description: 'Reference for SdkError and AjaxError codes raised by the SDK, plus the Bitrix24 REST error codes that surface through them.'
 navigation:
   title: Errors
-audited: 2026-07-01
+audited: 2026-07-02
 links:
   - label: SdkError
     iconName: GitHubIcon
@@ -23,7 +23,7 @@ links:
 
 The SDK raises errors through two related classes:
 
-- `SdkError` — thrown by SDK code itself (validation, configuration, deprecated paths, internal invariants). Always carries a `code`, a `status` (HTTP-like), and an optional `originalError`.
+- `SdkError` — thrown by SDK code itself (validation, configuration, deprecated paths, internal invariants). Always carries a `code`, a `status` (HTTP-like), and an optional `originalError`. Since #189 `originalError` is **non-enumerable**: it stays readable as `err.originalError` for local debugging, but a spread `{ ...err }`, `Object.keys(err)`, `JSON.stringify(err)`, or a Sentry-style capture skips it — so the raw transport error (which may carry a webhook secret in its `config`) can't leak through generic serialization. Prefer `code` / `status` / `message` for anything you log.
 - `AjaxError extends SdkError` — thrown when an HTTP call to Bitrix24 fails. Adds `requestInfo` (`method`, `requestId`, request params) so you can correlate with portal-side logs. Since v1.1.2 (#39), `requestInfo` does **not** include the full request URL and credential-bearing fields inside `params` are redacted — the goal is to keep webhook secrets out of `toJSON()` / `toString()` output.
 
 Method-style results that don't throw — `Call`, `CallList`, `Batch`, `BatchByChunk` — surface failures through `Result`/`AjaxResult`: check `.isSuccess` and read `.getErrorMessages()`. `FetchList`, by contrast, **does** throw on failure (the generator can't complete partially).

--- a/docs/content/docs/99.examples/3.webhook-cli-node.md
+++ b/docs/content/docs/99.examples/3.webhook-cli-node.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Webhook CLI smoke test'
 description: 'A 30-line Node script that authenticates against a Bitrix24 portal via inbound webhook and prints the calling user — useful as the first thing you run after creating a webhook.'
-audited: 2026-07-01
+audited: 2026-07-02
 category: 'examples'
 featured: true
 cookbookOrder: 1

--- a/packages/jssdk/src/core/sdk-error.ts
+++ b/packages/jssdk/src/core/sdk-error.ts
@@ -13,15 +13,17 @@ export class SdkError extends Error {
   protected _status: number
   public readonly timestamp: Date
   /**
-   * Redaction contract: opaque, un-scrubbed payload. Outside the redaction
-   * contract — it may carry transport-layer detail (e.g. `AxiosError.config.url`
-   * / request headers) that logger-side redaction does NOT scrub. This class's
-   * own `toJSON()` / `toString()` already omit it — the risk is only if you
-   * access `err.originalError` directly, so do NOT blanket-stringify it into a
-   * log/error sink; surface `code` / `status` / `message` (and
-   * `AjaxError.requestInfo`, which IS redacted) instead. (#73)
+   * Opaque, un-scrubbed payload — may carry transport-layer detail
+   * (e.g. `AxiosError.config.url` / request headers) with credentials that the
+   * logger-side redaction does NOT scrub. It is defined **non-enumerable**
+   * (see the constructor) so property-walking serializers — a spread
+   * `{ ...err }`, `Object.keys(err)`, `Object.assign({}, err)`, or a
+   * Sentry-style capture — skip it and can't leak the secret. `toJSON()` /
+   * `toString()` already omit it too. It stays readable as `err.originalError`
+   * for local debugging; prefer `code` / `status` / `message` (and
+   * `AjaxError.requestInfo`, which IS redacted) for anything you log. (#73, #189)
    */
-  public readonly originalError?: unknown
+  declare public readonly originalError?: unknown
 
   constructor(params: SdkErrorDetails) {
     const message = SdkError.formatErrorMessage(params)
@@ -31,7 +33,15 @@ export class SdkError extends Error {
     this.code = params.code
 
     this._status = params.status
-    this.originalError = params.originalError
+    // Non-enumerable so a serializer that walks own-enumerable properties
+    // (Sentry, `{ ...err }`, `Object.keys`) never sees the raw error and its
+    // credential-bearing `config`; still accessible via `err.originalError`. (#189)
+    Object.defineProperty(this, 'originalError', {
+      value: params.originalError,
+      enumerable: false,
+      writable: false,
+      configurable: true
+    })
     this.timestamp = new Date()
 
     this.cleanErrorStack()

--- a/packages/jssdk/src/frame/auth.ts
+++ b/packages/jssdk/src/frame/auth.ts
@@ -3,6 +3,13 @@ import type { MessageManager } from './message'
 import type { AuthActions, AuthData, RefreshAuthData, MessageInitData } from '../types/auth'
 import type { ApiVersion } from '../types/b24'
 import { MessageCommands } from './message'
+import { SdkError } from '../core/sdk-error'
+
+// How long to wait for the parent window to answer a `refreshAuth` postMessage
+// before giving up. Without this the promise never settles if the parent is
+// slow / navigated away / blocked — and since #182 every 401 refreshes, so a
+// hung parent would hang the request. (#189)
+const REFRESH_AUTH_TIMEOUT = 10_000
 
 /**
  * Authorization Manager
@@ -69,15 +76,40 @@ export class AuthManager implements AuthActions {
    * @link https://apidocs.bitrix24.com/sdk/bx24-js-sdk/system-functions/bx24-refresh-auth.html
    */
   public async refreshAuth(): Promise<AuthData> {
-    return this.#messageManager
-      .send(MessageCommands.refreshAuth, {})
-      .then((data: RefreshAuthData) => {
-        this.#accessToken = data.AUTH_ID
-        this.#refreshId = data.REFRESH_ID
-        this.#authExpires = Date.now() + Number.parseInt(data.AUTH_EXPIRES) * 1_000
+    // Bound the wait: `MessageManager.send` has no timeout of its own here, and
+    // its `isSafely` mode auto-*resolves* with `{ isSafely: true }` — which is
+    // NOT valid `AuthData`. So race the send against a timer that *rejects*, so
+    // a hung parent surfaces a clean error instead of never settling. (#189)
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () => reject(new SdkError({
+          code: 'JSSDK_FRAME_REFRESH_AUTH_TIMEOUT',
+          status: 408,
+          description: `refreshAuth: the parent window did not answer within ${REFRESH_AUTH_TIMEOUT}ms`
+        })),
+        REFRESH_AUTH_TIMEOUT
+      )
+    })
 
-        return Promise.resolve(this.getAuthData() as AuthData)
-      })
+    try {
+      const data = await Promise.race([
+        this.#messageManager.send(MessageCommands.refreshAuth, {}) as Promise<RefreshAuthData>,
+        timeout
+      ])
+
+      this.#accessToken = data.AUTH_ID
+      this.#refreshId = data.REFRESH_ID
+      this.#authExpires = Date.now() + Number.parseInt(data.AUTH_EXPIRES) * 1_000
+
+      return this.getAuthData() as AuthData
+    } finally {
+      // Clear the timer on either outcome so a resolved refresh doesn't leave a
+      // pending reject-timer running (and keep the event loop clean).
+      if (timer) {
+        clearTimeout(timer)
+      }
+    }
   }
 
   public getUniq(prefix: string): string {

--- a/test/integration/core/http-logger-redaction.unit.spec.ts
+++ b/test/integration/core/http-logger-redaction.unit.spec.ts
@@ -24,6 +24,7 @@ import {
   ParamsFactory
 } from '../../../packages/jssdk/src/'
 import { AjaxError } from '../../../packages/jssdk/src/core/http/ajax-error'
+import { SdkError } from '../../../packages/jssdk/src/core/sdk-error'
 import { redactSensitiveParams, redactSensitiveUrl } from '../../../packages/jssdk/src/core/http/redact'
 import type { LoggerInterface } from '../../../packages/jssdk/src/types/logger'
 
@@ -373,6 +374,51 @@ describe('core.http logger redaction @issue-39', () => {
     const stringBlob = err.toString()
     expect(stringBlob).not.toContain('OAUTH_TOKEN_PROBE_xxx')
     expect(stringBlob).not.toContain('USER_PASSWORD_PROBE_yyy')
+  })
+
+  it('#189 AjaxError.originalError is non-enumerable — property-walking serializers cannot leak the raw AxiosError', () => {
+    // The raw AxiosError carries `config` (URL with the webhook secret, and
+    // auth headers). #39 redaction covers requestInfo/toJSON/toString, but the
+    // raw error is stashed on `originalError`. It must be non-enumerable so a
+    // spread `{...err}`, `Object.keys`, `Object.assign`, or a Sentry-style
+    // capture skips it — while staying readable for local debugging.
+    const fakeAxiosError = {
+      name: 'AxiosError',
+      message: 'Request failed with status code 401',
+      config: {
+        url: `https://example.bitrix24.com/rest/1/${FAKE_SECRET}/crm.deal.add`,
+        headers: { Authorization: `Bearer ${FAKE_SECRET}` }
+      }
+    }
+    const err = AjaxError.fromException(fakeAxiosError, { code: 'AUTHORIZE_ERROR', status: 401 })
+
+    // Still accessible for debugging.
+    expect(err.originalError).toBe(fakeAxiosError)
+    // But non-enumerable — invisible to property-walking serializers.
+    expect(Object.getOwnPropertyDescriptor(err, 'originalError')?.enumerable).toBe(false)
+    expect(Object.keys(err)).not.toContain('originalError')
+
+    // None of the common serialize paths leak the secret:
+    expect(JSON.stringify({ ...err })).not.toContain(FAKE_SECRET) // spread
+    expect(JSON.stringify(Object.assign({}, err))).not.toContain(FAKE_SECRET) // Sentry-style copy
+    expect(JSON.stringify(err)).not.toContain(FAKE_SECRET) // toJSON path (already safe)
+    expect(JSON.stringify(err.toJSON())).not.toContain(FAKE_SECRET)
+  })
+
+  it('#189 SdkError.originalError is non-enumerable too (fix lives in the base constructor)', () => {
+    // The guarantee is implemented in SdkError's constructor, so assert it
+    // directly on the base class — not only via the AjaxError subclass.
+    const err = new SdkError({
+      code: 'JSSDK_INTERNAL_ERROR',
+      status: 500,
+      description: 'boom',
+      originalError: { config: { url: `https://x.bitrix24.com/rest/1/${FAKE_SECRET}/` } }
+    })
+    expect(err.originalError).toBeDefined() // still readable for debugging
+    expect(Object.getOwnPropertyDescriptor(err, 'originalError')?.enumerable).toBe(false)
+    expect(Object.keys(err)).not.toContain('originalError')
+    expect(JSON.stringify({ ...err })).not.toContain(FAKE_SECRET)
+    expect(JSON.stringify(err)).not.toContain(FAKE_SECRET)
   })
 
   it('retry path does not leak the secret across multiple attempts', async () => {

--- a/test/integration/frame/refresh-auth-timeout.unit.spec.ts
+++ b/test/integration/frame/refresh-auth-timeout.unit.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * #189 (part C) — `AuthManager.refreshAuth()` must not hang.
+ *
+ * The frame refresh sends a `refreshAuth` postMessage and awaits the parent's
+ * reply. `MessageManager.send` has no timeout of its own on this path (its
+ * `isSafely` mode auto-*resolves* with `{ isSafely: true }`, which is not valid
+ * `AuthData`). Since #182 every 401 triggers a refresh, so a parent that never
+ * answers (slow / navigated away / blocked) would hang the request forever.
+ *
+ * `refreshAuth()` now races the send against a *rejecting* timer, so a hung
+ * parent surfaces a clean `SdkError` after a bounded wait. This is a portal-free
+ * mocked unit spec — the parent-window round-trip isn't reachable in CI, so we
+ * stub `MessageManager.send`.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { AuthManager } from '../../../packages/jssdk/src/frame/auth'
+import { MessageManager } from '../../../packages/jssdk/src/frame/message/controller'
+import { SdkError } from '../../../packages/jssdk/src/core/sdk-error'
+
+const ORIGIN = 'https://portal.bitrix24.com'
+const REFRESH_AUTH_TIMEOUT = 10_000 // must match frame/auth.ts
+
+function buildAuthManager(send: () => Promise<unknown>): AuthManager {
+  const appFrame = {
+    getTargetOrigin: () => ORIGIN,
+    getTargetOriginWithPath: () => new Map()
+  } as never
+  const mgr = new MessageManager({ getTargetOrigin: () => ORIGIN } as never)
+  ;(mgr as unknown as { send: () => Promise<unknown> }).send = send
+  return new AuthManager(appFrame, mgr)
+}
+
+describe('#189 AuthManager.refreshAuth() is timeout-bounded', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('rejects with a clear SdkError when the parent never answers', async () => {
+    vi.useFakeTimers()
+    // A `send` that never settles — models a hung / gone parent window.
+    const auth = buildAuthManager(() => new Promise(() => {}))
+
+    const pending = auth.refreshAuth()
+    // Swallow the eventual rejection while we drive the clock, so it doesn't
+    // surface as an unhandled rejection before the assertion attaches.
+    pending.catch(() => {})
+
+    await vi.advanceTimersByTimeAsync(REFRESH_AUTH_TIMEOUT)
+
+    await expect(pending).rejects.toBeInstanceOf(SdkError)
+    await expect(pending).rejects.toMatchObject({
+      code: 'JSSDK_FRAME_REFRESH_AUTH_TIMEOUT'
+    })
+  })
+
+  it('resolves with AuthData when the parent answers in time (timer is cleared)', async () => {
+    // Real timers: the send resolves immediately, so the race settles well
+    // before the 10s timer — and the timer is cleared in `finally`, so nothing
+    // is left pending.
+    const auth = buildAuthManager(async () => ({
+      AUTH_ID: 'NEW_ACCESS',
+      REFRESH_ID: 'NEW_REFRESH',
+      AUTH_EXPIRES: '3600'
+    }))
+
+    const data = await auth.refreshAuth()
+    expect(data.access_token).toBe('NEW_ACCESS')
+    expect(data.refresh_token).toBe('NEW_REFRESH')
+  })
+})


### PR DESCRIPTION
Closes #189.

## Part C — `AuthManager.refreshAuth()` could hang forever
It awaited the parent window's reply to a `refreshAuth` `postMessage` with **no timeout**. Since #182 every 401 refreshes, so a slow / navigated-away / blocked parent hangs the request. `MessageManager.send`'s `isSafely` mode auto-**resolves** with `{ isSafely: true }` — not valid `AuthData` — so a plain safety timeout would feed garbage auth into the retry.

**Fix:** race the send against a **rejecting** 10s timer (cleared in `finally`), so a hung parent surfaces a clean `SdkError` (`JSSDK_FRAME_REFRESH_AUTH_TIMEOUT`). It propagates through the existing coalesced 401-retry path (`AbstractHttp._refreshAuth`) as a normal thrown error instead of never settling.

## Part D — `SdkError.originalError` leaked the raw `AxiosError`
The raw error holds `config` (request URL with the webhook secret, auth headers), un-redacted. `toJSON()` already omits it, but the field was **enumerable**, so a spread `{ ...err }`, `Object.keys`, `Object.assign`, or a Sentry-style capture still leaked the secret.

**Fix:** define it **non-enumerable** (`Object.defineProperty` + a `declare` field so no enumerable class-field slot is emitted). Property-walking serializers skip it; `err.originalError` stays readable for local debugging (the JSDoc keeps warning against blanket-logging it directly).

## Verification (standard 5-reviewer cycle — all SHIP, no MUST-FIX)
- `pnpm --filter @bitrix24/b24jssdk typecheck` clean; **362 unit tests pass**; eslint clean.
- New tests: `refresh-auth-timeout.unit.spec.ts` (rejects on a never-answering parent via fake timers; resolves + clears timer on a timely reply) and `#189` cases in `http-logger-redaction.unit.spec.ts` (non-enumerable + unleakable via spread/`Object.assign`/`JSON.stringify` on **both** `AjaxError` and `SdkError`).
- **Mutation-tested by the tester reviewer:** each test fails when its fix is reverted (timeout test times out; redaction test sees `enumerable: true`).
- security: leak closed for all realistic serialization vectors; correctness: all three race paths clear the timer, no unhandled rejection, no import cycle; programmer/edge + tech-director: non-enumerable is the right tradeoff, `Promise.race` is the right localized call for a hardening patch.

## Follow-ups (reviewer-noted, out of scope)
1. Add reject-on-timeout + guaranteed callback-map cleanup to the shared `MessageManager.send` — closes the one-entry-per-timeout `#callbackPromises` lingering-callback on a truly hung parent, and bounds the ~15 other `send()` call sites that have no timeout today.
2. Make `REFRESH_AUTH_TIMEOUT` (fixed 10s) configurable via `AuthManager`/`B24Frame` options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6MQtPUx9MZjXY2rbLZhbv)_