### PR TITLE
docs: align `audited` with the #320 commit date on 5 pages so docs-lint --strict is green

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: CallListV2.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 2.'
 category: 'actions'
-audited: 2026-07-29
+audited: 2026-07-30
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: CallList

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: FetchListV2.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 2 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-07-29
+audited: 2026-07-30
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: FetchList

--- a/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
+++ b/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
@@ -1,7 +1,7 @@
 ---
 title: Filtering
 description: 'Reference for building filter parameters in Bitrix24 REST API v2 (prefix operators) and v3 (array-of-triples), including date formatting and the order-stripping rule.'
-audited: 2026-07-29
+audited: 2026-07-30
 navigation:
   title: Filtering
 links:

--- a/docs/content/docs/99.examples/1.dashboard-deals-csv.md
+++ b/docs/content/docs/99.examples/1.dashboard-deals-csv.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Export deals to CSV'
 description: 'Stream every CRM deal that matches a date filter into a CSV file using a webhook and FetchListV2.'
-audited: 2026-07-29
+audited: 2026-07-30
 category: 'examples'
 featured: true
 cookbookOrder: 2

--- a/docs/content/docs/99.examples/5.pull-subscribe-frame.md
+++ b/docs/content/docs/99.examples/5.pull-subscribe-frame.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Subscribe to Pull events'
 description: 'Open a live channel from a Bitrix24 frame app and react to push events using useB24Helper + the Pull client.'
-audited: 2026-07-29
+audited: 2026-07-30
 category: 'examples'
 featured: true
 cookbookOrder: 5


### PR DESCRIPTION
## Why

The `docs-lint` job in [`ci.yml`](.github/workflows/ci.yml) has been **red on `main`** since #320 merged, and it fails every open PR regardless of that PR's own contents. It is what turns the otherwise-green Dependabot PR #321 red.

`dde9a9d` (#320) edited three sources — `packages/jssdk/src/core/actions/v2/call-list.ts`, `.../fetch-list.ts`, and `packages/jssdk/src/helper/helper-manager.ts` — and correctly re-stamped the pages citing them in the same commit, as `AGENTS.md` requires. But five stamps read `2026-07-29` while the commit itself landed `2026-07-30T06:20:09+03:00`. `docs-lint.mjs` resolves a source's age with `git log -1 --format=%cI`, so those pages claimed an audit a day *before* the source they cite changed:

```
WARN 2.working-with-the-rest-api/2.call-list-rest-api-ver2.md: source "…/v2/call-list.ts" was modified on 2026-07-30, after audited=2026-07-29
WARN 2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md: source "…/v2/fetch-list.ts" was modified on 2026-07-30, after audited=2026-07-29
WARN 2.working-with-the-rest-api/5.filtering.md:                source "…/v2/call-list.ts" was modified on 2026-07-30, after audited=2026-07-29
WARN 99.examples/1.dashboard-deals-csv.md:                      source "…/v2/fetch-list.ts" was modified on 2026-07-30, after audited=2026-07-29
WARN 99.examples/5.pull-subscribe-frame.md:                     source "…/helper/helper-manager.ts" was modified on 2026-07-30, after audited=2026-07-29

docs-lint: 0 error(s), 5 warning(s)
##[error]Process completed with exit code 1
```

`--strict` exits 1 on any warning, so 5 warnings sink the gate.

## What changed

`audited: 2026-07-29` → `2026-07-30` on those five pages. Nothing else.

## Why the content needs no change

This is a same-commit inconsistency, not a missed content review — a sixth page from the same commit, `5.choosing-the-right-method.md`, was already stamped `2026-07-30` and passes.

The audit those pages assert still holds:

- **`call-list.ts` / `fetch-list.ts`** — internal refactor with identical behaviour: `do … while (isContinue)` collapsed to `while (true)` with the same `break` conditions, the same cursor handling, and the same warning text. The dead `isContinue` flag is simply gone.
- **`helper-manager.ts`** — one line, attaching the caught value as `cause` to an error whose message (`Failed to load data`) is unchanged. #320 already documented that on `50.helper.md` and under `### Fixed` in the CHANGELOG.

No CHANGELOG entry here: `audited` is lint metadata and carries no consumer-visible change.

## Verification

| Check | Result |
| --- | --- |
| `node scripts/docs-lint.mjs --strict` | 0 errors, 0 warnings (was exit 1) |
| `node scripts/docs-link-check.mjs` | 0 broken links, 0 warnings |
| `pnpm run lint` | 0 errors (1 pre-existing warning in `docs/server/api/ai.post.ts`, untouched here) |
| `pnpm run typecheck` | clean — every workspace, plus `docs-typecheck` 152 blocks / 0 errors |

## Follow-ups this unblocks

Found while triaging the six open Dependabot PRs:

- **#318** (checkout v7.0.0→v7.0.1, setup-node v6.4.0→v7.0.0) — ready. Both pinned SHAs verified against the real tags; setup-node v7's only documented breaking change is "Migrated to ESM", `runs.using` stays `node24`, and inputs were only added, so the repo's `node-version` / `cache` / `registry-url` usage is unaffected.
- **#321** (`@comark/vue` 0.3.1→0.5.1, `@nuxtjs/mcp-toolkit` 0.16.1→0.18.0) — green apart from this gate; mergeable once this lands.
- **#282 / #283 / #284 / #285** — superseded. #320 already applied those majors at *higher* versions (`@types/node` `^26.1.2` vs `^26.0.1`; `ai` `^7.0.39` vs `^7.0.8`; `@ai-sdk/mcp` `^2.0.18` vs `^2.0.4`; `@ai-sdk/vue` `^4.0.39` vs `^4.0.8`), and all four now conflict with `main` on the lockfile. Closing them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rrttw4hxQSjwkr1wwyFkDN)_