### PR TITLE
chore(release): hide runner-level types and restore the Features/Bug Fixes headings

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing `@bitrix24/b24jssdk`
 
-<sub>Last reviewed: 2026-08-18.</sub>
+<sub>Last reviewed: 2026-08-21.</sub>
 
 > **Releases are moving to release-please (#347).** Once the handover below is
 > done, the routine release is: review the standing release PR, approve its held
@@ -34,8 +34,27 @@ What this changes for everyday work:
   invisible in the changelog. `deps` and `security` are mapped there because
   this repo uses them; the one-off types this repo has also used (`platform`,
   `dx`, `http`) are not — pick from the mapped list instead.
+- **Never start a line of the commit body with `word:`.** release-please parses
+  the body line by line, and any line shaped like a conventional commit becomes
+  its **own changelog entry**. This is not hypothetical — 2.1.0 shipped with two
+  of them. A body line reading `docs: @comark/vue ^0.3.1 -> ^0.5.1` turned into a
+  changelog bullet, and so did a line opening with `docs:lint`, where that was
+  meant as the name of the pnpm script and got read as type `docs` plus a
+  description. Put a script name mid-sentence — `run docs:lint` — or reword the
+  line so it does not begin with a bare word and a colon.
+- **`ci`, `chore`, `test` and `style` are mapped but hidden.** They keep the
+  commit history honest without filling a consumer-facing changelog with runner
+  bumps and lockfile churn. They still count toward the release (a patch), they
+  just do not print. Anything a consumer of the SDK should read about belongs
+  under a visible type.
 - **`[Unreleased]` is no longer hand-maintained.** Write the explanation in the
   commit subject and body of the PR that makes the change.
+
+  The subject is now the whole entry: the body does not reach the changelog at
+  all. Where a change genuinely needs a paragraph — a migration, a behaviour
+  change, a "verified live against a portal" note — add that paragraph to the
+  release PR's `CHANGELOG.md` by hand before merging it. That is a deliberate
+  edit on the release branch, not a return to maintaining `[Unreleased]`.
 
 ### Handover — one-time, on the first release PR
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,9 +10,9 @@
         { "type": "json", "path": "packages/jssdk-nuxt/package.json", "jsonpath": "$.version" }
       ],
       "changelog-sections": [
-        { "type": "feat", "section": "Added" },
-        { "type": "feature", "section": "Added" },
-        { "type": "fix", "section": "Fixed" },
+        { "type": "feat", "section": "Features" },
+        { "type": "feature", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
         { "type": "perf", "section": "Performance" },
         { "type": "revert", "section": "Reverts" },
         { "type": "security", "section": "Security" },
@@ -20,10 +20,10 @@
         { "type": "refactor", "section": "Changed" },
         { "type": "build", "section": "Changed" },
         { "type": "docs", "section": "Docs" },
-        { "type": "test", "section": "Tests" },
-        { "type": "ci", "section": "CI" },
-        { "type": "chore", "section": "Chore" },
-        { "type": "style", "section": "Chore" }
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "ci", "section": "CI", "hidden": true },
+        { "type": "chore", "section": "Chore", "hidden": true },
+        { "type": "style", "section": "Chore", "hidden": true }
       ]
     }
   }


### PR DESCRIPTION
Three things the generated 2.1.0 changelog surfaced, all found by reading it against the hand-written entries above it.

### The headings had drifted

Everything up to and including 2.0.0 uses `### Features` / `### Bug Fixes`. The generated 2.1.0 section said `### Added` / `### Fixed`, so the file spoke two vocabularies depending on how far down you read. Renamed back to what the file already used.

### `ci` / `chore` / `test` / `style` are now hidden

Nine of the forty generated 2.1.0 entries were runner bumps and lockfile churn. `bump pnpm/action-setup from 6.0.9 to 6.0.10` tells someone consuming the SDK nothing, and previous hand-written releases never carried that class of entry.

They stay **mapped**, not removed — so they still count toward the release as a patch and stay visible in the commit history. They simply do not print.

### The body-line rule, in RELEASING.md

This one is a real trap rather than a matter of taste. release-please parses the commit body **line by line**, and any line shaped like a conventional commit becomes its own changelog entry. 2.1.0 shipped two of them:

| Body line | What it became |
| --- | --- |
| `docs: @comark/vue ^0.3.1 -> ^0.5.1 and @nuxtjs/mcp-toolkit …` | a `Docs` bullet |
| `docs:lint and \`pnpm audit --audit-level=moderate\` all pass.` | a `Docs` bullet reading "lint and `pnpm audit…` all pass" |

The second is the instructive one: `docs:lint` was the name of a pnpm script, and got read as type `docs` plus a description. The guide now says not to open a body line with a bare word and a colon, and to put script names mid-sentence.

While there, spelled out something the guide implied but never stated: the commit **body does not reach the changelog at all**, only the subject. So a change that genuinely needs a paragraph — a migration, a behaviour change, a "verified live against a portal" note — gets that paragraph added to the release PR's `CHANGELOG.md` by hand before merging. That is a deliberate edit on the release branch, not a return to maintaining `[Unreleased]`.

### Effect on the standing release PR

#353 regenerates on merge, so the renamed headings and the hidden sections apply to 2.1.0 itself. The two junk `Docs` entries come from already-merged commit bodies and will regenerate too — those get removed by hand on the release branch, together with folding the hand-written `[Unreleased]` prose into the 2.1.0 section.

### Verification

`lint:md`, `md-internal-links`, and a JSON parse of the config. `Last reviewed` stamp on `RELEASING.md` refreshed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_