### PR TITLE
deps: take js-yaml 5, with the named-import migration it requires

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint": "^10.8.1",
     "express": "^5.2.1",
     "grammy": "^1.45.1",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^5.3.0",
     "markdownlint-cli2": "^0.23.2",
     "node-cron": "^4.6.0",
     "nuxt": "^4.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ overrides:
   tar: '>=7.5.16 <8'
   launch-editor: '>=2.14.1 <3'
   markdown-it: '>=14.1.2 <15'
-  js-yaml: '>=4.3.1 <5'
+  js-yaml: '>=5.3.0 <6'
   sharp: '>=0.35.3 <0.36'
   h3: 1.15.11
   '@nuxtjs/mdc': '>=0.23.0 <1'
@@ -77,8 +77,8 @@ importers:
         specifier: ^1.45.1
         version: 1.45.1
       js-yaml:
-        specifier: '>=4.3.1 <5'
-        version: 4.3.1
+        specifier: '>=5.3.0 <6'
+        version: 5.3.0
       markdownlint-cli2:
         specifier: ^0.23.2
         version: 0.23.2
@@ -4816,8 +4816,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@5.3.0:
+    resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
     hasBin: true
 
   jsdoc-type-pratt-parser@7.3.0:
@@ -7827,7 +7827,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 4.3.1
+      js-yaml: 5.3.0
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -11649,7 +11649,7 @@ snapshots:
     dependencies:
       entities: 8.0.0
       htmlparser2: 12.0.0
-      js-yaml: 4.3.1
+      js-yaml: 5.3.0
       markdown-exit: 1.1.0-beta.2
     optionalDependencies:
       shiki: 4.4.3
@@ -13065,7 +13065,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.3.1:
+  js-yaml@5.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -13377,7 +13377,7 @@ snapshots:
   markdownlint-cli2@0.23.2:
     dependencies:
       globby: 16.2.2
-      js-yaml: 4.3.1
+      js-yaml: 5.3.0
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.3.0
@@ -13777,7 +13777,7 @@ snapshots:
   minimark@1.0.0:
     dependencies:
       entities: 7.0.1
-      js-yaml: 4.3.1
+      js-yaml: 5.3.0
 
   minimatch@10.2.6:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,10 +26,12 @@ packages:
 # dedupe pins at the end of the block are exact versions instead, so they need no
 # ceiling). An override wins over the range every dependent declares, so an
 # unbounded floor silently pulls a new major into the whole tree the moment one is
-# published — `pnpm update` moved `js-yaml` 4 → 5 (pure ESM, no default export: it
-# broke `scripts/_docs-utils.mjs`) and `fast-uri` 3 → 4 (past the `^3.0.1` that
-# `ajv` declares) in exactly this way. A major crossing must be a deliberate edit
-# here, not a side effect of a bump.
+# published — `pnpm update` once moved `js-yaml` 4 → 5 (pure ESM, no default
+# export: it broke `scripts/_docs-utils.mjs`) and `fast-uri` 3 → 4 (past the
+# `^3.0.1` that `ajv` declares) in exactly this way. A major crossing must be a
+# deliberate edit here, not a side effect of a bump — js-yaml 5 is on the floor
+# below only because that edit was later made on purpose, with the named-import
+# migration `scripts/_docs-utils.mjs` needed to go with it.
 #
 # LOWER BOUND: keep each floor at or above what the manifests declare. Because the
 # override replaces the declared range AND is what pnpm records as the lockfile
@@ -107,8 +109,9 @@ overrides:
   markdown-it: '>=14.1.2 <15'
   # GHSA-h67p-54hq-rp68 — js-yaml quadratic-complexity DoS in merge-key aliases;
   # GHSA-5p4m-2wfm-xmqj — quadratic CPU consumption in `!!omap` resolution
-  # (CVE-2026-59870 fix not backported below 4.3.1)
-  js-yaml: '>=4.3.1 <5'
+  # (CVE-2026-59870 fix not backported below 4.3.1; the 5.x line carries both
+  # fixes, and 5 is what the root manifest now declares)
+  js-yaml: '>=5.3.0 <6'
   # GHSA-f88m-g3jw-g9cj — sharp; reached via docs>@nuxt/image>ipx and
   # docs>nuxt-og-image. sharp is 0.x, so the ceiling is the minor.
   sharp: '>=0.35.3 <0.36'

--- a/scripts/_docs-utils.mjs
+++ b/scripts/_docs-utils.mjs
@@ -6,7 +6,9 @@
 
 import { readdirSync, lstatSync } from 'node:fs'
 import { join } from 'node:path'
-import yaml from 'js-yaml'
+// js-yaml 5 is pure ESM and dropped the default export, so the two symbols we
+// use are imported by name.
+import { load as yamlLoad, JSON_SCHEMA } from 'js-yaml'
 
 /**
  * Recursively collect every `.md` file under `dir`.
@@ -100,7 +102,7 @@ export function parseFrontmatter(text) {
     // observable output doesn't change: `audited: 2026-05-26` stays a string
     // (the default schema's YAML timestamp type coerces it to a JS Date,
     // breaking the `frontmatter.audited + 'T…'` concat in docs-lint.mjs).
-    parsed = yaml.load(fm, { schema: yaml.JSON_SCHEMA })
+    parsed = yamlLoad(fm, { schema: JSON_SCHEMA })
   } catch {
     return { frontmatter: {}, body }
   }


### PR DESCRIPTION
Resolves what #325 was proposing, by making the change that PR couldn't make on its own.

The `js-yaml` override carried a deliberate `<5` ceiling: version 5 is pure ESM and dropped the default export, while `scripts/_docs-utils.mjs` did `import yaml from 'js-yaml'`. That's the whole of the incompatibility — both symbols the file actually uses, `load` and `JSON_SCHEMA`, are still exported by name in 5.3.0.

Changes:

- `scripts/_docs-utils.mjs` imports `load` and `JSON_SCHEMA` by name. The `JSON_SCHEMA` choice is unchanged and still load-bearing — it keeps `audited: 2026-05-26` a string instead of a JS `Date`, which the `audited + 'T…'` concat in `docs-lint.mjs` depends on.
- Override raised to `>=5.3.0 <6`, root manifest to `^5.3.0`. The 5.x line carries the two advisories the floor exists for (GHSA-h67p-54hq-rp68, GHSA-5p4m-2wfm-xmqj), so the security intent is preserved.
- Refreshed the ceiling rationale at the top of the override block, which used this exact bump as its cautionary example — it now records that the crossing was made deliberately, together with the code migration, rather than reading as an open warning against a state the repo is now in.

The whole tree resolves to a single `js-yaml@5.3.0`; no 4.x copy remains.

Verification: `docs:lint:test` 48/48 pass, `docs:lint` reports 0 errors / 0 warnings on both the page and link passes, `pnpm audit --audit-level=moderate` finds nothing, and `pnpm install --frozen-lockfile` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_