### PR TITLE
docs(process): correct the "CHANGELOG is auto-generated" claim + fix v1.0.2 date & stale release grouping (#178)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ Cutting a release (bump → changelog → tag → publish) is documented in **[R
 
 ## Key Conventions
 
-- **Conventional Commits**: `feat`/`fix` for behaviour, `docs`/`chore` otherwise (e.g. `feat(http): add adaptive delayer`, `fix(frame): refresh auth on 401`). The CHANGELOG is generated from these.
+- **Conventional Commits**: `feat`/`fix` for behaviour, `docs`/`chore` otherwise (e.g. `feat(http): add adaptive delayer`, `fix(frame): refresh auth on 401`). These prefixes guide which section a change lands in, but the CHANGELOG is **hand-maintained** — not auto-generated: add your entry under `## [Unreleased]` in [CHANGELOG.md](CHANGELOG.md) (keep-a-changelog style: Added / Changed / Fixed / Docs), and it is finalised into a versioned section at release time (see [RELEASING.md](RELEASING.md)). Adopting changelog tooling is tracked separately (#310).
 - **No default exports**: every export is named so consumers stay tree-shakeable (`sideEffects: false`).
 - **TypeScript strict**: `tsc` for the core SDK; `vue-tsc` for the Nuxt / docs / playground projects.
 - **Public contract**: exports from [packages/jssdk/src/index.ts](packages/jssdk/src/index.ts) are a public API. Any breaking change needs a deprecation cycle, not a silent rename.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * **tools:** expanded the `Text`, `Type`, `Browser`, and `useFormatter` documentation pages to the full tools skeleton and added complete JSDoc to `packages/jssdk/src/tools/text.ts`. `Text.getDateForLog()` now uses the `yyyy` year token (was `y`) to match its documented `yyyy-MM-dd HH:mm:ss` format — output is unchanged for four-digit years (#291).
 * **security:** new [Security patterns](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/security/) page for event-receiver / OAuth apps — reply-`2xx`-first ordering and constant-time `application_token` verification, with a checklist (#84).
 * **skills:** document the skill installation paths on the AI Skills page — project / personal install, the published `/.well-known/skills/` URL, and vendor-in for non-Claude tools (#124).
+* **docs:** corrected the `AGENTS.md` claim that the CHANGELOG is auto-generated — it is hand-maintained (keep-a-changelog style, finalised at release per `RELEASING.md`); and fixed the `v1.0.2` CHANGELOG date `2026-03-17` → `2026-02-17` to match the actual GitHub release (#178).
 
 ### Deprecations
 
@@ -260,7 +261,7 @@
 
 * **ListPayload**: remove any from the union 
 
-## [1.0.2](https://github.com/bitrix24/b24jssdk/compare/v1.0.1...v1.0.2) (2026-03-17)
+## [1.0.2](https://github.com/bitrix24/b24jssdk/compare/v1.0.1...v1.0.2) (2026-02-17)
 
 ### Bug Fixes
 
@@ -308,7 +309,12 @@ Please see the full [SDK v1 migration guide](https://bitrix24.github.io/b24jssdk
 * **Http.#prepareMethod:** telemetry transfer to task methods
 
 ## [0.4.9] (2025-09-12)
+
+_No user-facing changes (empty release)._
+
 ## [0.4.8] (2025-09-12)
+
+_No user-facing changes (empty release)._
 
 ## [0.4.7](https://github.com/bitrix24/b24jssdk/compare/v0.4.6...v0.4.7) (2025-09-12)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -106,7 +106,10 @@ fires both publish workflows — each runs CI, then publishes its package.
    ```
 
    Then add a new empty `## [Unreleased]` section above it for the next cycle.
-   Keep the `Features` / `Bug Fixes` / `Security` / `Chore` grouping.
+   Keep the keep-a-changelog grouping the `[Unreleased]` buffer uses —
+   `Added` / `Changed` / `Fixed` / `Docs` / `Deprecations`. (Released sections
+   from the `1.x` era used the older `Features` / `Bug Fixes` / `Security` /
+   `Chore` grouping; don't reintroduce it for new sections.)
 
 4. **Commit and push to `main`.**
 


### PR DESCRIPTION
Closes #178. Automation follow-up tracked in #310.

## Problem
`AGENTS.md` claimed "The CHANGELOG is generated from these [conventional commits]" — but there is **no changelog tooling** in the repo (verified: no `changelogen`/`release-it`/`conventional-changelog`/`standard-version` anywhere in package.json/scripts/workflows), and `RELEASING.md` itself describes a **manual** finalise-the-changelog step. The claim was false and self-contradictory. #178 also flagged the `v1.0.2` entry dated `2026-03-17` while the GitHub release was published `2026-02-17`, and empty `0.4.8`/`0.4.9` entries.

## Fixes (docs-only)
- **AGENTS.md** — replace the false "generated" claim with an accurate description of the manual keep-a-changelog process (`## [Unreleased]` → Added/Changed/Fixed/Docs, finalised at release per RELEASING.md); breadcrumb to the automation follow-up (#310).
- **CHANGELOG.md** — fix `v1.0.2` date `2026-03-17` → `2026-02-17` (matches the release's `published_at`; restores chronological order v1.0.1 → **v1.0.2** → v1.0.3). Annotate the genuinely-empty `0.4.8`/`0.4.9` releases (`_No user-facing changes (empty release)._`) so they aren't misread as dropped content. Record the fix under `## [Unreleased]` → Docs.
- **RELEASING.md** — step 3 told the releaser to keep the older `Features`/`Bug Fixes`/`Security`/`Chore` grouping, but the `[Unreleased]` buffer uses keep-a-changelog headings; aligned it (same doc-vs-reality defect class #178 targets — surfaced by an adversarial doc-audit reviewer).

## Verification
- `pnpm run lint:md` — 0 errors (21 files)
- `node scripts/docs-lint.mjs --strict` — 0 errors, 0 warnings (editing `.md` docs doesn't age any content page's `audited:`)
- All factual claims independently verified against the live repo + GitHub release API (release-bump script, publish workflows, OIDC no-token, #119 token, CHANGELOG date order).

Reviewed by a 5-perspective pass (fact-check, consistency/docs, scope/bookkeeping, adversarial doc-audit, follow-up integrity) — all SHIP; the RELEASING.md grouping fix was folded in from the adversarial reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6MQtPUx9MZjXY2rbLZhbv

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6MQtPUx9MZjXY2rbLZhbv)_