### PR TITLE
platform: drop EOL Node 18 from engines, add Nuxt engines, test 22+24, pin publish (#174)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,15 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Test on every supported non-EOL Node line so the runtimes the SDK
+    # advertises in `engines` are actually exercised (#174). 22 = the line the
+    # publish workflows build the artifact on (lowest supported + validated);
+    # 24 = newest active LTS. (Node 20 is still in `engines` but EOL and slated
+    # for removal in #312, so it is intentionally not in the matrix.)
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -198,7 +207,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: ${{ matrix.node }}
           cache: pnpm
 
       - name: Install dependencies
@@ -218,7 +227,9 @@ jobs:
         # Audit prod + dev dependencies at the `moderate` threshold. Dev deps
         # execute during lint/typecheck/docs builds in CI, so a vulnerable one
         # is in-scope. Known transitive advisories are pinned to patched
-        # versions via `overrides` in pnpm-workspace.yaml (#110).
+        # versions via `overrides` in pnpm-workspace.yaml (#110). Node-agnostic,
+        # so run it once (on the baseline leg), not per matrix entry.
+        if: matrix.node == 22
         run: pnpm audit --audit-level=moderate
 
   build:

--- a/.github/workflows/npm-publish-js-sdk-nuxt.yml
+++ b/.github/workflows/npm-publish-js-sdk-nuxt.yml
@@ -93,7 +93,12 @@ jobs:
       - name: Install node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 'lts/*'
+          # Pinned to 22 — the LOWEST supported + CI-validated Node line (the ci
+          # test job runs a 22 + 24 matrix). Building the published artifact on
+          # the floor, not the newest LTS, keeps the output consumable by every
+          # supported consumer, and replaces the floating `lts/*` with a
+          # deterministic runtime (#174).
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 

--- a/.github/workflows/npm-publish-js-sdk.yml
+++ b/.github/workflows/npm-publish-js-sdk.yml
@@ -92,7 +92,12 @@ jobs:
       - name: Install node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 'lts/*'
+          # Pinned to 22 — the LOWEST supported + CI-validated Node line (the ci
+          # test job runs a 22 + 24 matrix). Building the published artifact on
+          # the floor, not the newest LTS, keeps the output consumable by every
+          # supported consumer, and replaces the floating `lts/*` with a
+          # deterministic runtime (#174).
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 * **types:** `TypeHttp.ajaxClient` is now `AxiosInstance` instead of `AxiosInstance | any` (the union erased the type) (#153).
+* **build:** dropped end-of-life Node.js 18 from `engines` — the supported range is now `^20.0.0 || >=22.0.0`, and `@bitrix24/b24jssdk-nuxt` now declares the same range (it previously had none). Node 20 is retained for now; its removal is a breaking change deferred to the next major (#312). CI now runs the unit tests on a Node `22 + 24` matrix, and both npm-publish workflows build the artifact on a pinned, CI-validated Node 22 instead of the floating `lts/*` (#174).
 
 ### Fixed
 

--- a/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
+++ b/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
@@ -21,7 +21,7 @@ Both the `ESM` and `CommonJS` entries keep their dependencies (`axios`, `luxon`,
 Before you begin, make sure you have the latest version of Node.js installed.
 
 ::note
-We support version Node.js `^18.0.0 || ^20.0.0 || >=22.0.0`
+We support version Node.js `^20.0.0 || >=22.0.0` (Node 18 is EOL and no longer supported).
 ::
 
 Then run the following command to install the library:

--- a/docs/content/docs/99.examples/1.crm-analytics.md
+++ b/docs/content/docs/99.examples/1.crm-analytics.md
@@ -17,7 +17,7 @@ Loads every deal on the portal in chunks (no loading all rows into RAM), groups 
 
 ## Stack
 
-Node.js 18+. No external dependencies.
+Node.js 20+. No external dependencies.
 
 ## Environment
 

--- a/docs/content/docs/99.examples/10.error-handling.md
+++ b/docs/content/docs/99.examples/10.error-handling.md
@@ -27,7 +27,7 @@ Also covers `setRestrictionManagerParams` with the new knobs:
 
 ## Stack
 
-Node.js 18+. No external dependencies.
+Node.js 20+. No external dependencies.
 
 ## Environment
 

--- a/docs/content/docs/99.examples/11.event-registration.md
+++ b/docs/content/docs/99.examples/11.event-registration.md
@@ -23,7 +23,7 @@ Run it once after deploying your handler; re-run on every config change.
 
 ## Stack
 
-Node.js 18+. No external dependencies.
+Node.js 20+. No external dependencies.
 
 ## Environment
 

--- a/docs/content/docs/99.examples/12.oauth-install.md
+++ b/docs/content/docs/99.examples/12.oauth-install.md
@@ -28,7 +28,7 @@ Use this as the scaffold for a multi-tenant backend that serves many Bitrix24 po
 
 ## Stack
 
-Node.js 18+, `express`.
+Node.js 20+, `express`.
 
 ## Install
 

--- a/docs/content/docs/99.examples/2.mass-messaging.md
+++ b/docs/content/docs/99.examples/2.mass-messaging.md
@@ -17,7 +17,7 @@ Reads up to 100 contacts that match a filter, builds a personal greeting from a 
 
 ## Stack
 
-Node.js 18+. No external dependencies.
+Node.js 20+. No external dependencies.
 
 ## Environment
 

--- a/docs/content/docs/99.examples/3.task-automation.md
+++ b/docs/content/docs/99.examples/3.task-automation.md
@@ -17,7 +17,7 @@ Loads open deals (excluding `WON`/`LOSE`) every minute, compares each stage with
 
 ## Stack
 
-Node.js 18+. No external dependencies.
+Node.js 20+. No external dependencies.
 
 ## Environment
 

--- a/docs/content/docs/99.examples/4.erp-sync.md
+++ b/docs/content/docs/99.examples/4.erp-sync.md
@@ -17,7 +17,7 @@ Pulls contacts from both Bitrix24 (via `actions.v2.fetchList.make`) and an exter
 
 ## Stack
 
-Node.js 18+, `node-cron`.
+Node.js 20+, `node-cron`.
 
 ## Install
 

--- a/docs/content/docs/99.examples/5.disk-files.md
+++ b/docs/content/docs/99.examples/5.disk-files.md
@@ -17,7 +17,7 @@ Touches every read/write operation Bitrix24 Disk supports without multipart: `di
 
 ## Stack
 
-Node.js 18+. No external dependencies.
+Node.js 20+. No external dependencies.
 
 ## Environment
 

--- a/docs/content/docs/99.examples/6.telegram-bot.md
+++ b/docs/content/docs/99.examples/6.telegram-bot.md
@@ -17,7 +17,7 @@ Watches `crm.item.list` for deals with `id > lastSeenDealId` and base stage `NEW
 
 ## Stack
 
-Node.js 18+, `grammy`, `node-cron`.
+Node.js 20+, `grammy`, `node-cron`.
 
 ## Install
 

--- a/docs/content/docs/99.examples/7.webhook-handler.md
+++ b/docs/content/docs/99.examples/7.webhook-handler.md
@@ -21,7 +21,7 @@ Stands up an Express endpoint at `POST /webhook` that maps `ONCRMDEALADD`, `ONCR
 
 ## Stack
 
-Node.js 18+, `express`.
+Node.js 20+, `express`.
 
 ## Install
 

--- a/docs/content/docs/99.examples/8.ai-assistant.md
+++ b/docs/content/docs/99.examples/8.ai-assistant.md
@@ -17,7 +17,7 @@ Given a deal id on the command line, it fetches the deal (`crm.item.get` via `ac
 
 ## Stack
 
-Node.js 18+, `openai`.
+Node.js 20+, `openai`.
 
 ## Install
 

--- a/docs/content/docs/99.examples/9.web-search-llm.md
+++ b/docs/content/docs/99.examples/9.web-search-llm.md
@@ -17,7 +17,7 @@ Bitrix24 REST has no native web search or LLM endpoint. This recipe demonstrates
 
 ## Stack
 
-Node.js 18+, `openai`. Web search is BYOC — replace `webSearch()` with your call to Tavily, Brave, SerpAPI, or any other provider.
+Node.js 20+, `openai`. Web search is BYOC — replace `webSearch()` with your call to Tavily, Brave, SerpAPI, or any other provider.
 
 ## Install
 

--- a/packages/jssdk-nuxt/package.json
+++ b/packages/jssdk-nuxt/package.json
@@ -39,6 +39,9 @@
     "LICENSE",
     "dist"
   ],
+  "engines": {
+    "node": "^20.0.0 || >=22.0.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jssdk/README-AI.md
+++ b/packages/jssdk/README-AI.md
@@ -231,7 +231,7 @@ for await (const chunk of $b24.fetchListMethod('crm.item.list', { entityTypeId: 
 
 Notes
 
-- Supported Node versions: ^18, ^20, or >=22.
+- Supported Node versions: ^20 or >=22.
 - B24Hook warns if used on the client; keep it server-side.
 
 

--- a/packages/jssdk/docker-compose.yml
+++ b/packages/jssdk/docker-compose.yml
@@ -1,14 +1,18 @@
+# Local cross-runtime smoke: mirrors the CI `test` job's Node matrix (22 + 24),
+# the supported+validated lines. EOL Node 18 was removed with the `engines`
+# drop in #174; Node 20 stays in `engines` for now but is EOL and slated for
+# removal in #312, so it is not exercised here.
 services:
-  test-node18:
-    image: node:18-alpine
+  test-node22:
+    image: node:22-alpine
     volumes:
       - .:/app
       - /app/node_modules
     working_dir: /app
     command: sh -c "npm install --no-audit && npm run build && npm test"
 
-  test-node20:
-    image: node:20-alpine
+  test-node24:
+    image: node:24-alpine
     volumes:
       - .:/app
       - /app/node_modules

--- a/packages/jssdk/package.json
+++ b/packages/jssdk/package.json
@@ -58,7 +58,7 @@
     "package.json"
   ],
   "engines": {
-    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+    "node": "^20.0.0 || >=22.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/skills/b24jssdk-core/SKILL.md
+++ b/skills/b24jssdk-core/SKILL.md
@@ -50,7 +50,7 @@ const $b24 = new B24Hook({
 Notes:
 
 - Keep `B24Hook` server-side only. The webhook URL contains a long-lived secret.
-- Supported Node: `^18`, `^20`, `>=22`.
+- Supported Node: `^20`, `>=22`.
 
 ## B24Frame (in-iframe app)
 


### PR DESCRIPTION
Closes #174.

The SDK advertised runtimes it never tested (including two EOL lines) and built the published artifact on a floating `lts/*` that CI never validated — silent compatibility drift in both directions.

## Changes (non-breaking hygiene)
The genuinely breaking move — dropping **Node 20** — is deferred to the next major and tracked in **#312**.

- **`packages/jssdk` engines**: `^18.0.0 || ^20.0.0 || >=22.0.0` → `^20.0.0 || >=22.0.0` (drop EOL Node 18).
- **`packages/jssdk-nuxt`**: add `engines.node: "^20.0.0 || >=22.0.0"` (it had **none**).
- **`ci.yml` `test` job**: run the unit suite on a Node **`22 + 24`** matrix (`fail-fast: false`) so the advertised runtimes are actually exercised. The node-agnostic `pnpm audit` is gated to the 22 leg so it still runs exactly once.
- **Both npm-publish workflows**: pin `node-version` from floating `lts/*` → **`22`** — the *lowest* supported + CI-validated line, so the published artifact is built on the floor (consumable by every supported consumer) with a deterministic runtime.

## Docs / consistency synced
The engines string in `4.nodejs.md`, the "Node.js 18+" floor in **12** example pages, `README-AI.md`, the `b24jssdk-core` skill, and the local `docker-compose.yml` smoke matrix (`test-node18/20` → `22/24`) all now reflect the supported set. `CHANGELOG.md` `[Unreleased]` › Changed records the drop.

## Why pin publish to 22 (not 24)
The artifact should build on the **lowest** runtime we still support and validate, not the newest — so nothing that only breaks on an older-but-supported runtime slips through. Both 22 and 24 are now in CI; 22 is the conservative, fully-validated choice. (`lts/*` currently resolves to 24, so this also removes the float.)

## Known gap (tracked)
`engines` still advertises Node 20 (EOL) but CI tests only `22 + 24` — adding a soon-to-be-removed line to the matrix wasn't worth the runner minutes. The gap is closed by **removing** 20 in **#312**, not by growing the matrix backward.

## Verification
- `pnpm --filter @bitrix24/b24jssdk typecheck` — clean · `pnpm run lint` — 0 errors
- `pnpm run package-jssdk:test:run-unit` — **377 passed**
- `pnpm run lint:md` — 0 errors · `node scripts/docs-lint.mjs --strict` — 0/0
- All 3 workflow YAMLs + both `package.json` parse clean

Reviewed by a 5-perspective pass (CI-correctness, platform/semver, docs/consistency, supply-chain/publish, tech-director). Their findings are folded in: publish pinned to **22** (tech-director), the CHANGELOG entry added (all), and 3 doc stragglers fixed (docs reviewer: `README-AI.md`, `SKILL.md`, `docker-compose.yml`).

> Note on required checks: this turns `test` into `test (22)` / `test (24)`. The required status check is the `ci` aggregator (which `contains(needs.*.result, 'failure')` across matrix legs), so this doesn't affect branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6MQtPUx9MZjXY2rbLZhbv

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6MQtPUx9MZjXY2rbLZhbv)_