### PR TITLE
ci(dependabot): ignore three majors blocked by upstream peer ranges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,8 +51,23 @@ updates:
     # registries, which typecheck and the build both pass without noticing. docs imports
     # `Slot` from it directly, so the dependency has to stay declared; it just has to
     # match whatever `@bitrix24/b24ui-nuxt` pins. Bump it only when b24ui-nuxt does.
+    # The three below are blocked by a peer range in a dependency we do not
+    # control, so the major lands as a PR that can never go green. Only the
+    # majors are ignored — minor/patch still flow through the group. Drop the
+    # entry once the named upstream widens its range.
+    #   typescript 7        — rollup-plugin-dts (via unbuild, which builds the
+    #                         published .d.ts) declares ^4.5 || ^5.0 || ^6.0.
+    #   better-sqlite3 13   — @nuxt/content pins ^12.5.0.
+    #   @takumi-rs/core 2   — nuxt-og-image ships @takumi-rs/helpers 1.8.7, and
+    #                         core/helpers have to stay on one major together.
     ignore:
       - dependency-name: "reka-ui"
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "better-sqlite3"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@takumi-rs/core"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         update-types:


### PR DESCRIPTION
Three major-version PRs (#327, #324, #326) each conflict with a range declared by a package we don't control, so Dependabot keeps reopening a PR that can never go green. All three are now closed with the reason recorded on the PR.

This adds an `ignore` entry for each, scoped to `version-update:semver-major` only — minor and patch updates still flow through the `npm-minor-patch` group as before.

| Package | Blocked by |
|---|---|
| `typescript` 7 | `rollup-plugin-dts` (via `unbuild`, which builds the published `.d.ts`) declares `^4.5 \|\| ^5.0 \|\| ^6.0` |
| `better-sqlite3` 13 | `@nuxt/content` pins `^12.5.0` |
| `@takumi-rs/core` 2 | `nuxt-og-image` ships `@takumi-rs/helpers` 1.8.7; core and helpers have to stay on one major together |

Each entry names its blocking package in the comment above the block, so the entry can be dropped as soon as that upstream widens its range — the same pattern as the existing `reka-ui` note.

Verified the file still parses and that the three entries land under the npm ecosystem's `ignore` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_