### PR TITLE
fix(frame): initializeB24Frame() no longer strands callers or leaks a frame on failed init (#142)

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/30.frame-initialize-b24-frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame-initialize-b24-frame.md
@@ -2,7 +2,7 @@
 title: B24Frame Initialization
 description: 'Function is designed to initialize a B24Frame'
 category: 'B24Frame'
-audited: 2026-07-02
+audited: 2026-07-03
 navigation.title: Initialization
 links:
   - label: initializeB24Frame
@@ -26,6 +26,10 @@ It manages the initialization process and handles potential connection errors.
 
 ::note
 Supports repeated calls until initialization is complete, using a callback queue.
+::
+
+::caution
+If the app is opened **outside** the Bitrix24 iframe (a direct URL, a dev server, the install screen), `window.name` carries no `DOMAIN`/`APP_SID`. The promise then **rejects promptly** with an `SdkError` (`code: JSSDK_CLIENT_SIDE_WARNING`, `status: 500`) instead of hanging — including every queued concurrent caller — and a later call may retry once the app runs inside Bitrix24. Always `await` inside `try/catch`.
 ::
 
 **Parameters**

--- a/docs/content/docs/2.working-with-the-rest-api/6.errors.md
+++ b/docs/content/docs/2.working-with-the-rest-api/6.errors.md
@@ -3,7 +3,7 @@ title: Error codes and handling
 description: 'Reference for SdkError and AjaxError codes raised by the SDK, plus the Bitrix24 REST error codes that surface through them.'
 navigation:
   title: Errors
-audited: 2026-07-02
+audited: 2026-07-03
 links:
   - label: SdkError
     iconName: GitHubIcon
@@ -84,7 +84,7 @@ Codes are stable strings — match on them, don't parse messages.
 | `JSSDK_UNKNOWN_ERROR` | 500 | various | Fallback when no more specific code applies. |
 | `JSSDK_INTERNAL_ERROR` | 500 | `SdkError.fromException` | Default code when wrapping an unknown exception. |
 | `JSSDK_INTERNAL_AJAX_ERROR` | 500 | `AjaxError.fromException` | Default code when wrapping an unknown HTTP error. |
-| `JSSDK_CLIENT_SIDE_WARNING` | — | `B24Hook` constructor | Warning emitted when a `B24Hook` is instantiated in the browser — webhooks expose a portal-wide secret and shouldn't ship to client bundles. |
+| `JSSDK_CLIENT_SIDE_WARNING` | — / 500 | `B24Hook` (browser) · `initializeB24Frame` | Two cases. As a **logged warning** (no `status`): a `B24Hook` is instantiated in the browser — webhooks expose a portal-wide secret and shouldn't ship to client bundles. As a **rejected `SdkError`** (`status: 500`): `initializeB24Frame()` ran outside the Bitrix24 iframe, so `window.name` carried no `DOMAIN`/`APP_SID` — open the app inside Bitrix24 (or paste the URL into the app settings). The rejection is prompt and a later call may retry. |
 
 ## REST-side codes that come back as `AjaxError`
 

--- a/docs/content/docs/99.examples/2.frame-app-skeleton.md
+++ b/docs/content/docs/99.examples/2.frame-app-skeleton.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Frame app skeleton'
 description: 'Minimum viable Bitrix24 iframe app: init handshake, set title, persist app state, open a slider, close cleanly.'
-audited: 2026-06-28
+audited: 2026-07-03
 category: 'examples'
 featured: true
 cookbookOrder: 4

--- a/packages/jssdk/src/loader-b24frame.ts
+++ b/packages/jssdk/src/loader-b24frame.ts
@@ -22,13 +22,20 @@ let isStartWatch = false
 // region Watch ////
 function startWatch() {
   window.setTimeout(() => {
-    if (!isInit || $b24Frame === null) {
+    // Poll only while initialization is still pending — i.e. it has neither
+    // succeeded (isInit + $b24Frame) NOR failed (connectError). Previously the
+    // loop ignored connectError, so a failed init kept polling forever and every
+    // queued caller waited on a promise that never settled. Now a terminal
+    // failure ends the loop and flushes the queue with a rejection. (#142)
+    if (connectError === null && (!isInit || $b24Frame === null)) {
       startWatch()
       return
     }
 
     processResult()
     listCallBack = []
+    // Let a later initializeB24Frame() re-arm the watch if it retries. (#142)
+    isStartWatch = false
   }, delay)
 }
 
@@ -37,6 +44,7 @@ function processResult(): void {
     for (const callBack of listCallBack) {
       callBack.reject(connectError)
     }
+    return
   }
 
   if (!isInit || $b24Frame === null) {
@@ -46,6 +54,35 @@ function processResult(): void {
   for (const callBack of listCallBack) {
     callBack.resolve($b24Frame as B24Frame)
   }
+}
+
+// Terminal failure of the first init: record the error, reject everyone already
+// queued (so no awaiter is stranded), clear the queue, and reset isMakeFirstCall
+// so a subsequent initializeB24Frame() can retry from scratch. (#142)
+function failInit(error: Error): void {
+  connectError = error
+
+  // Tear down the frame built by the failed attempt: its constructor subscribed
+  // a window `message` listener that only B24Frame.destroy() removes. Without
+  // this, a retry would build a SECOND frame and leave the first listener live —
+  // two handlers then process the same incoming messages (cross-talk), not just
+  // a leak. Guarded so a throwing destroy() can't mask the real error. (#142)
+  if ($b24Frame !== null) {
+    try {
+      $b24Frame.destroy()
+    } catch {
+      // ignore — the init already failed; we only care about detaching listeners
+    }
+    $b24Frame = null
+  }
+
+  const queued = listCallBack
+  listCallBack = []
+  for (const callBack of queued) {
+    callBack.reject(error)
+  }
+
+  isMakeFirstCall = false
 }
 // endregion ////
 
@@ -81,6 +118,12 @@ export async function initializeB24Frame(
 
   // region First Call ///
   isMakeFirstCall = true
+  // Start each fresh attempt from a clean slate so a retry after a previous
+  // failure isn't poisoned by the old connectError (which would otherwise make
+  // startWatch reject the new attempt's callers too). (#142)
+  connectError = null
+  $b24Frame = null
+  isInit = false
 
   return new Promise((resolve, reject) => {
     const queryParams: B24FrameQueryParams = {
@@ -99,13 +142,17 @@ export async function initializeB24Frame(
     }
 
     if (!queryParams.DOMAIN || !queryParams.APP_SID) {
-      // throw new Error('Unable to initialize Bitrix24Frame library!')
-      connectError = new SdkError({
+      // Reject AND stop: previously execution fell through here, constructing a
+      // B24Frame (which subscribes a window `message` listener) and calling
+      // .init() against an invalid target origin. Bail out cleanly instead. (#142)
+      const error = new SdkError({
         code: 'JSSDK_CLIENT_SIDE_WARNING',
         description: 'Well done! Now paste this URL into the Bitrix24 app settings',
         status: 500
       })
-      reject(connectError)
+      reject(error)
+      failInit(error)
+      return
     }
 
     $b24Frame = new B24Frame(
@@ -120,8 +167,8 @@ export async function initializeB24Frame(
         resolve($b24Frame as B24Frame)
       })
       .catch((error) => {
-        connectError = error
-        reject(connectError)
+        reject(error)
+        failInit(error)
       })
   })
   // endregion ////

--- a/test/integration/frame/initialize-b24frame-142.unit.spec.ts
+++ b/test/integration/frame/initialize-b24frame-142.unit.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * #142 — `initializeB24Frame()` must not strand callers or leak a frame on a
+ * failed init.
+ *
+ * The loader keeps module-level singleton state, so each test re-imports it
+ * fresh via `vi.resetModules()`. `B24Frame` is mocked so we can (a) count how
+ * many times it is constructed — the missing-DOMAIN path must construct ZERO —
+ * and (b) drive its `init()` outcome. Runs in the `jsSdk:unit` project (Node,
+ * no DOM), so a minimal `window` stub provides `name` + `setTimeout`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Controls shared with the hoisted B24Frame mock below.
+let frameConstructCount = 0
+let frameDestroyCount = 0
+let initBehavior: () => Promise<void> = () => Promise.resolve()
+
+vi.mock('../../../packages/jssdk/src/frame', () => ({
+  B24Frame: class {
+    constructor(_queryParams: any, _options: any) {
+      frameConstructCount += 1
+    }
+
+    init(): Promise<void> {
+      return initBehavior()
+    }
+
+    destroy(): void {
+      frameDestroyCount += 1
+    }
+  }
+}))
+
+function setWindow(name: string): void {
+  ;(globalThis as any).window = {
+    name,
+    setTimeout: (fn: (...args: any[]) => void, ms?: number) => setTimeout(fn, ms)
+  }
+}
+
+const VALID_NAME = 'acme.bitrix24.com|1|APPSID123'
+
+async function loadLoader() {
+  return import('../../../packages/jssdk/src/loader-b24frame')
+}
+
+describe('#142 initializeB24Frame() failure handling', () => {
+  beforeEach(() => {
+    frameConstructCount = 0
+    frameDestroyCount = 0
+    initBehavior = () => Promise.resolve()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    delete (globalThis as any).window
+  })
+
+  it('rejects and constructs NO frame when window.name lacks DOMAIN/APP_SID', async () => {
+    setWindow('') // no name → DOMAIN/APP_SID stay null
+    const { initializeB24Frame } = await loadLoader()
+
+    await expect(initializeB24Frame()).rejects.toMatchObject({
+      code: 'JSSDK_CLIENT_SIDE_WARNING'
+    })
+    // The core bug: execution used to fall through and build a B24Frame (which
+    // subscribes a window `message` listener) + call .init(). It must not.
+    expect(frameConstructCount).toBe(0)
+  })
+
+  it('does not strand concurrent callers on the missing-DOMAIN path', async () => {
+    setWindow('')
+    const { initializeB24Frame } = await loadLoader()
+
+    // Both are issued before any await; the second must NOT hang forever.
+    const p1 = initializeB24Frame()
+    const p2 = initializeB24Frame()
+
+    await expect(p1).rejects.toMatchObject({ code: 'JSSDK_CLIENT_SIDE_WARNING' })
+    await expect(p2).rejects.toMatchObject({ code: 'JSSDK_CLIENT_SIDE_WARNING' })
+    expect(frameConstructCount).toBe(0)
+  })
+
+  it('rejects a queued caller when the first init() rejects asynchronously', async () => {
+    setWindow(VALID_NAME) // valid params → a frame IS constructed, init pending
+    let rejectInit!: (error: any) => void
+    initBehavior = () => new Promise<void>((_resolve, reject) => {
+      rejectInit = reject
+    })
+    const { initializeB24Frame } = await loadLoader()
+
+    const p1 = initializeB24Frame() // first call — init() pending
+    const p2 = initializeB24Frame() // queued behind the pending first call
+    p1.catch(() => {})
+    p2.catch(() => {})
+
+    const boom = new Error('init boom')
+    rejectInit(boom)
+
+    // The queued caller must be rejected (previously it waited on a promise
+    // that never settled while the 50ms watch looped forever).
+    await expect(p1).rejects.toBe(boom)
+    await expect(p2).rejects.toBe(boom)
+    expect(frameConstructCount).toBe(1)
+  })
+
+  it('allows a retry after a failure (isMakeFirstCall + connectError are reset)', async () => {
+    setWindow('') // first attempt fails: missing DOMAIN
+    const mod = await loadLoader()
+
+    await expect(mod.initializeB24Frame()).rejects.toMatchObject({
+      code: 'JSSDK_CLIENT_SIDE_WARNING'
+    })
+    expect(frameConstructCount).toBe(0)
+
+    // Environment fixed → a retry must be able to succeed from scratch, not be
+    // poisoned by the previous connectError.
+    ;(globalThis as any).window.name = VALID_NAME
+    initBehavior = () => Promise.resolve()
+
+    const b24 = await mod.initializeB24Frame()
+    expect(b24).toBeTruthy()
+    expect(frameConstructCount).toBe(1) // only the successful retry built a frame
+  })
+
+  it('destroys the frame from a failed async init before a retry builds a new one', async () => {
+    setWindow(VALID_NAME)
+    let rejectInit!: (error: any) => void
+    initBehavior = () => new Promise<void>((_resolve, reject) => {
+      rejectInit = reject
+    })
+    const mod = await loadLoader()
+
+    const failing = mod.initializeB24Frame()
+    failing.catch(() => {})
+    rejectInit(new Error('init boom'))
+    await expect(failing).rejects.toThrow('init boom')
+
+    // The frame built by the failed attempt must be torn down (its window
+    // `message` listener removed) so a retry doesn't leave two live handlers.
+    expect(frameConstructCount).toBe(1)
+    expect(frameDestroyCount).toBe(1)
+
+    // Retry succeeds and builds exactly one fresh frame.
+    initBehavior = () => Promise.resolve()
+    const b24 = await mod.initializeB24Frame()
+    expect(b24).toBeTruthy()
+    expect(frameConstructCount).toBe(2)
+  })
+
+  it('a caller that QUEUES via startWatch during a retry resolves (not poisoned by the old connectError)', async () => {
+    // Pins the entry-time `connectError = null` reset: the retry keeps its init
+    // pending so a second retry caller goes through the isMakeFirstCall/startWatch
+    // queue path (not a direct resolve). A stale connectError would make the
+    // watch reject this queued caller.
+    setWindow(VALID_NAME)
+    let rejectFirst!: (error: any) => void
+    initBehavior = () => new Promise<void>((_resolve, reject) => {
+      rejectFirst = reject
+    })
+    const mod = await loadLoader()
+
+    const failing = mod.initializeB24Frame()
+    failing.catch(() => {})
+    rejectFirst(new Error('first boom'))
+    await expect(failing).rejects.toThrow('first boom')
+
+    // Retry: keep init pending so the second caller queues via startWatch.
+    let resolveRetry!: () => void
+    initBehavior = () => new Promise<void>((resolve) => {
+      resolveRetry = resolve
+    })
+    const retryA = mod.initializeB24Frame() // fresh first-call, init pending
+    const retryB = mod.initializeB24Frame() // queued via startWatch
+    retryA.catch(() => {})
+    retryB.catch(() => {})
+
+    resolveRetry()
+
+    await expect(retryA).resolves.toBeTruthy()
+    await expect(retryB).resolves.toBeTruthy() // must NOT be rejected with 'first boom'
+  })
+
+  it('stops the watch loop after a failure — no infinite 50ms polling', async () => {
+    // Pins startWatch's `connectError === null` termination guard. A queued
+    // caller arms the watch; once init fails the loop must stop, leaving no
+    // pending timer. Without the guard the watch re-arms itself forever.
+    vi.useFakeTimers()
+    try {
+      setWindow(VALID_NAME)
+      let rejectInit!: (error: any) => void
+      initBehavior = () => new Promise<void>((_resolve, reject) => {
+        rejectInit = reject
+      })
+      const { initializeB24Frame } = await loadLoader()
+
+      const pA = initializeB24Frame() // first call, init pending
+      const pB = initializeB24Frame() // queued → arms startWatch
+      pA.catch(() => {})
+      pB.catch(() => {})
+
+      expect(vi.getTimerCount()).toBeGreaterThanOrEqual(1)
+
+      rejectInit(new Error('boom'))
+      // Flush the .catch/failInit microtasks and run the armed watch timer.
+      await vi.advanceTimersByTimeAsync(50 * 4)
+
+      // The watch must have terminated: nothing left polling.
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})


### PR DESCRIPTION
Closes #142.

## The bug (severity: high)
When `window.name` lacked `DOMAIN`/`APP_SID`, `initializeB24Frame()` set `connectError`, called `reject()` and then **fell through without `return`** — still constructing a `B24Frame` (which subscribes a window `message` listener) and calling `.init()` against an **invalid target origin**. Meanwhile `startWatch()` polled every 50 ms and **never checked `connectError`**, so every caller queued in `listCallBack` awaited a promise that **never settled** and the timer looped forever. Any frame app opened **outside** the Bitrix24 iframe (direct URL, dev server, install screen) hit exactly this path — the 2nd+ awaiters hung silently.

## Fixes
- **`return` after reject** on the missing-`DOMAIN` path → no `B24Frame` is built, no postMessage to an invalid origin (closes a small security exposure too).
- **`startWatch()` terminates** when `connectError !== null` and flushes the queue via `processResult()` (which also gained a missing `return`) → queued callers are rejected instead of hanging, and the poll loop stops.
- **New `failInit()`** records the error, rejects every queued caller, clears the queue, **destroys the frame built by a failed async init** (removing its window `message` listener so a retry can't leave two live handlers cross-talking — flagged by two reviewers as a correctness risk, not just a leak), and resets `isMakeFirstCall` so a later call can retry.
- **First-call entry resets** `connectError`/`$b24Frame`/`isInit`, so a retry after a prior failure isn't poisoned by the stale `connectError`.

## Tests
New `test/integration/frame/initialize-b24frame-142.unit.spec.ts` (7 cases): missing-DOMAIN bail (**zero** frames constructed), concurrent-caller no-hang, async-init rejection of a queued caller, retry-after-failure, stale-frame `destroy()` on retry, a queued-via-`startWatch` retry caller **resolving** (not poisoned), and the watch loop **terminating** after failure (no infinite polling). The last two are **mutation-verified** to catch reverts of the `startWatch` guard and the entry-time reset (closing two coverage gaps the tester reviewer found).

## Docs
`6.errors.md` now notes `JSSDK_CLIENT_SIDE_WARNING` is **also** emitted (as a rejected `SdkError`, status 500) by `initializeB24Frame()` outside the iframe (previously listed only the `B24Hook` browser-warning source). `audited:` bumped to 2026-07-03.

## Verification
- `pnpm --filter @bitrix24/b24jssdk typecheck` — clean
- `pnpm run lint` — 0 errors (1 pre-existing unrelated warning)
- `pnpm run package-jssdk:test:run-unit` — **377 passed** (+7)
- `node scripts/docs-lint.mjs --strict` — 0 errors, 0 warnings

Reviewed by a 5-perspective pass (correctness/concurrency, tester/mutation, edge/API, security, tech-director) — all SHIP. The stale-frame `destroy()` and the two mutation-coverage gaps were folded in per their findings.

## Follow-ups (filed as separate work, not in scope)
- Collapse the singleton + 50 ms busy-poll into a single shared init promise (removes 3 of the 4 module booleans) — tech-director's recommended refactor, too broad for a severity-high hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6MQtPUx9MZjXY2rbLZhbv

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6MQtPUx9MZjXY2rbLZhbv)_