### PR TITLE
docs(logger): record what #346 deliberately left outside the isolation

### DIFF
--- a/packages/jssdk/src/logger/assert-logger-shape.ts
+++ b/packages/jssdk/src/logger/assert-logger-shape.ts
@@ -39,6 +39,15 @@ const LOG_METHODS = [
  * callable, and does not invoke anything. Calling the methods to inspect their
  * return value would emit spurious log records as a side effect of installation.
  *
+ * A warning is as far as the SDK goes here, by decision rather than by omission
+ * (#346). It does **not** wrap the installed logger to isolate it the way
+ * `Logger.log()` isolates its handlers, so an implementation that throws
+ * synchronously — before the promise the callsite's `.catch(() => {})` expects —
+ * still reaches the caller. Wrapping would put the SDK in charge of code it
+ * does not own, at all ~94 callsites, to guard a case the compiler already
+ * rejects; the contract is that your methods return promises, and this check is
+ * the reminder, not the enforcement.
+ *
  * @param logger The logger about to be installed.
  * @param source Where it is being installed, used in the warning text.
  */

--- a/packages/jssdk/src/logger/logger.ts
+++ b/packages/jssdk/src/logger/logger.ts
@@ -62,6 +62,35 @@ export class Logger extends AbstractLogger implements LoggerInterface {
    * raised while a caller builds its log arguments — those are evaluated eagerly
    * at the callsite, before `log()` is reached (see `truncateForLog`, #338).
    *
+   * ### Deliberately outside this guarantee
+   *
+   * Three gaps sit outside `log()` and were each weighed and left open on
+   * purpose (#346). They are recorded here so they are not re-opened as
+   * oversights:
+   *
+   * 1. **A third-party `LoggerInterface` is not isolated.** This guarantee
+   *    belongs to this class, not to the interface. Every SDK callsite is
+   *    written `…info(…).catch(() => {})`, which absorbs a *rejected promise*;
+   *    an implementation that throws *synchronously*, before returning one,
+   *    escapes into the caller. `setLogger(...)` warns about the shape it can
+   *    check without calling anything (see `warnOnNonPromiseLogger`); returning
+   *    promises is the implementor's side of the contract. Wrapping every
+   *    installed logger defensively was considered and rejected: it would make
+   *    the SDK responsible for code it does not own, on every one of ~94
+   *    callsites, to cover a case TypeScript already rejects at compile time.
+   *
+   * 2. **A handler that fails forever is never detached.** Each failure is
+   *    reported, every time — see {@link reportLoggingFailure}. Auto-detaching
+   *    after N failures was considered and rejected: it silently changes a
+   *    configuration the application made, and "N failures" is a policy the SDK
+   *    has no basis to pick on the application's behalf.
+   *
+   * 3. **The synchronous half — argument construction — stays the caller's.**
+   *    Making it total would mean wrapping the argument list at every callsite,
+   *    which trades a narrow, findable failure (#338 was one expression in one
+   *    helper) for noise at every call. Individual helpers on the hot path are
+   *    made total instead, as `truncateForLog` was.
+   *
    * @inheritDoc
    */
   public async log(level: LogLevel, message: string, context?: Record<string, any>): Promise<void> {
@@ -132,6 +161,12 @@ export class Logger extends AbstractLogger implements LoggerInterface {
    *
    * `console` is used rather than the logger — routing a logging failure back
    * through the logger that just failed is how this turns into recursion.
+   *
+   * The handler is **not** detached, however many times it fails. Doing so would
+   * silently discard part of a configuration the application built, and the
+   * threshold that would trigger it is a policy call the SDK cannot make for the
+   * application. A sink that is broken stays wired and stays loud; whoever reads
+   * the output decides what to do about it (#346).
    */
   private reportLoggingFailure(source: Processor | Handler, error: unknown): void {
     const name = (source as { constructor?: { name?: string } })?.constructor?.name ?? 'processor'


### PR DESCRIPTION
Comments only — no behaviour change, no API change. 428 unit tests unchanged.

### Why

The isolation added in #346 lives inside `Logger.log()`. Three gaps sit *outside* it. Each was raised during that work, weighed, and left open on purpose — but the reasoning stayed in the review thread, so the code reads as if they were simply missed. The next person to look will re-open all three as oversights.

This writes the decisions down where a reader meets the guarantee, not in a changelog entry they will never scroll back to.

### The three, and why each stays open

**A third-party `LoggerInterface` is not isolated.** Every SDK callsite is written `…info(…).catch(() => {})`, which absorbs a *rejected promise*. An implementation that throws *synchronously*, before returning one, escapes into the caller — and `setLogger()` accepts any implementation. Wrapping every installed logger defensively would make the SDK responsible for code it does not own, at all ~94 callsites, to guard a case TypeScript already rejects at compile time. So `setLogger()` warns about the shape it can check without calling anything, and returning promises stays the implementor's side of the contract.

**A handler that fails forever is never detached.** Auto-detaching after N failures silently discards part of a configuration the application built, and "N failures" is a policy the SDK has no basis to pick on the application's behalf. A broken sink stays wired and stays loud; whoever reads the output decides what to do. This also completes the note on `reportLoggingFailure`, which already explained why failures are not deduplicated but not why the handler survives.

**Argument construction stays the caller's.** Log arguments are evaluated at the callsite, before `log()` is reached, so the isolation cannot reach them — this is exactly the #338 class. Making it total would mean wrapping the argument list at every callsite, trading a narrow, findable failure (#338 was one expression in one helper) for noise at every call. Individual helpers on the hot path are made total instead, as `truncateForLog` was.

### Where

- `packages/jssdk/src/logger/logger.ts` — a *Deliberately outside this guarantee* block on `log()`, plus the detach decision on `reportLoggingFailure`.
- `packages/jssdk/src/logger/assert-logger-shape.ts` — why a warning is as far as the check goes.

### Verification

`eslint` (the one remaining warning is pre-existing, in `docs/server/api/ai.post.ts`), full `typecheck` (all eight passes), and the 428 unit tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_