### PR TITLE
chore: bump pnpm 11.4.0 → 11.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Bitrix24 REST API JS SDK",
   "version": "2.0.0",
   "author": "Bitrix",
-  "packageManager": "pnpm@11.4.0",
+  "packageManager": "pnpm@11.22.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bitrix24/b24jssdk.git"


### PR DESCRIPTION
Groundwork for the release automation in #347.

npm trusted publishing over OIDC has **no documented minimum pnpm version** — the pnpm docs describe the `--provenance` flag but never name a floor for the OIDC exchange. The sibling `bitrix24/b24ui` repo is verified working on 11.20.0 (its published `dist.attestations` carries an SLSA provenance predicate). We were on 11.4.0, so moving to current removes the version gap as a variable before the first automated publish — where a silent OIDC failure looks like a green job that simply produced no provenance.

One line changes. `packageManager` is the single source of truth: both `pnpm/action-setup` steps in `ci.yml` deliberately omit `version:` and read it from here, so there is no second place to keep in sync. The lockfile is untouched.

Verified locally on 11.22.0:

- `pnpm install --frozen-lockfile` — clean
- 423 unit tests across 44 files — pass
- `package-jssdk:build` — succeeds (6.45 MB dist)
- `eslint .` — no errors (one pre-existing warning in `docs/server/api/ai.post.ts`, untouched by this branch)
- `docs-lint --strict` — 0/0
- `pnpm audit --audit-level=moderate` — no advisories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_