### PR TITLE
docs(releasing): merging the release PR does not publish to npm

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,12 +1,20 @@
 # Keeps a single open release PR up to date with the next version bump and the
-# changelog assembled from conventional-commit subjects. Merging that PR is the
-# release: it tags, publishes a GitHub Release, and the two npm-publish
-# workflows fire on that `release: published` event exactly as they do today.
+# changelog assembled from conventional-commit subjects. Merging that PR tags the
+# version and publishes a GitHub Release.
+#
+# It does NOT reach npm. GitHub does not start workflows from events raised with
+# the built-in GITHUB_TOKEN, which is what this job runs as, so the
+# `release: published` event the two npm-publish workflows listen for never
+# reaches them. Observed on the 2.1.0 release: tag and Release created, neither
+# publish workflow started. The two are dispatched by hand from `main` as the
+# last step of a release — see "The last step is manual" in RELEASING.md.
+# Automating it would mean giving this job a GitHub App token or a PAT, so the
+# release is raised by an identity that is not GITHUB_TOKEN.
 #
 # Deliberately NOT wired to publish directly. npm's Trusted Publisher entries
 # are keyed to the two exact filenames `npm-publish-js-sdk.yml` and
 # `npm-publish-js-sdk-nuxt.yml`; a publish reached from any other workflow file
-# fails the OIDC token exchange. Leaving the release event as the trigger keeps
+# fails the OIDC token exchange. Keeping the publish in those two files keeps
 # that contract untouched — no npm-side change is needed to adopt this. (#347)
 name: Release Please
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,10 +2,12 @@
 
 <sub>Last reviewed: 2026-08-21.</sub>
 
-> **Releases are moving to release-please (#347).** Once the handover below is
-> done, the routine release is: review the standing release PR, approve its held
-> CI run, merge. Everything in *Step by step* stays valid as the fallback path
-> and as the description of what the automation does on your behalf.
+> **Releases are moving to release-please (#347).** The routine release is:
+> review the standing release PR, merge it, then **start the two publish
+> workflows by hand** — merging does not start them (see
+> [The last step is manual](#the-last-step-is-manual)). Everything in *Step by
+> step* stays valid as the fallback path and as the description of what the
+> automation does on your behalf.
 
 ## The release PR flow
 
@@ -16,10 +18,45 @@ carries the version bump across all three `package.json` files plus
 the conventional-commit subjects merged since the last tag. Fifteen merged fixes
 update that one PR fifteen times; they do not cut fifteen releases.
 
-Merging it tags `vX.Y.Z` and publishes a GitHub Release — which is the same
-`release: published` event the two `npm-publish-*.yml` workflows already listen
-for. **No npm-side change is needed**: their Trusted Publisher entries stay
-keyed to their own filenames, untouched.
+Merging it tags `vX.Y.Z` and publishes a GitHub Release. **No npm-side change is
+needed**: the Trusted Publisher entries stay keyed to their own filenames,
+untouched. What merging does *not* do is publish to npm — see below.
+
+### The last step is manual
+
+The two `npm-publish-*.yml` workflows listen for `release: published`, and
+release-please does publish a release. They still do not start, and this is not a
+misconfiguration that can be tuned away: **GitHub does not start workflows from
+events raised with the built-in `GITHUB_TOKEN`.** release-please runs with that
+token, so the release it publishes reaches no workflow. Observed on the 2.1.0
+release: the tag and the GitHub Release appeared, and neither publish workflow
+ran until dispatched by hand.
+
+So after merging the release PR, start both, in this order:
+
+1. Actions → **NPM publish JS SDK 🚀** → *Run workflow* on `main`
+2. wait for it to finish, then Actions → **NPM publish JS SDK Nuxt 🚀** → *Run
+   workflow* on `main`
+
+Both accept `workflow_dispatch` from `main` by design, `main` already carries the
+released version, and every guard still applies — version lockstep, the
+already-published check, and a full CI run before the publish step. Only the
+`Verify package version matches release tag` step is skipped, since a dispatch
+has no release tag to compare against; the lockstep check covers the same ground.
+
+Switching a tag push in for the release event does **not** help — the tag is
+created by the same token, so it is suppressed for the same reason. The only way
+to automate this step is to give release-please a GitHub App token or a PAT, so
+the release is raised by an identity that is not `GITHUB_TOKEN`. That is a
+deliberate trade: a stored credential in exchange for two clicks per release.
+
+### The release notes are not the changelog
+
+The GitHub Release body is rendered by release-please from its own changeset, not
+read from `CHANGELOG.md`. An edit made to `CHANGELOG.md` on the release branch
+therefore lands in the repository but **not** in the release notes — the two
+diverge silently. If the release page should match the file, paste the section in
+by hand after publishing.
 
 What this changes for everyday work:
 
@@ -112,12 +149,14 @@ How to cut a release of the two published packages — `@bitrix24/b24jssdk` (cor
 SDK) and `@bitrix24/b24jssdk-nuxt` (Nuxt module). They ship **in lockstep at one
 shared version**; there is no independent release of either package.
 
-Publishing is automated by two sibling workflows —
+Publishing is done by two sibling workflows —
 [`npm-publish-js-sdk.yml`](.github/workflows/npm-publish-js-sdk.yml) (core) and
 [`npm-publish-js-sdk-nuxt.yml`](.github/workflows/npm-publish-js-sdk-nuxt.yml)
-(Nuxt) — both triggered by a published GitHub Release. The human steps are: bump
-the version, finalise the changelog, tag, and publish a GitHub Release. The
-workflows do the rest.
+(Nuxt). Both start on a published GitHub Release **when a person publishes it**,
+and both also accept a manual `workflow_dispatch` from `main`. The human steps
+are: bump the version, finalise the changelog, tag, and publish a GitHub Release.
+A release published by automation reaches neither workflow — see
+[The last step is manual](#the-last-step-is-manual).
 
 > **Why two workflows, not one `release.yml`?** npm OIDC trusted publishing keys
 > each package's Trusted Publisher entry to **one exact workflow filename**. The two


### PR DESCRIPTION
Documentation only — no workflow logic, no config, no secrets.

### What the 2.1.0 release showed

`RELEASING.md` and the comment atop `release-please.yml` both promised that merging the release PR finishes the release: it tags, publishes a GitHub Release, and "the two npm-publish workflows fire on that `release: published` event exactly as they do today."

They do not. **GitHub does not start workflows from events raised with the built-in `GITHUB_TOKEN`**, and release-please runs as that token — so the release it publishes reaches nothing. Observed on 2.1.0: tag `v2.1.0` and the GitHub Release were created, and neither publish workflow started until dispatched by hand. Both packages reached npm only after that.

This is the second claim from #352 that the first real run disproved, after `bootstrap-sha` in #354.

### What changes

`RELEASING.md` gains **The last step is manual** — the two dispatches as a numbered step, in order (core first, then Nuxt), and why every guard still holds under `workflow_dispatch`: version lockstep, the already-published check, and a full CI run all still gate it. Only `Verify package version matches release tag` is skipped, since a dispatch has no tag to compare against, and the lockstep check covers the same ground.

It also records the two dead ends so neither gets re-proposed:

- **A tag-push trigger does not help** — the tag is created by the same token, so it is suppressed for the same reason.
- **The only real automation is a GitHub App token or a PAT** for release-please, so the release is raised by an identity that is not `GITHUB_TOKEN`. That is a stored credential in exchange for two clicks per release; naming the trade is more useful than leaving it as an open question.

`RELEASING.md` also gains **The release notes are not the changelog**: the GitHub Release body is rendered by release-please from its own changeset, not read from `CHANGELOG.md`. Editing the changelog on the release branch leaves the file and the release page silently different — which is what happened to 2.1.0, and had to be pasted in by hand.

The banner at the top of the file and the "Publishing is automated by…" paragraph are corrected to match, and the `release-please.yml` comment block is fixed in place.

### Verification

`lint:md`, `md-internal-links` (97 links), and a YAML parse of the edited workflow. `actionlint` is not installed locally — CI runs it in `docs-lint`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_