### PR TITLE
fix(frame): MessageManager no longer throws on foreign traffic or strands sends

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/30.frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame.md
@@ -128,7 +128,11 @@ Performs the parent-window handshake (`getInitData`), wires the manager state, a
 destroy(): void
 ```
 
-Unsubscribes from `postMessage` events. Always call before unmounting the host component to avoid leaks.
+Tears the frame down: unsubscribes from `postMessage` events, clears the pending-command timers, and drops the placement callbacks. Always call before unmounting the host component to avoid leaks.
+
+Any command still waiting on the parent window is **rejected** with `JSSDK_FRAME_DISPOSED` rather than left pending — nothing can answer it once the listener is gone, and silence is the one outcome a caller cannot act on. Mirrors how a disposed `PullClient` rejects `start()` with `PULL_DISPOSED`.
+
+This matters for a command whose promise you discarded. `parent.closeApplication()` and `slider.closeSliderAppPage()` are the usual pair, since they run precisely while the app is closing: if you call one without awaiting it and destroy the frame in the same breath, attach `.catch(() => {})` so the rejection does not surface as an unhandled one.
 
 ### `installFinish`
 

--- a/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
+++ b/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
@@ -47,6 +47,8 @@ These codes propagate through the promise rejection path. Wrap your calls in `tr
 | `INVALID_ARG_VALUE` | One of the arguments has a value Bitrix24 rejected. |
 | `PULL_DISABLED` | `PullClient.start()` — Push & Pull server is disabled on the portal. |
 | `PULL_DISPOSED` | `PullClient.start()` called after `destroy()` — create a new instance. |
+| `JSSDK_FRAME_DISPOSED` | A frame command was still waiting on the parent window when `B24Frame.destroy()` ran — nothing can answer it now. |
+| `JSSDK_FRAME_BAD_PAYLOAD` | The parent window answered a frame command with a payload that is not valid JSON. |
 
 ## Soft Errors (returned in `AjaxResult`)
 

--- a/packages/jssdk/src/frame/message/controller.ts
+++ b/packages/jssdk/src/frame/message/controller.ts
@@ -13,6 +13,12 @@ import { SdkError } from '../../core/sdk-error'
  */
 const MAX_REJECTED_ORIGINS = 50
 
+/**
+ * How much of an inbound callback id may appear in an error message. The id is
+ * sender-chosen, and error messages reach logs (#146).
+ */
+const MAX_CALLBACK_ID_IN_ERROR = 64
+
 interface PromiseHandlers {
   resolve: (value: any) => void
   reject: (reason?: any) => void
@@ -102,9 +108,19 @@ export class MessageManager {
    * act on.
    *
    * Note the consequence: a `send()` whose result was discarded without a
-   * `.catch()` turns into an unhandled rejection at teardown. Every such
-   * fire-and-forget path in the SDK passes `isSafely`, which settles on its own
-   * timer and so is normally already gone by the time this runs.
+   * `.catch()` turns into an unhandled rejection at teardown. Most SDK commands
+   * pass `isSafely`, which settles them on their own timer, so they are normally
+   * already gone by the time this runs — but **not all of them do**.
+   * `ParentManager.closeApplication()` and `SliderManager.closeSliderAppPage()`
+   * deliberately pass `isSafely: false` ("everything will be closed, and timeout
+   * will not be able to do anything"), and those are exactly the calls made as
+   * an app tears itself down — the likeliest race with this method. The awaited
+   * commands (`getInitData`, `refreshAuth`, the dialog selectors) send without
+   * `isSafely` too, but their callers await them, so the rejection surfaces
+   * where it can be handled.
+   *
+   * A caller that fires `closeApplication()` without awaiting it should attach
+   * `.catch(() => {})` if it also tears the frame down in the same breath.
    */
   unsubscribe(): void {
     window.removeEventListener('message', this.runCallbackHandler)
@@ -298,9 +314,14 @@ export class MessageManager {
             origin: event.origin
           }).catch(() => {})
 
+          // `cmd.id` is the first colon-segment of an inbound message, so its
+          // content and length are chosen by the sender. It is a callback key,
+          // not a credential — but unlike the payload it DOES reach logs, via
+          // SdkError's enumerable `message`. Truncated so a sender cannot use
+          // this description as an amplifier.
           this.#rejectPromise(cmd.id, new SdkError({
             code: 'JSSDK_FRAME_BAD_PAYLOAD',
-            description: `The parent window answered command "${cmd.id}" with a payload that is not valid JSON.`,
+            description: `The parent window answered command "${cmd.id.slice(0, MAX_CALLBACK_ID_IN_ERROR)}" with a payload that is not valid JSON.`,
             status: 0
           }))
 

--- a/packages/jssdk/src/frame/message/controller.ts
+++ b/packages/jssdk/src/frame/message/controller.ts
@@ -5,6 +5,13 @@ import { LoggerFactory } from '../../logger'
 import { Type } from '../../tools/type'
 import { Text } from '../../tools/text'
 import { omit } from '../../tools'
+import { SdkError } from '../../core/sdk-error'
+
+/**
+ * Ceiling on {@link MessageManager.#rejectedOrigins}. The key is chosen by the
+ * sender, so the set is only bounded if we bound it (#146).
+ */
+const MAX_REJECTED_ORIGINS = 50
 
 interface PromiseHandlers {
   resolve: (value: any) => void
@@ -39,7 +46,12 @@ export class MessageManager {
   #callbackPromises: Map<string, PromiseHandlers>
   #callbackSingletone: Map<string, (...args: any[]) => void>
   // origins already warned about (#244) — dedup so a peer spamming postMessage
-  // from a foreign origin can't flood a wired logger sink
+  // from a foreign origin can't flood a wired logger sink. Capped, because the
+  // dedup key is attacker-chosen: a peer can post from an unbounded supply of
+  // distinct origins (`a.evil.test`, `b.evil.test`, …) and every unseen one adds
+  // an entry. Past the cap the set stops growing and later origins are simply
+  // not warned about — losing a log line is the right trade against unbounded
+  // memory in a long-lived frame (#146).
   #rejectedOrigins: Set<string> = new Set()
 
   protected _logger: LoggerInterface
@@ -73,10 +85,47 @@ export class MessageManager {
   }
 
   /**
-   * Unsubscribe from the onMessage event of the parent window
+   * Unsubscribe from the onMessage event of the parent window, and tear the
+   * manager down.
+   *
+   * Removing the listener is not enough. Every in-flight `send()` is waiting on
+   * a promise that only the listener could settle, so dropping the listener
+   * alone strands each of them **forever** — with its `isSafely` timer still
+   * armed and its entry still in the callback map. `B24Frame.destroy()` calls
+   * this, so an SPA that mounts and unmounts the frame accumulated one such set
+   * per cycle (#146; the same class of leak as #222 in `PullClient`).
+   *
+   * Pending sends are therefore **rejected**, not left hanging, with
+   * `JSSDK_FRAME_DISPOSED` — mirroring how a disposed `PullClient` rejects
+   * `start()` with `PULL_DISPOSED`. A caller awaiting a command that can no
+   * longer be answered should learn that; silence is the one outcome it cannot
+   * act on.
+   *
+   * Note the consequence: a `send()` whose result was discarded without a
+   * `.catch()` turns into an unhandled rejection at teardown. Every such
+   * fire-and-forget path in the SDK passes `isSafely`, which settles on its own
+   * timer and so is normally already gone by the time this runs.
    */
   unsubscribe(): void {
     window.removeEventListener('message', this.runCallbackHandler)
+
+    for (const [key, promise] of this.#callbackPromises) {
+      if (promise.timeoutId) {
+        clearTimeout(promise.timeoutId)
+      }
+
+      this.#callbackPromises.delete(key)
+      promise.reject(new SdkError({
+        code: 'JSSDK_FRAME_DISPOSED',
+        description: 'The B24Frame was destroyed before the parent window answered this command.',
+        status: 0
+      }))
+    }
+
+    // Placement event handlers are registered for the lifetime of the frame and
+    // are never fired again once the listener is gone.
+    this.#callbackSingletone.clear()
+    this.#rejectedOrigins.clear()
   }
 
   // endregion ////
@@ -192,7 +241,7 @@ export class MessageManager {
       // parent) — log the origins only, never event.data, which may carry the
       // AUTH_ID / REFRESH_ID a foreign sender must not have echoed back (#244).
       // Log once per distinct origin so a spamming peer can't flood the sink.
-      if (!this.#rejectedOrigins.has(event.origin)) {
+      if (!this.#rejectedOrigins.has(event.origin) && this.#rejectedOrigins.size < MAX_REJECTED_ORIGINS) {
         this.#rejectedOrigins.add(event.origin)
         this.getLogger().warning('message rejected: unexpected origin', {
           origin: event.origin,
@@ -203,12 +252,22 @@ export class MessageManager {
       return
     }
 
-    if (event.data) {
-      const tmp = event.data.split(':')
+    // The wire format is a colon-joined string. Anything else on this origin is
+    // not ours: `postMessage` is a shared channel, and a page hosting the frame
+    // may carry other libraries (or a browser extension) posting objects on it.
+    // `event.data.split` on such a message threw a TypeError out of a window
+    // event listener — an uncaught error, on traffic the SDK simply should have
+    // ignored (#146).
+    if (typeof event.data === 'string' && event.data.length > 0) {
+      // Narrowing `event.data` to `string` above also made this indexing
+      // checked — it used to sit behind `any`. `split` on a non-empty string
+      // always yields at least one element, so the fallback is unreachable, but
+      // it keeps the type honest rather than asserting it away.
+      const [id = '', ...rest] = event.data.split(':')
 
       const cmd: { id: string, args: any } = {
-        id: tmp[0],
-        args: tmp.slice(1).join(':')
+        id,
+        args: rest.join(':')
       }
 
       // Log only the callback id and origin — never `event.data` / `cmd.args`.
@@ -221,7 +280,32 @@ export class MessageManager {
       }).catch(() => {})
 
       if (cmd.args) {
-        cmd.args = JSON.parse(cmd.args)
+        try {
+          cmd.args = JSON.parse(cmd.args)
+        } catch {
+          // A payload we cannot read is not a payload we may guess at. Before
+          // this, the throw escaped the listener and left the waiting promise
+          // pending forever — the caller was told nothing, and waited for an
+          // answer that had in fact already arrived, broken (#146).
+          //
+          // The caught error is deliberately not logged and not attached as
+          // `cause`. V8 quotes the offending input in its message — `Unexpected
+          // token 'a', "auth=..." is not valid JSON` — and this payload is the
+          // one that carries AUTH_ID / REFRESH_ID (#43). The id and origin below
+          // say which command failed, which is what a reader needs.
+          this.getLogger().warning('message dropped: payload is not valid JSON', {
+            id: cmd.id,
+            origin: event.origin
+          }).catch(() => {})
+
+          this.#rejectPromise(cmd.id, new SdkError({
+            code: 'JSSDK_FRAME_BAD_PAYLOAD',
+            description: `The parent window answered command "${cmd.id}" with a payload that is not valid JSON.`,
+            status: 0
+          }))
+
+          return
+        }
       }
 
       if (this.#callbackPromises.has(cmd.id)) {
@@ -241,6 +325,26 @@ export class MessageManager {
         }
       }
     }
+  }
+
+  /**
+   * Settle a waiting promise with a rejection, if one is still waiting.
+   *
+   * Silent when the key is unknown: a payload can arrive for a command that
+   * already timed out under `isSafely`, and there is nothing left to reject.
+   */
+  #rejectPromise(key: string, error: SdkError): void {
+    const promise = this.#callbackPromises.get(key)
+    if (!promise) {
+      return
+    }
+
+    if (promise.timeoutId) {
+      clearTimeout(promise.timeoutId)
+    }
+
+    this.#callbackPromises.delete(key)
+    promise.reject(error)
   }
 
   /**

--- a/skills/b24jssdk-frame-ui/SKILL.md
+++ b/skills/b24jssdk-frame-ui/SKILL.md
@@ -266,6 +266,7 @@ onBeforeUnmount(() => {
 - ❌ `$b24.placement.call('setValue', { value: { id: 1 } })` — throws because `value` is not a string. Use `$b24.placement.setValue({ id: 1 })` or stringify yourself.
 - ❌ Storing secrets in `options.appSet` — placement options are visible to everyone with access to the placement.
 - ❌ Treating a resolved `parent.im*` promise as proof the call started or the chat opened — nothing answers those commands; the promise only means the message was posted.
+- ❌ Firing `parent.closeApplication()` without `.catch(() => {})` and calling `$b24.destroy()` in the same breath — `destroy()` rejects every in-flight command with `JSSDK_FRAME_DISPOSED`, and a discarded promise becomes an unhandled rejection. Either `await` the close or attach a `.catch`.
 - ❌ Treating an absent `selectCRM` bucket as an empty array — they are `undefined`. Use `picked.deal ?? []`.
 - ❌ `return navigateTo(target)` from Nuxt route middleware to route an opened slider — discarded without error on a prerendered entry route. Navigate from `onNuxtReady` while hydrating.
 - ❌ Reading `$b24.placement.options?.place` without allowing for a JSON string — `PLACEMENT_OPTIONS` is not always an object, and key case is not guaranteed across entry points. On a string this yields `undefined` silently.

--- a/test/integration/frame/message-manager-hardening.unit.spec.ts
+++ b/test/integration/frame/message-manager-hardening.unit.spec.ts
@@ -18,7 +18,7 @@
  * `parent` are stubbed here — `send()` uses `window.setTimeout` and posts to
  * `parent`, and `unsubscribe()` touches `window.removeEventListener`.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { MessageManager } from '../../../packages/jssdk/src/frame/message/controller'
 import { SdkError } from '../../../packages/jssdk/src/core/sdk-error'
 import type { LoggerInterface } from '../../../packages/jssdk/src/types/logger'
@@ -159,19 +159,60 @@ describe('#146 unsubscribe() tears the manager down instead of stranding it', ()
     await expect(pending).rejects.toMatchObject({ code: 'JSSDK_FRAME_DISPOSED' })
   })
 
-  it('clears the isSafely timer, so nothing fires after teardown', async () => {
+  it('clears the isSafely timer rather than leaving it to no-op', async () => {
+    vi.useFakeTimers()
+    try {
+      const mgr = manager()
+
+      const pending = mgr.send('someCommand', { isSafely: true, safelyTime: 10 })
+      pending.catch(() => {})
+
+      expect(vi.getTimerCount()).toBe(1)
+      mgr.unsubscribe()
+
+      // Asserting on the timer itself, not on the outcome. The send() timeout
+      // callback re-checks the callback map before resolving, so a timer left
+      // armed would fire, find nothing, and do nothing — the promise would still
+      // be rejected and an outcome-based assertion would pass with the
+      // clearTimeout deleted. What must hold is that no timer survives teardown:
+      // a destroyed frame should leave nothing on the event loop.
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects a send that deliberately opted out of isSafely', async () => {
     const mgr = manager()
 
-    const pending = mgr.send('someCommand', { isSafely: true, safelyTime: 10 })
-    const settled = pending.then(() => 'resolved', () => 'rejected')
-
+    // closeApplication() / closeSliderAppPage() pass isSafely: false on purpose
+    // — "everything will be closed, and timeout will not be able to do
+    // anything". They are also the calls an app makes while tearing itself
+    // down, so racing them against destroy() is the realistic case, and the one
+    // that surfaces as an unhandled rejection if the caller discarded the
+    // promise.
+    const pending = mgr.send('closeApplication', { isSafely: false })
     mgr.unsubscribe()
 
-    // The isSafely timer would have resolved this at +10ms. Teardown got there
-    // first, and the timer must not fire afterwards.
-    await expect(settled).resolves.toBe('rejected')
-    await new Promise(resolve => setTimeout(resolve, 40))
-    await expect(settled).resolves.toBe('rejected')
+    await expect(pending).rejects.toMatchObject({ code: 'JSSDK_FRAME_DISPOSED' })
+  })
+
+  it('resets the foreign-origin dedup set, so a reused origin warns again', () => {
+    const captured: string[] = []
+    const mgr = new MessageManager({ getTargetOrigin: () => ORIGIN } as never)
+    mgr.setLogger({
+      ...silentLogger(),
+      warning: async (message: string) => { captured.push(message) }
+    } as unknown as LoggerInterface)
+
+    const foreign = { origin: 'https://peer.example', data: 'x:{}' } as MessageEvent
+    mgr._runCallback(foreign)
+    mgr._runCallback(foreign)
+    expect(captured).toHaveLength(1) // deduped
+
+    mgr.unsubscribe()
+    mgr._runCallback(foreign)
+    expect(captured).toHaveLength(2) // set was cleared at teardown
   })
 
   it('drops placement callbacks, which cannot fire once the listener is gone', () => {

--- a/test/integration/frame/message-manager-hardening.unit.spec.ts
+++ b/test/integration/frame/message-manager-hardening.unit.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * #146 — three ways `MessageManager` could leave a frame in a bad state.
+ *
+ * None of them needs an attacker. `postMessage` is a shared channel, so a page
+ * hosting the frame may carry other libraries posting on the same origin, and
+ * `B24Frame.destroy()` is ordinary SPA teardown.
+ *
+ *   1. `event.data.split(':')` assumed a string. A same-origin peer posting an
+ *      object threw a `TypeError` out of a window event listener.
+ *   2. `JSON.parse(cmd.args)` was unguarded. A malformed payload threw out of
+ *      the listener too, and the promise waiting on that command was then left
+ *      pending forever — the caller waited for an answer that had arrived.
+ *   3. `unsubscribe()` removed the listener and nothing else, so every in-flight
+ *      send was stranded with its timer armed and its map entry held. One such
+ *      set per mount/unmount cycle.
+ *
+ * Portal-free (jsSdk:unit). The project's environment is `node`, so `window` and
+ * `parent` are stubbed here — `send()` uses `window.setTimeout` and posts to
+ * `parent`, and `unsubscribe()` touches `window.removeEventListener`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { MessageManager } from '../../../packages/jssdk/src/frame/message/controller'
+import { SdkError } from '../../../packages/jssdk/src/core/sdk-error'
+import type { LoggerInterface } from '../../../packages/jssdk/src/types/logger'
+
+const ORIGIN = 'https://portal.bitrix24.com'
+
+/** Every `cmd` string handed to `parent.postMessage`, newest last. */
+let posted: string[] = []
+let savedWindow: unknown
+let savedParent: unknown
+
+beforeEach(() => {
+  posted = []
+  savedWindow = (globalThis as any).window
+  savedParent = (globalThis as any).parent
+  ;(globalThis as any).window = {
+    addEventListener() {},
+    removeEventListener() {},
+    setTimeout: (fn: () => void, ms: number) => setTimeout(fn, ms)
+  }
+  ;(globalThis as any).parent = {
+    postMessage(cmd: unknown) {
+      posted.push(String(cmd))
+    }
+  }
+})
+
+afterEach(() => {
+  ;(globalThis as any).window = savedWindow
+  ;(globalThis as any).parent = savedParent
+})
+
+function silentLogger(): LoggerInterface {
+  const sink = () => async () => {}
+  return {
+    log: async () => {}, debug: sink(), info: sink(), notice: sink(),
+    warning: sink(), error: sink(), critical: sink(), alert: sink(),
+    emergency: sink()
+  } as unknown as LoggerInterface
+}
+
+function manager(): MessageManager {
+  const mgr = new MessageManager({
+    getTargetOrigin: () => ORIGIN,
+    getAppSid: () => 'APPSID'
+  } as never)
+  mgr.setLogger(silentLogger())
+  return mgr
+}
+
+/**
+ * The callback key is generated inside `send()` and is only observable in the
+ * `cmd` string posted to the parent — `<command>:<params?>:<key>:<appSid>`,
+ * with empty segments dropped. With no params that is `[command, key, appSid]`.
+ */
+function lastCallbackKey(): string {
+  const cmd = posted.at(-1)
+  if (!cmd) {
+    throw new Error('send() posted nothing to the parent')
+  }
+  const parts = cmd.split(':')
+  const key = parts.at(-2)
+  if (!key) {
+    throw new Error(`no callback key in posted cmd: ${cmd}`)
+  }
+  return key
+}
+
+describe('#146 inbound data that is not our wire format is ignored, not thrown on', () => {
+  it.each([
+    ['an object', { hello: 'world' }],
+    ['an array', ['a', 'b']],
+    ['a number', 42],
+    ['null', null],
+    ['undefined', undefined],
+    ['an empty string', '']
+  ])('does not throw when a same-origin peer posts %s', (_label, data) => {
+    const mgr = manager()
+
+    // This runs inside a window 'message' listener: a throw here is an uncaught
+    // error, raised on traffic that is simply not ours.
+    expect(() => mgr._runCallback({ origin: ORIGIN, data } as MessageEvent)).not.toThrow()
+  })
+
+  it('still resolves a well-formed string message', async () => {
+    const mgr = manager()
+
+    const pending = mgr.send('getInitData')
+    mgr._runCallback({
+      origin: ORIGIN,
+      data: `${lastCallbackKey()}:${JSON.stringify({ ok: true })}`
+    } as MessageEvent)
+
+    await expect(pending).resolves.toEqual({ ok: true })
+  })
+})
+
+describe('#146 a malformed payload settles the waiting promise instead of stranding it', () => {
+  it('rejects with JSSDK_FRAME_BAD_PAYLOAD rather than hanging', async () => {
+    const mgr = manager()
+
+    const pending = mgr.send('getInitData')
+    mgr._runCallback({ origin: ORIGIN, data: `${lastCallbackKey()}:{not json` } as MessageEvent)
+
+    // Before the fix this never settled at all, so a plain await would hang the
+    // run rather than fail it.
+    await expect(pending).rejects.toThrow(SdkError)
+    await expect(pending).rejects.toMatchObject({ code: 'JSSDK_FRAME_BAD_PAYLOAD' })
+  })
+
+  it('does not throw out of the listener on a malformed payload', () => {
+    const mgr = manager()
+
+    const pending = mgr.send('getInitData')
+    pending.catch(() => {})
+
+    expect(() =>
+      mgr._runCallback({ origin: ORIGIN, data: `${lastCallbackKey()}:{not json` } as MessageEvent)
+    ).not.toThrow()
+  })
+
+  it('is silent when nothing is waiting — the command may already have timed out', () => {
+    const mgr = manager()
+
+    expect(() =>
+      mgr._runCallback({ origin: ORIGIN, data: 'unknown-key:{not json' } as MessageEvent)
+    ).not.toThrow()
+  })
+})
+
+describe('#146 unsubscribe() tears the manager down instead of stranding it', () => {
+  it('rejects an in-flight send with JSSDK_FRAME_DISPOSED', async () => {
+    const mgr = manager()
+
+    const pending = mgr.send('getInitData')
+    mgr.unsubscribe()
+
+    await expect(pending).rejects.toMatchObject({ code: 'JSSDK_FRAME_DISPOSED' })
+  })
+
+  it('clears the isSafely timer, so nothing fires after teardown', async () => {
+    const mgr = manager()
+
+    const pending = mgr.send('someCommand', { isSafely: true, safelyTime: 10 })
+    const settled = pending.then(() => 'resolved', () => 'rejected')
+
+    mgr.unsubscribe()
+
+    // The isSafely timer would have resolved this at +10ms. Teardown got there
+    // first, and the timer must not fire afterwards.
+    await expect(settled).resolves.toBe('rejected')
+    await new Promise(resolve => setTimeout(resolve, 40))
+    await expect(settled).resolves.toBe('rejected')
+  })
+
+  it('drops placement callbacks, which cannot fire once the listener is gone', () => {
+    const mgr = manager()
+    const seen: unknown[] = []
+
+    const pending = mgr.send('bindEvent', {
+      callBack: (args: unknown) => seen.push(args),
+      isSafely: true
+    })
+    pending.catch(() => {})
+    const key = lastCallbackKey()
+
+    mgr.unsubscribe()
+    mgr._runCallback({ origin: ORIGIN, data: `${key}:${JSON.stringify({ late: true })}` } as MessageEvent)
+
+    expect(seen).toEqual([])
+  })
+})
+
+describe('#146 the foreign-origin warning set cannot grow without bound', () => {
+  it('stops growing past the cap, and keeps rejecting the messages', () => {
+    const captured: string[] = []
+    const mgr = new MessageManager({ getTargetOrigin: () => ORIGIN } as never)
+    mgr.setLogger({
+      ...silentLogger(),
+      warning: async (message: string) => { captured.push(message) }
+    } as unknown as LoggerInterface)
+
+    // The dedup key is chosen by the sender, so an unbounded supply of distinct
+    // origins would otherwise mean an unbounded set.
+    for (let i = 0; i < 200; i++) {
+      mgr._runCallback({ origin: `https://peer-${i}.example`, data: 'x:{}' } as MessageEvent)
+    }
+
+    expect(captured.length).toBeLessThanOrEqual(50)
+    expect(captured.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
Closes #146.

Three defects. None needs an attacker to reach: `postMessage` is a shared channel — a page hosting the frame may carry other libraries, or a browser extension, posting on the same origin — and `B24Frame.destroy()` is ordinary SPA teardown.

### 1. `event.data.split(':')` assumed a string

A same-origin peer posting an object raised a `TypeError` **out of a window event listener** — an uncaught error, on traffic the SDK should simply have ignored. The handler now processes only non-empty strings, which is the wire format it documents.

Narrowing `event.data` to `string` also made the indexing that follows type-checked; it had been sitting behind `any`, and `tsc` immediately flagged `tmp[0]` as `string | undefined`.

### 2. `JSON.parse(cmd.args)` was unguarded

A malformed payload threw out of the listener too — and worse, left the promise waiting on that command **pending forever**. The caller went on waiting for an answer that had already arrived, broken. It now rejects with `JSSDK_FRAME_BAD_PAYLOAD`.

The caught error is deliberately **not** logged and not attached as `cause`. V8 quotes the offending input in its message (`Unexpected token 'a', "auth=…" is not valid JSON`), and this is the payload carrying `AUTH_ID` / `REFRESH_ID` (#43). The id and origin say which command failed, which is what a reader needs.

### 3. `unsubscribe()` removed the listener and nothing else

Every in-flight `send()` waits on a promise only that listener can settle, so teardown stranded each one — timer still armed, map entry still held. `B24Frame.destroy()` calls this, so an SPA that mounts and unmounts the frame accumulated one such set per cycle. Same class as #222 in `PullClient`.

Teardown now clears the timers, **rejects** the pending sends with `JSSDK_FRAME_DISPOSED`, and empties both maps — mirroring how a disposed `PullClient` rejects `start()` with `PULL_DISPOSED`.

Two decisions worth calling out:

- **Reject rather than leave hanging.** A caller awaiting a command that can no longer be answered should learn that; silence is the one outcome it cannot act on. The consequence is documented on the method: a `send()` whose result was discarded without a `.catch()` becomes an unhandled rejection at teardown. Every fire-and-forget path in the SDK passes `isSafely`, which settles on its own timer and is normally already gone by then.
- **Placement callbacks are cleared at teardown, not on delivery.** `placementBindEvent` is a long-lived subscription the portal fires repeatedly — deleting the entry when it first fires would break every placement event handler after the first.

### Also: the foreign-origin warning set is capped

Its dedup key is chosen by the sender, so a peer posting from an unbounded supply of distinct origins (`a.evil.test`, `b.evil.test`, …) grew the set without bound. Past the cap it stops growing and later origins are not warned about — losing a log line is the right trade against unbounded memory in a long-lived frame.

### Verification

14 new specs in `test/integration/frame/message-manager-hardening.unit.spec.ts`.

**9 of the 14 fail against the unfixed code**, and the `JSSDK_FRAME_DISPOSED` one does not fail but **hangs to the 10s timeout** — which is the never-settling defect, reproduced rather than described. The other 5 pass either way; they are regression guards for the cases `if (event.data)` already covered.

Full suite 442 passing (was 428), `eslint` (the one warning is pre-existing, in `docs/server/api/ai.post.ts`), full `typecheck` — all eight passes — `docs-lint --strict`, `md-internal-links`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_