### PR TITLE
test(core): live smoke tests for the v3 modules from #203

### DIFF
--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -39,6 +39,13 @@ Both projects load `.env.test` (gitignored) via `dotenv`.
 
 The webhook must have at minimum the `crm`, `tasks`, `user`, `im`, and `main` scopes. The `im` scope is required by the issue-23 regression spec (`im.chat.get` inside a batch); `main` is **not exposed in the standard webhook scope picker** in the Bitrix24 UI and must be added manually — it is required by the v3 batch-ref spec that calls `main.eventlog.list`.
 
+`actions-v3-modules.spec.ts` additionally needs `mail`, `humanresources` and
+`timeman`. Unlike the ones above, these depend on the portal's plan and may not
+be available at all — a portal without them is a reason to skip that spec, not a
+failure to chase. Its assertions carry the portal's own error text so the three
+causes stay apart: `insufficient_scope` is a webhook fix, `METHODNOTFOUND` means
+the module is absent, anything else is a real shape problem.
+
 ### Limiter preset
 
 The integration test client uses `ParamsFactory.getDefault()`. The under-load setup ([test/0_setup/setup-under-load-jssdk.ts](../../test/0_setup/setup-under-load-jssdk.ts)) uses `ParamsFactory.getBatchProcessing()` — when authoring a new under-load test, do not switch back to `getDefault()` or the load profile will be wrong. To use any other preset locally, pass `restrictionParams` explicitly.

--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -40,9 +40,10 @@ Both projects load `.env.test` (gitignored) via `dotenv`.
 The webhook must have at minimum the `crm`, `tasks`, `user`, `im`, and `main` scopes. The `im` scope is required by the issue-23 regression spec (`im.chat.get` inside a batch); `main` is **not exposed in the standard webhook scope picker** in the Bitrix24 UI and must be added manually — it is required by the v3 batch-ref spec that calls `main.eventlog.list`.
 
 `actions-v3-modules.spec.ts` additionally needs `mail`, `humanresources` and
-`timeman`. Unlike the ones above, these depend on the portal's plan and may not
-be available at all — a portal without them is a reason to skip that spec, not a
-failure to chase. Its assertions carry the portal's own error text so the three
+`timeman`. Unlike the ones above, `mail` and `humanresources` depend on the
+portal's plan and may not be available at all. The spec does not skip itself in
+that case — it reports red — so a portal without those modules is a reason to
+exclude that spec locally, not a failure to chase. Its assertions carry the portal's own error text so the three
 causes stay apart: `insufficient_scope` is a webhook fix, `METHODNOTFOUND` means
 the module is absent, anything else is a real shape problem.
 

--- a/test/integration/core/actions-v3-modules.spec.ts
+++ b/test/integration/core/actions-v3-modules.spec.ts
@@ -20,7 +20,14 @@ import { setupB24Tests } from '../../0_setup/hooks-integration-jssdk'
  * .github/contributing/testing.md). The webhook needs the `mail`,
  * `humanresources` and `timeman` scopes on top of the usual set; `mail` and
  * `humanresources` in particular depend on the portal's plan and may simply not
- * be available, which is a legitimate reason to skip rather than to fail.
+ * be available.
+ *
+ * There is no automatic skip for that case, and deliberately so: the SDK cannot
+ * tell "this portal has no mail module" from "v3 routing for mail is broken"
+ * without asking the portal, which is the call being made. So a portal without
+ * the module reports red, and the assertion message below is what tells you it
+ * is an absent module rather than a regression — at which point excluding this
+ * spec locally is the right response, not chasing the failure.
  *
  * On failure the assertion message carries the portal's own error text, because
  * the three causes need different actions and are otherwise indistinguishable:
@@ -28,12 +35,6 @@ import { setupB24Tests } from '../../0_setup/hooks-integration-jssdk'
  * the module is absent or the method is not on v3 after all, and anything else is
  * a real shape problem worth reporting.
  */
-
-/** Field shape the limiter reads off every v3 response. */
-type V3Time = {
-  operating: number
-  operating_reset_at: number
-}
 
 async function smokeList(
   b24: ReturnType<ReturnType<typeof setupB24Tests>['getB24Client']>,
@@ -50,9 +51,14 @@ async function smokeList(
   ).toBe(true)
 
   const data = response.getData()!
-  expect(data.result, `${method} returned no result envelope`).toBeDefined()
 
-  const time = data.time as unknown as V3Time
+  // A `.list` method's payload shape differs per module, so this asserts only
+  // that an envelope came back — not its keys. It still separates a real
+  // round-trip from `result: null`, which is what a broken route looks like.
+  expect(data.result, `${method} returned no result envelope`).toBeDefined()
+  expect(data.result, `${method} returned an empty result envelope`).not.toBeNull()
+
+  const time = data.time
   expect(time).toHaveProperty('operating')
   expect(time.operating).toBeGreaterThanOrEqual(0)
   expect(time.operating_reset_at).toBeGreaterThan(0)

--- a/test/integration/core/actions-v3-modules.spec.ts
+++ b/test/integration/core/actions-v3-modules.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { setupB24Tests } from '../../0_setup/hooks-integration-jssdk'
+
+/**
+ * Read-path smoke tests for the rest-v3 modules added in #203 — `mail.*`,
+ * `humanresources.*`, `timeman.record.*` (#205).
+ *
+ * Why these exist. #203 wired routing for ~63 newly published v3 methods, and
+ * nothing confirmed the request/response actually round-trips on a live portal.
+ * That gap widened when the client-side allowlist was removed in 2.0.0: the SDK
+ * now sends **any** method to the v3 endpoint and lets the server decide, so
+ * there is no client-side signal left at all. A live call is the only check.
+ *
+ * What is asserted. One list method per module, and the v3 envelope around it:
+ * `result` present, and a `time` block whose `operating` counters are the shape
+ * the limiter reads. Nothing about the records themselves — a portal may hold
+ * none, and an empty list is a perfectly good round-trip.
+ *
+ * **Local-only.** These need `B24_HOOK`, and CI does not run Vitest at all (see
+ * .github/contributing/testing.md). The webhook needs the `mail`,
+ * `humanresources` and `timeman` scopes on top of the usual set; `mail` and
+ * `humanresources` in particular depend on the portal's plan and may simply not
+ * be available, which is a legitimate reason to skip rather than to fail.
+ *
+ * On failure the assertion message carries the portal's own error text, because
+ * the three causes need different actions and are otherwise indistinguishable:
+ * a missing scope (`insufficient_scope`) is a webhook fix, `METHODNOTFOUND` means
+ * the module is absent or the method is not on v3 after all, and anything else is
+ * a real shape problem worth reporting.
+ */
+
+/** Field shape the limiter reads off every v3 response. */
+type V3Time = {
+  operating: number
+  operating_reset_at: number
+}
+
+async function smokeList(
+  b24: ReturnType<ReturnType<typeof setupB24Tests>['getB24Client']>,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<void> {
+  const requestId = `test@apiV3/${method}`
+  const response = await b24.actions.v3.call.make<Record<string, unknown>>({ method, params, requestId })
+
+  // The portal's own words, so a red test says which of the three causes it is.
+  expect(
+    response.isSuccess,
+    `${method} failed: ${response.getErrorMessages().join('; ')}`
+  ).toBe(true)
+
+  const data = response.getData()!
+  expect(data.result, `${method} returned no result envelope`).toBeDefined()
+
+  const time = data.time as unknown as V3Time
+  expect(time).toHaveProperty('operating')
+  expect(time.operating).toBeGreaterThanOrEqual(0)
+  expect(time.operating_reset_at).toBeGreaterThan(0)
+}
+
+describe('core.actions.call @apiV3 — modules from #203', () => {
+  const { getB24Client } = setupB24Tests()
+
+  describe('mail', () => {
+    it('mail.mailbox.list @apiV3 isSuccess', async () => {
+      await smokeList(getB24Client(), 'mail.mailbox.list')
+    })
+  })
+
+  describe('humanresources', () => {
+    it('humanresources.node.list @apiV3 isSuccess', async () => {
+      await smokeList(getB24Client(), 'humanresources.node.list')
+    })
+  })
+
+  describe('timeman', () => {
+    it('timeman.record.list @apiV3 isSuccess', async () => {
+      await smokeList(getB24Client(), 'timeman.record.list')
+    })
+  })
+})


### PR DESCRIPTION
Closes #205.

### What this does

Adds read-path smoke tests for the rest-v3 modules wired in #203 — one `.list` method per module (`mail.mailbox.list`, `humanresources.node.list`, `timeman.record.list`) — plus the webhook scopes they need in `.github/contributing/testing.md`.

### On the two halves of #205

The issue asked for two things, and only one of them still exists.

**The `// done` marking is obsolete.** It referred to `versionManager.#supportMethods`, the client-side allowlist of v3-capable methods. That allowlist was removed in 2.0.0 — `isSupport()` now returns `true` unconditionally and the SDK sends any method to the v3 endpoint, letting the server decide. There is no list left to annotate, so nothing here marks anything.

**The verification half matters more than before,** for the same reason: with the allowlist gone there is no client-side signal at all that a method routes correctly. A live call is the only remaining check, which is what this adds.

### Deviations worth naming

- **One file, not three.** The issue proposed `actions-v3-mail.spec.ts` / `-humanresources` / `-timeman`; the directory convention (`actions-v3-batch.spec.ts`, `actions-v3-call.spec.ts`) would also suggest per-area files. Three files would have been three copies of the same 15-line helper for one test each, so they share `smokeList` in one file instead.
- **No negative-path cases per module.** `actions-v3-call.spec.ts` already covers v3's error routing (`@notSupported`, bad id, wrong id) at the transport level; repeating it per module would test the same code path three more times.

### Verification

Local: eslint, full `typecheck` (all eight passes), `docs-lint --strict`, `lint:md`, `check-v3-method-refs`, and the 428 unit tests — all clean.

**The integration specs themselves have not been run** — there is no portal reachable from here. They need `B24_HOOK` plus the three extra scopes, and `mail` / `humanresources` depend on the portal's plan. The spec deliberately does not skip itself when a module is absent: the SDK cannot tell "no mail module on this portal" from "v3 routing for mail is broken" without making the call, so it reports red and the assertion message carries the portal's own error text (`insufficient_scope` → webhook fix, `METHODNOTFOUND` → module absent, anything else → a real shape problem).
