### PR TITLE
fix(pull): harden PullClient lifecycle — SSR safety, unified teardown, in-flight start() abort (#222)

### DIFF
--- a/packages/jssdk/src/pullClient/client.ts
+++ b/packages/jssdk/src/pullClient/client.ts
@@ -109,6 +109,25 @@ export class PullClient implements ConnectorParent {
   private _watchUpdateTimeout: ReturnType<typeof setTimeout> | null = null
   private _pingWaitTimeout: ReturnType<typeof setTimeout> | null = null
 
+  // Single source of truth for every tracked timer field. armTimeout()/
+  // clearAllTimers() route through this list so a future timer cannot be added
+  // without a matching teardown — the leak class behind #141 (#222). Individual
+  // fields are kept because call-sites read their identity (e.g. `if
+  // (this._reconnectTimeout)`), but clearAllTimers() is the one teardown path.
+  private readonly _timerFields = [
+    '_reconnectTimeout',
+    '_restartTimeout',
+    '_restoreWebSocketTimeout',
+    '_checkInterval',
+    '_offlineTimeout',
+    '_watchUpdateTimeout',
+    '_pingWaitTimeout'
+  ] as const
+
+  // Records every window listener init() registered so removeAllWindowListeners()
+  // can drop exactly what was added, keeping arm/teardown symmetric (#222).
+  private _windowListeners: Array<{ type: string, handler: () => void }> = []
+
   // manual stop workaround ////
   private _isManualDisconnect: boolean = false
 
@@ -133,6 +152,16 @@ export class PullClient implements ConnectorParent {
   } = null
 
   private _startingPromise: null | Promise<boolean> = null
+
+  // Monotonic token bumped on every start() and on destroy(). start()'s
+  // loadConfig()/connect() continuations capture the value at kick-off and bail
+  // if it no longer matches — deterministically neutralising an in-flight start()
+  // when destroy() (or a fresh start()) supersedes it, even for overlapping
+  // start/destroy/start. The underlying rest transport
+  // (this._restClient.actions.v2.call.make) does not accept an AbortSignal, so
+  // this generation-token approach is used instead of an AbortController; the
+  // network round-trip itself is not cancelled (remaining follow-up). (#222)
+  private _startGeneration: number = 0
   // endregion ////
 
   // region Init ////
@@ -201,7 +230,10 @@ export class PullClient implements ConnectorParent {
     }
     // endregion ////
 
-    this._isSecure = document?.location.href.indexOf('https') === 0
+    // Guard the `document` global: under SSR/Node it is undefined and even
+    // `document?.` throws a ReferenceError on an undeclared identifier (#222).
+    this._isSecure = typeof document !== 'undefined'
+      && document?.location.href.indexOf('https') === 0
 
     if (this._userId && !this._skipStorageInit) {
       this._storage = new StorageManager({
@@ -253,13 +285,12 @@ export class PullClient implements ConnectorParent {
   destroy(): void {
     this._disposed = true
 
+    // Invalidate any in-flight start() continuation (#222).
+    this._startGeneration++
+
     this.stop(CloseReasons.NORMAL_CLOSURE, 'manual stop')
 
-    if (typeof window !== 'undefined') {
-      window.removeEventListener('beforeunload', this._onBeforeUnloadHandler)
-      window.removeEventListener('offline', this._onOfflineHandler)
-      window.removeEventListener('online', this._onOnlineHandler)
-    }
+    this.removeAllWindowListeners()
 
     // Drop the cached pull config on teardown: it holds the push `jwt` and the
     // channel signatures, which must not linger in localStorage after the client
@@ -300,11 +331,9 @@ export class PullClient implements ConnectorParent {
       ? ConnectionType.WebSocket
       : ConnectionType.LongPolling
 
-    if (typeof window !== 'undefined') {
-      window.addEventListener('beforeunload', this._onBeforeUnloadHandler)
-      window.addEventListener('offline', this._onOfflineHandler)
-      window.addEventListener('online', this._onOnlineHandler)
-    }
+    this.addWindowListener('beforeunload', this._onBeforeUnloadHandler)
+    this.addWindowListener('offline', this._onOfflineHandler)
+    this.addWindowListener('online', this._onOnlineHandler)
 
     /**
      * @memo Not use under Node.js
@@ -632,9 +661,27 @@ export class PullClient implements ConnectorParent {
     }
 
     this._starting = true
+    // Capture the current generation; a destroy() or a newer start() bumps
+    // _startGeneration and the continuation below bails (#222).
+    const startGeneration = ++this._startGeneration
     return (this._startingPromise = new Promise((resolve, reject) => {
       this.loadConfig('client_start')
         .then((config) => {
+          // Abort the continuation if the client was destroyed or superseded
+          // while loadConfig()'s network round-trip was in flight. The
+          // _disposed guards inside setConfig/init/connect are a second line of
+          // defence; this bails deterministically and rejects the start (#222).
+          if (this._disposed || this._startGeneration !== startGeneration) {
+            this._starting = false
+            reject({
+              ex: {
+                error: 'PULL_DISPOSED',
+                error_description: 'PullClient has been destroyed; create a new instance'
+              }
+            })
+            return
+          }
+
           this.setConfig(config as TypePullClientConfig, allowConfigCaching)
           this.init()
           this.updateWatch(true)
@@ -732,28 +779,51 @@ export class PullClient implements ConnectorParent {
   // running. Previously only _checkInterval was cleared, so the other six timers
   // (including the self-rescheduling watch-extend) survived teardown (#141).
   private clearAllTimers(): void {
-    for (const timer of [
-      this._reconnectTimeout,
-      this._restartTimeout,
-      this._restoreWebSocketTimeout,
-      this._offlineTimeout,
-      this._watchUpdateTimeout,
-      this._pingWaitTimeout
-    ]) {
+    for (const field of this._timerFields) {
+      const timer = this[field]
       if (timer) {
-        clearTimeout(timer)
+        if (field === '_checkInterval') {
+          clearInterval(timer)
+        } else {
+          clearTimeout(timer)
+        }
+      }
+      this[field] = null
+    }
+  }
+
+  // Arm a tracked setTimeout: clears any existing id for the field first (same
+  // clear-before-set the call-sites did by hand), then stores the new id. The
+  // interval-backed _checkInterval keeps its own setInterval path. (#222)
+  private armTimeout(
+    field: Exclude<(typeof this._timerFields)[number], '_checkInterval'>,
+    fn: () => void,
+    ms: number
+  ): void {
+    const existing = this[field]
+    if (existing) {
+      clearTimeout(existing)
+    }
+    this[field] = setTimeout(fn, ms)
+  }
+
+  // Window-listener registry: init() adds through here, destroy() drops through
+  // removeAllWindowListeners(), so a listener can't be added without teardown. (#222)
+  private addWindowListener(type: string, handler: () => void): void {
+    if (typeof window === 'undefined') {
+      return
+    }
+    window.addEventListener(type, handler)
+    this._windowListeners.push({ type, handler })
+  }
+
+  private removeAllWindowListeners(): void {
+    if (typeof window !== 'undefined') {
+      for (const { type, handler } of this._windowListeners) {
+        window.removeEventListener(type, handler)
       }
     }
-    if (this._checkInterval) {
-      clearInterval(this._checkInterval)
-    }
-    this._reconnectTimeout = null
-    this._restartTimeout = null
-    this._restoreWebSocketTimeout = null
-    this._offlineTimeout = null
-    this._watchUpdateTimeout = null
-    this._pingWaitTimeout = null
-    this._checkInterval = null
+    this._windowListeners = []
   }
 
   public reconnect(
@@ -1083,7 +1153,7 @@ export class PullClient implements ConnectorParent {
       'UserId': this._userId + (this._userId > 0 ? '' : '(guest)'),
       'Guest userId':
         this._guestMode && this._guestUserId !== 0 ? this._guestUserId : '-',
-      'Browser online': navigator.onLine ? 'Y' : 'N',
+      'Browser online': (typeof navigator !== 'undefined' && navigator.onLine) ? 'Y' : 'N',
       'Connect': this.isConnected() ? 'Y' : 'N',
       'Server type': this.isSharedMode() ? 'cloud' : 'local',
       'WebSocket supported': this.isWebSocketSupported() ? 'Y' : 'N',
@@ -1225,7 +1295,7 @@ export class PullClient implements ConnectorParent {
   }
 
   public isWebSocketSupported(): boolean {
-    return typeof window.WebSocket !== 'undefined'
+    return typeof window !== 'undefined' && typeof window.WebSocket !== 'undefined'
   }
 
   public isWebSocketAllowed(): boolean {
@@ -1852,7 +1922,7 @@ export class PullClient implements ConnectorParent {
          * @memotry to delete the key "history"
          * (landing site change history, see http://jabber.bx/view.php?id=136492)
          */
-        if (localStorage && localStorage.removeItem) {
+        if (typeof localStorage !== 'undefined' && localStorage.removeItem) {
           localStorage.removeItem('history')
         }
         this.getLogger().error(
@@ -1952,16 +2022,11 @@ export class PullClient implements ConnectorParent {
         )
       }
     }
-    if (this._reconnectTimeout) {
-      clearTimeout(this._reconnectTimeout)
-      this._reconnectTimeout = null
-    }
-
     this.logToConsole(
       `Pull: scheduling reconnection in ${connectionDelay} seconds; attempt # ${this._connectionAttempt}`
     )
 
-    this._reconnectTimeout = setTimeout(() => {
+    this.armTimeout('_reconnectTimeout', () => {
       this.connect().catch((error) => {
         this.getLogger().error('scheduleReconnect', { error })
       })
@@ -1981,7 +2046,7 @@ export class PullClient implements ConnectorParent {
       return
     }
 
-    this._restoreWebSocketTimeout = setTimeout(() => {
+    this.armTimeout('_restoreWebSocketTimeout', () => {
       this._restoreWebSocketTimeout = null
       this.restoreWebSocketConnection()
     }, RESTORE_WEBSOCKET_TIMEOUT * 1_000)
@@ -2028,16 +2093,12 @@ export class PullClient implements ConnectorParent {
       return
     }
 
-    if (this._restartTimeout) {
-      clearTimeout(this._restartTimeout)
-      this._restartTimeout = null
-    }
-
     if (restartDelay < 1) {
       restartDelay = Math.ceil(Math.random() * 30) + 5
     }
 
-    this._restartTimeout = setTimeout(
+    this.armTimeout(
+      '_restartTimeout',
       () => this.restart(disconnectCode, disconnectReason),
       restartDelay * 1_000
     )
@@ -2581,12 +2642,7 @@ export class PullClient implements ConnectorParent {
       return
     }
 
-    if (this._offlineTimeout) {
-      clearTimeout(this._offlineTimeout)
-      this._offlineTimeout = null
-    }
-
-    this._offlineTimeout = setTimeout(() => {
+    this.armTimeout('_offlineTimeout', () => {
       this._offlineTimeout = null
       this.sendPullStatus(status)
     }, delay)
@@ -2638,12 +2694,8 @@ export class PullClient implements ConnectorParent {
       return
     }
 
-    if (this._watchUpdateTimeout) {
-      clearTimeout(this._watchUpdateTimeout)
-      this._watchUpdateTimeout = null
-    }
-
-    this._watchUpdateTimeout = setTimeout(
+    this.armTimeout(
+      '_watchUpdateTimeout',
       () => {
         /**
          * @memo test this
@@ -2699,12 +2751,8 @@ export class PullClient implements ConnectorParent {
       return
     }
 
-    if (this._pingWaitTimeout) {
-      clearTimeout(this._pingWaitTimeout)
-      this._pingWaitTimeout = null
-    }
-
-    this._pingWaitTimeout = setTimeout(
+    this.armTimeout(
+      '_pingWaitTimeout',
       this._onPingTimeoutHandler,
       PING_TIMEOUT * 2 * 1_000
     )

--- a/packages/jssdk/src/pullClient/long-polling-connector.ts
+++ b/packages/jssdk/src/pullClient/long-polling-connector.ts
@@ -11,7 +11,12 @@ export class LongPollingConnector extends AbstractConnector {
 
   private _requestTimeout: ReturnType<typeof setTimeout> | null
   private _failureTimeout: ReturnType<typeof setTimeout> | null
-  private readonly _xhr: XMLHttpRequest
+  // Created lazily on the first connect() rather than in the constructor: the
+  // connector is built eagerly by PullClient.init() (which runs inside start())
+  // regardless of the chosen transport, and `new XMLHttpRequest()` throws a
+  // ReferenceError under SSR/Node where the global is absent. Deferring it keeps
+  // construct + init + start SSR-safe; connect() degrades gracefully instead. (#222)
+  private _xhr: XMLHttpRequest | null
   private _requestAborted: boolean
 
   constructor(config: ConnectorConfig) {
@@ -22,7 +27,7 @@ export class LongPollingConnector extends AbstractConnector {
 
     this._requestTimeout = null
     this._failureTimeout = null
-    this._xhr = this.createXhr()
+    this._xhr = null
     this._requestAborted = false
   }
 
@@ -30,6 +35,21 @@ export class LongPollingConnector extends AbstractConnector {
    * @inheritDoc
    */
   override connect(): void {
+    if (!this._xhr) {
+      // No XMLHttpRequest under SSR/Node: a long-polling connection needs a
+      // browser. Surface a clean error instead of a raw ReferenceError. (#222)
+      if (typeof XMLHttpRequest === 'undefined') {
+        this._callbacks.onError(
+          new Error(
+            'LongPollingConnector: XMLHttpRequest is not available in this'
+            + ' environment (SSR/Node); a long-polling connection requires a browser'
+          )
+        )
+        return
+      }
+      this._xhr = this.createXhr()
+    }
+
     this._active = true
     this.performRequest()
   }
@@ -63,7 +83,12 @@ export class LongPollingConnector extends AbstractConnector {
       throw new Error('Long polling connection path is not defined')
     }
 
-    if (this._xhr.readyState !== 0 && this._xhr.readyState !== 4) {
+    const xhr = this._xhr
+    if (!xhr) {
+      return
+    }
+
+    if (xhr.readyState !== 0 && xhr.readyState !== 4) {
       return
     }
 
@@ -78,20 +103,25 @@ export class LongPollingConnector extends AbstractConnector {
       LONG_POLLING_TIMEOUT * 1_000
     )
 
-    this._xhr.open('GET', this.connectionPath)
-    this._xhr.send()
+    xhr.open('GET', this.connectionPath)
+    xhr.send()
   }
 
   private onRequestTimeout() {
     this._requestAborted = true
-    this._xhr.abort()
+    this._xhr?.abort()
     this.performRequest()
   }
 
   private onXhrReadyStateChange(): void {
-    if (this._xhr.readyState === 4) {
-      if (!this._requestAborted || this._xhr.status == 200) {
-        this.onResponse(this._xhr.response)
+    const xhr = this._xhr
+    if (!xhr) {
+      return
+    }
+
+    if (xhr.readyState === 4) {
+      if (!this._requestAborted || xhr.status == 200) {
+        this.onResponse(xhr.response)
       }
 
       this._requestAborted = false
@@ -109,6 +139,13 @@ export class LongPollingConnector extends AbstractConnector {
       return false
     }
 
+    if (typeof XMLHttpRequest === 'undefined') {
+      this.getLogger().error(
+        `${Text.getDateForLog()}: Pull: XMLHttpRequest is not available; cannot publish`
+      )
+      return false
+    }
+
     const xhr = new XMLHttpRequest()
     xhr.open('POST', path)
     xhr.send(buffer)
@@ -119,7 +156,12 @@ export class LongPollingConnector extends AbstractConnector {
   private onResponse(response: any): void {
     this.clearTimeOut()
 
-    if (this._xhr.status === 200) {
+    const xhr = this._xhr
+    if (!xhr) {
+      return
+    }
+
+    if (xhr.status === 200) {
       this.connected = true
       if (Type.isStringFilled(response) || response instanceof ArrayBuffer) {
         this._callbacks.onMessage(response)
@@ -127,13 +169,13 @@ export class LongPollingConnector extends AbstractConnector {
         this._parent.session.mid = null
       }
       this.performRequest()
-    } else if (this._xhr.status === 304) {
+    } else if (xhr.status === 304) {
       this.connected = true
       if (
-        this._xhr.getResponseHeader('Expires')
+        xhr.getResponseHeader('Expires')
         === 'Thu, 01 Jan 1973 11:11:01 GMT'
       ) {
-        const lastMessageId = this._xhr.getResponseHeader('Last-Message-Id')
+        const lastMessageId = xhr.getResponseHeader('Last-Message-Id')
         if (Type.isStringFilled(lastMessageId)) {
           this._parent.setLastMessageId(lastMessageId || '')
         }

--- a/packages/jssdk/src/pullClient/shared-config.ts
+++ b/packages/jssdk/src/pullClient/shared-config.ts
@@ -23,7 +23,9 @@ export class SharedConfig {
         : () => {}
     } as SharedConfigCallbacks
 
-    if (this._storage) {
+    // Guard `window`: under SSR/Node it is undefined and referencing it throws
+    // a ReferenceError. Skip the cross-tab storage listener there (#222).
+    if (this._storage && typeof window !== 'undefined') {
       window.addEventListener('storage', this.onLocalStorageSet.bind(this))
     }
   }

--- a/packages/jssdk/src/pullClient/storage-manager.ts
+++ b/packages/jssdk/src/pullClient/storage-manager.ts
@@ -24,7 +24,7 @@ export class StorageManager implements TypeStorageManager {
   }
 
   set(name: string, value: any): void {
-    if (typeof window.localStorage === 'undefined') {
+    if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
       this.getLogger().error('localStorage undefined', {
         error: new Error('undefined window.localStorage')
       })
@@ -39,7 +39,7 @@ export class StorageManager implements TypeStorageManager {
   }
 
   get(name: string, defaultValue: any): any {
-    if (typeof window.localStorage === 'undefined') {
+    if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
       return defaultValue || null
     }
 
@@ -52,7 +52,7 @@ export class StorageManager implements TypeStorageManager {
   }
 
   remove(name: string): void {
-    if (typeof window.localStorage === 'undefined') {
+    if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
       this.getLogger().error('localStorage undefined', {
         error: new Error('undefined window.localStorage')
       })

--- a/test/integration/pull/pull-client-lifecycle-222.unit.spec.ts
+++ b/test/integration/pull/pull-client-lifecycle-222.unit.spec.ts
@@ -1,0 +1,308 @@
+/**
+ * Unit tests for PullClient lifecycle hardening (#222). Runs in the `jsSdk:unit`
+ * CI project (Node, no DOM). Covers:
+ *   - Deliverable 1: SSR / Node safety — construct + start() must not throw when
+ *     `window` / `navigator` / `document` are undefined; the guarded globals
+ *     (navigator.onLine, window.WebSocket) degrade instead of throwing.
+ *   - Deliverable 2: unified timer + window-listener registry — after destroy()
+ *     every armed timer is cleared (clearTimeout/clearInterval spied) and every
+ *     window listener registered by init() is removed.
+ *   - Deliverable 3: an in-flight start() is neutralised by the start-generation
+ *     token when destroy() runs before loadConfig() resolves.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { PullClient } from '../../../packages/jssdk/src/pullClient/client'
+import type { TypeB24 } from '../../../packages/jssdk/src/types/b24'
+
+type Listener = (...args: any[]) => void
+
+function installWindowStub() {
+  const added = new Map<string, Set<Listener>>()
+  const removed: Array<{ type: string, handler: Listener }> = []
+  const stub = {
+    added,
+    removed,
+    WebSocket: function WebSocketStub() {},
+    addEventListener(type: string, handler: Listener) {
+      if (!added.has(type)) {
+        added.set(type, new Set())
+      }
+      added.get(type)!.add(handler)
+    },
+    removeEventListener(type: string, handler: Listener) {
+      removed.push({ type, handler })
+      added.get(type)?.delete(handler)
+    }
+  }
+  ;(globalThis as any).window = stub
+  ;(globalThis as any).document = { location: { href: 'https://test.local/' } }
+  ;(globalThis as any).navigator = { onLine: true }
+  ;(globalThis as any).XMLHttpRequest = class {
+    responseType = ''
+    onreadystatechange: Listener | null = null
+    open() {}
+    send() {}
+    abort() {}
+    setRequestHeader() {}
+    addEventListener() {}
+    removeEventListener() {}
+  }
+  return stub
+}
+
+function clearGlobals() {
+  delete (globalThis as any).window
+  delete (globalThis as any).document
+  delete (globalThis as any).navigator
+  delete (globalThis as any).XMLHttpRequest
+}
+
+function createClient(): PullClient {
+  return new PullClient({
+    b24: {} as unknown as TypeB24,
+    userId: 42,
+    siteId: 'test',
+    serverEnabled: true,
+    skipStorageInit: true,
+    skipCheckRevision: true
+  })
+}
+
+const VALID_CONFIG = {
+  server: { config_timestamp: 1 },
+  channels: {},
+  publicChannels: {}
+} as any
+
+// region Deliverable 1 — SSR / Node safety ////
+describe('PullClient SSR safety (#222 D1)', () => {
+  afterEach(() => {
+    clearGlobals()
+  })
+
+  it('constructs without throwing when window/navigator/document are undefined', () => {
+    clearGlobals()
+    expect(() => createClient()).not.toThrow()
+  })
+
+  it('isWebSocketSupported() returns false (no throw) without a window', () => {
+    clearGlobals()
+    const client = createClient()
+    expect(() => client.isWebSocketSupported()).not.toThrow()
+    expect(client.isWebSocketSupported()).toBe(false)
+  })
+
+  it('getDebugInfo() does not throw when navigator is undefined', () => {
+    clearGlobals()
+    const client = createClient()
+    expect(() => client.getDebugInfo()).not.toThrow()
+    expect(client.getDebugInfo()['Browser online']).toBe('N')
+  })
+
+  it('start() does not throw under SSR (loadConfig/connect stubbed)', async () => {
+    clearGlobals()
+    // window/navigator/document AND XMLHttpRequest all stay undefined — a real
+    // Node/SSR runtime. init() (run inside start()) must construct the
+    // LongPollingConnector without a global XHR: the connector defers
+    // `new XMLHttpRequest()` to connect(), so construct/init/start stay
+    // ReferenceError-free. Only the network round-trip (connect) is stubbed,
+    // because there is genuinely no transport to exercise under SSR. (#222)
+    const client = createClient()
+    const internal = client as any
+    internal.loadConfig = () => Promise.resolve({ ...VALID_CONFIG })
+    internal.connect = () => Promise.resolve()
+
+    // Pass a config so _config is seeded before setConfig() iterates it.
+    await expect(client.start({ ...VALID_CONFIG })).resolves.toBe(true)
+    // init() must have picked long-polling (no window.WebSocket), constructed
+    // the long-polling connector without throwing (lazy XHR), and registered no
+    // window listeners.
+    expect(internal._connectionType).toBe('longPolling')
+    expect(internal._connectors.longPolling).toBeTruthy()
+    expect(internal._windowListeners.length).toBe(0)
+
+    client.destroy()
+  })
+
+  it('long-polling connect() degrades to onError (no throw) when XMLHttpRequest is absent', async () => {
+    // Directly exercise the connector's SSR path: with no global XHR, connect()
+    // must surface a clean Error via the onError callback rather than throwing a
+    // raw ReferenceError. (#222)
+    clearGlobals()
+    const { LongPollingConnector } = await import(
+      '../../../packages/jssdk/src/pullClient/long-polling-connector'
+    )
+    const onError = vi.fn()
+    const connector = new LongPollingConnector({
+      parent: {
+        isProtobufSupported: () => false,
+        isJsonRpc: () => true,
+        getConnectionPath: () => 'https://test.local/pull'
+      },
+      onOpen: () => {},
+      onMessage: () => {},
+      onDisconnect: () => {},
+      onError
+    } as any)
+
+    expect(() => connector.connect()).not.toThrow()
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error)
+  })
+})
+// endregion ////
+
+// region Deliverable 2 — timer + listener registry ////
+describe('PullClient teardown registry (#222 D2)', () => {
+  beforeEach(() => {
+    installWindowStub()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    clearGlobals()
+  })
+
+  it('destroy() clears every armed timer and leaves none pending', () => {
+    const client = createClient()
+    const internal = client as any
+    internal.init()
+
+    internal.updateWatch(true)
+    internal.scheduleReconnect(5)
+    internal.scheduleRestart(1000, 'test', 5)
+    internal.scheduleRestoreWebSocketConnection()
+    internal.startCheckConfig()
+    internal.updatePingWaitTimeout()
+
+    const armed = vi.getTimerCount()
+    expect(armed).toBeGreaterThanOrEqual(6)
+
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+
+    client.destroy()
+
+    // Every setTimeout-backed timer went through clearTimeout, the interval
+    // through clearInterval, and nothing is left scheduled.
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+    expect(clearIntervalSpy).toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+
+    // Advancing time fires nothing new.
+    vi.advanceTimersByTime(60 * 60 * 1000)
+    expect(vi.getTimerCount()).toBe(0)
+
+    clearTimeoutSpy.mockRestore()
+    clearIntervalSpy.mockRestore()
+  })
+
+  it('destroy() removes every window listener init() registered', () => {
+    const client = createClient()
+    const internal = client as any
+    internal.init()
+
+    const stub = (globalThis as any).window
+    const removeSpy = vi.spyOn(stub, 'removeEventListener')
+
+    expect(internal._windowListeners.length).toBe(3)
+
+    client.destroy()
+
+    expect(removeSpy).toHaveBeenCalledTimes(3)
+    expect(internal._windowListeners.length).toBe(0)
+    for (const type of ['beforeunload', 'offline', 'online']) {
+      expect(stub.added.get(type)?.size ?? 0).toBe(0)
+    }
+  })
+})
+// endregion ////
+
+// region Deliverable 3 — abort an in-flight start() ////
+describe('PullClient in-flight start() abort (#222 D3)', () => {
+  beforeEach(() => {
+    installWindowStub()
+  })
+
+  afterEach(() => {
+    clearGlobals()
+  })
+
+  it('destroy() during a pending loadConfig() rejects the start and runs no post-destroy work', async () => {
+    const client = createClient()
+    const internal = client as any
+
+    let resolveLoad!: (config: any) => void
+    internal.loadConfig = () => new Promise((resolve) => {
+      resolveLoad = resolve
+    })
+    const connectSpy = vi.fn(() => Promise.resolve())
+    const setConfigSpy = vi.spyOn(internal, 'setConfig')
+    internal.connect = connectSpy
+
+    const startPromise = client.start()
+    const rejection = expect(startPromise).rejects.toMatchObject({
+      ex: { error: 'PULL_DISPOSED' }
+    })
+
+    // Tear the client down while loadConfig() is still in flight, then let it
+    // resolve: the continuation must bail on the generation-token mismatch.
+    client.destroy()
+    resolveLoad(VALID_CONFIG)
+
+    await rejection
+    expect(connectSpy).not.toHaveBeenCalled()
+    expect(setConfigSpy).not.toHaveBeenCalled()
+  })
+
+  it('a superseded start() is neutralised by the generation token even when NOT disposed', async () => {
+    // The previous case can't distinguish the generation-token guard from the
+    // `_disposed` guard, because destroy() trips both at once. Here `_disposed`
+    // stays false and ONLY the generation moves forward, so this pins the token
+    // half specifically: reverting the `_startGeneration !== startGeneration`
+    // clause makes this fail. (#222)
+    const client = createClient()
+    const internal = client as any
+
+    let resolveFirst!: (config: any) => void
+    let calls = 0
+    internal.loadConfig = () => new Promise((resolve) => {
+      calls += 1
+      if (calls === 1) {
+        resolveFirst = resolve
+      }
+      // The second loadConfig() stays pending forever.
+    })
+    const connectSpy = vi.fn(() => Promise.resolve())
+    const setConfigSpy = vi.spyOn(internal, 'setConfig')
+    internal.connect = connectSpy
+
+    // First start(): captures generation N, loadConfig #1 pending.
+    const firstStart = client.start()
+    firstStart.catch(() => {})
+
+    // Simulate the in-flight reset that lets a fresh start() supersede the first
+    // WITHOUT destroy(), so _disposed stays false: the second start() bumps the
+    // generation and begins its own loadConfig.
+    internal._starting = false
+    internal._startingPromise = null
+    const secondStart = client.start()
+    secondStart.catch(() => {})
+
+    // Resolve the FIRST loadConfig: its continuation captured the old generation,
+    // which has since moved on (and _disposed is false), so it must bail with
+    // PULL_DISPOSED and run no setConfig/connect.
+    resolveFirst(VALID_CONFIG)
+
+    await expect(firstStart).rejects.toMatchObject({
+      ex: { error: 'PULL_DISPOSED' }
+    })
+    expect(internal._disposed).toBe(false)
+    expect(setConfigSpy).not.toHaveBeenCalled()
+    expect(connectSpy).not.toHaveBeenCalled()
+
+    client.destroy()
+  })
+})
+// endregion ////

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,13 @@ export default defineConfig({
           name: 'jsSdk:unit',
           environment: 'node',
           testTimeout: 10_000,
+          // Some unit specs (the PullClient SSR/lifecycle suites) mutate shared
+          // browser globals — `globalThis.window` / `document` / `navigator` /
+          // `XMLHttpRequest` — to simulate Node/SSR. Running files in parallel
+          // let one file's global teardown race another's assertions, producing
+          // flaky `window is not defined` failures. Serialise the files so the
+          // global mutations can't interleave. (#222)
+          fileParallelism: false,
           include: ['./test/integration/**/*.unit.spec.ts']
         }
       },


### PR DESCRIPTION
Closes #222.

Hardens the `PullClient` lifecycle along three axes.

## D1 — SSR / Node safety
Guards every browser global reachable at **construct / `start()` / `init()`**, so importing and constructing `PullClient` in isomorphic (SSR) code no longer throws a `ReferenceError`:

- `client.ts` — `document` (`isSecure`), `navigator.onLine` (`getDebugInfo`), `window.WebSocket` (`isWebSocketSupported`), `localStorage` (the `setConfig` catch block)
- `shared-config.ts` — the cross-tab `window` `storage` listener
- `storage-manager.ts` — `set` / `get` / `remove` localStorage access
- `long-polling-connector.ts` — **the key fix.** `init()` builds the `LongPollingConnector` eagerly regardless of which transport is chosen, and its constructor called `new XMLHttpRequest()` unconditionally → a `ReferenceError` under real SSR. The XHR is now created **lazily on the first `connect()`**; when no global `XMLHttpRequest` exists, `connect()` surfaces a clean `Error` via `onError` instead of throwing.

All guards use `typeof x !== 'undefined'` (optional chaining does **not** protect an undeclared identifier).

## D2 — unified timer + window-listener registry
A single `_timerFields` list drives `armTimeout()` (clear-before-set) and `clearAllTimers()`, and a `_windowListeners` registry pairs `addWindowListener()` with `removeAllWindowListeners()`. A timer or listener can no longer be added without a matching teardown path — the leak class behind #141.

## D3 — abort an in-flight `start()`
A monotonic `_startGeneration` token, bumped on every `start()` and on `destroy()`, lets the `loadConfig()` continuation bail and reject with `PULL_DISPOSED` when the client is destroyed (or superseded by a newer `start()`) while the config round-trip is in flight. No post-destroy work can re-persist the push `jwt` / channel signatures back into `localStorage`.

> The REST transport (`actions.v2.call.make`) accepts no `AbortSignal`, so the network round-trip itself is not cancelled — the continuation is neutralised, not the request. Wiring real cancellation through the shared REST client is a documented follow-up (below).

## Tests
New `test/integration/pull/pull-client-lifecycle-222.unit.spec.ts`:
- **D1** — construct + `start()` under real SSR with **no `XMLHttpRequest` stub** (proves genuine SSR safety, not a mocked one); plus a connector-level case asserting `connect()` degrades to `onError` rather than throwing when the global is absent.
- **D2** — `destroy()` clears every armed timer (spied `clearTimeout`/`clearInterval`, `getTimerCount() === 0`) and removes every window listener `init()` registered.
- **D3** — destroy-during-`loadConfig()`, **plus** a case that isolates the generation token from the `_disposed` flag (mutation-verified: reverting the `_startGeneration` clause fails this test).

`vitest.config.ts` — `jsSdk:unit` now runs files with `fileParallelism: false`, so the SSR specs' shared-`globalThis` mutations can't race across files (fixes a pre-existing flaky-`window is not defined` class).

## Verification
- `pnpm --filter @bitrix24/b24jssdk typecheck` — clean
- `pnpm run lint` — 0 errors (1 pre-existing unrelated warning)
- `pnpm run package-jssdk:test:run-unit` — **370 passed** (+9 new), stable across repeated runs

Reviewed by a 5-perspective pass (correctness/concurrency, SSR/edge, tester/mutation, security, tech-director); the unanimous MUST-FIX (unguarded XHR undercutting the SSR claim) and the flaky-test + generation-token-coverage findings are all addressed above.

## Follow-ups (not in scope)
- Cancel the actual `loadConfig()` network round-trip (needs `AbortSignal` support in `actions.v2.call.make` / the shared REST client — cross-cutting).
- Consider constructing `LongPollingConnector`/`WebSocketConnector` lazily on first `connect()` to shrink `start()`'s surface further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6MQtPUx9MZjXY2rbLZhbv

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6MQtPUx9MZjXY2rbLZhbv)_