### PR TITLE
docs: warn that an app which never calls installFinish() receives no events

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/30.frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame.md
@@ -142,6 +142,28 @@ installFinish(): Promise<any>
 
 Sends `setInstallFinish` to the parent. Throws `Error('Application was previously installed. You cannot call installFinish')`{lang="ts-type"} when called outside install mode — guard with `isInstallMode`.
 
+::warning
+**An application that never calls this stays half-installed, and the portal does not deliver events to it.** Bot handlers, handlers registered with `event.bind`, and other outgoing calls simply never reach your endpoints.
+
+Nothing fails loudly. Registration succeeds, `imbot.register` returns a `botId`, querying the handlers lists them — and no traffic ever arrives. Every visible signal says the setup is correct, which is why this is usually debugged at the wrong layer: nginx, tunnels, TLS, routing.
+
+Call it once, from the install page, as the last step of your install flow. An application with no install UI still needs to call it — the install page is opened either way, and that iframe is the only place the call can be made from.
+
+To check an application after the fact, ask the portal:
+
+```ts
+const response = await $b24.actions.v2.call.make<{ INSTALLED: boolean }>({
+  method: 'app.info',
+  requestId: 'app-info-1'
+})
+console.log(response.getData()!.result.INSTALLED) // false ⇒ installFinish() never landed
+```
+::
+
+::note
+The portal reacts to this call by **reloading the page**: from the installer it restarts the application, from the settings stage it re-runs the `init` handlers. Anything your code does after `await installFinish()` may not run — treat it as the last statement of the install flow, not a step in the middle of one.
+::
+
 ### `getAppSid`
 
 ```ts-type

--- a/docs/content/docs/2.working-with-the-rest-api/30.frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame.md
@@ -140,14 +140,20 @@ This matters for a command whose promise you discarded. `parent.closeApplication
 installFinish(): Promise<any>
 ```
 
-Sends `setInstallFinish` to the parent. Throws `Error('Application was previously installed. You cannot call installFinish')`{lang="ts-type"} when called outside install mode — guard with `isInstallMode`.
+Sends `setInstallFinish` to the parent. The returned promise **rejects** with `Error('Application was previously installed. You cannot call installFinish')`{lang="ts-type"} when called outside install mode — guard with `isInstallMode`.
+
+Note that this is a bare `Error`{lang="ts-type"}, not an `SdkError`{lang="ts-type"}, so it carries no `code` to match on. That inconsistency is tracked in [#155](https://github.com/bitrix24/b24jssdk/issues/155); until it is resolved, do not write a `catch` that keys off `error.code` here.
 
 ::warning
 **An application that never calls this stays half-installed, and the portal does not deliver events to it.** Bot handlers, handlers registered with `event.bind`, and other outgoing calls simply never reach your endpoints.
 
+The confirmed case is a chat bot, from a Bitrix24 support thread: *"without it, outgoing handlers do not work"*. Their wording was general, so treat the rest as affected too — but the bot case is the one with a report behind it. This is not stated on the [`BX24.installFinish` page](https://apidocs.bitrix24.ru/sdk/bx24-js-sdk/system-functions/bx24-install-finish.html), which describes the call only from the install-flow side.
+
 Nothing fails loudly. Registration succeeds, `imbot.register` returns a `botId`, querying the handlers lists them — and no traffic ever arrives. Every visible signal says the setup is correct, which is why this is usually debugged at the wrong layer: nginx, tunnels, TLS, routing.
 
 Call it once, from the install page, as the last step of your install flow. An application with no install UI still needs to call it — the install page is opened either way, and that iframe is the only place the call can be made from.
+
+Finishing the installation is a **lifecycle** step, not a security one. An app that also runs an OAuth install/uninstall endpoint still has to verify `application_token` on `ONAPPINSTALL` / `ONAPPUNINSTALL` — see [Security patterns](/docs/working-with-the-rest-api/security/). The two are unrelated, and doing this one does not cover the other.
 
 To check an application after the fact, ask the portal:
 
@@ -161,7 +167,9 @@ console.log(response.getData()!.result.INSTALLED) // false ⇒ installFinish() n
 ::
 
 ::note
-The portal reacts to this call by **reloading the page**: from the installer it restarts the application, from the settings stage it re-runs the `init` handlers. Anything your code does after `await installFinish()` may not run — treat it as the last statement of the install flow, not a step in the middle of one.
+The portal reacts to this call by **reloading the page**: from the installer it restarts the application, from the settings stage it re-runs the `init` handlers.
+
+That is stronger than "the next line might not run". This command is sent without the SDK's `isSafely` timer, so its promise settles only when the parent window answers — and if the reload happens first, **the promise never settles at all**. The `await` does not return, and a `finally` block attached to it does not execute. Treat `installFinish()` as the last statement of the install flow, and do not build state that depends on it resolving.
 ::
 
 ### `getAppSid`

--- a/docs/content/docs/2.working-with-the-rest-api/30.frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame.md
@@ -145,13 +145,15 @@ Sends `setInstallFinish` to the parent. The returned promise **rejects** with `E
 Note that this is a bare `Error`{lang="ts-type"}, not an `SdkError`{lang="ts-type"}, so it carries no `code` to match on. That inconsistency is tracked in [#155](https://github.com/bitrix24/b24jssdk/issues/155); until it is resolved, do not write a `catch` that keys off `error.code` here.
 
 ::warning
-**An application that never calls this stays half-installed, and the portal does not deliver events to it.** Bot handlers, handlers registered with `event.bind`, and other outgoing calls simply never reach your endpoints.
+**An application with an installation interface that never calls this stays half-installed, and the portal does not deliver events to it.** Handlers bound with `event.bind` never fire, placements bound with `placement.bind` never appear, and other outgoing calls never reach your endpoints — even though each of those registration calls returned success.
 
-The confirmed case is a chat bot, from a Bitrix24 support thread: *"without it, outgoing handlers do not work"*. Their wording was general, so treat the rest as affected too — but the bot case is the one with a report behind it. This is not stated on the [`BX24.installFinish` page](https://apidocs.bitrix24.ru/sdk/bx24-js-sdk/system-functions/bx24-install-finish.html), which describes the call only from the install-flow side.
+This is Bitrix24's documented behaviour: [What doesn't work until installation is complete](https://apidocs.bitrix24.com/settings/app-installation/installation-finish.html#what-doesnt-work-until-installation-is-complete) lists exactly `placement.bind` and `event.bind` as inert until the install is finished.
 
 Nothing fails loudly. Registration succeeds, `imbot.register` returns a `botId`, querying the handlers lists them — and no traffic ever arrives. Every visible signal says the setup is correct, which is why this is usually debugged at the wrong layer: nginx, tunnels, TLS, routing.
 
-Call it once, from the install page, as the last step of your install flow. An application with no install UI still needs to call it — the install page is opened either way, and that iframe is the only place the call can be made from.
+Call it once, from the install page, as the last step of your install flow.
+
+**This applies only to an app that has an installation interface.** An API-only app with no interface must *not* call `installFinish()` — its installation completes automatically, and the method works only inside a browser interface frame (an install callback runs server-side and cannot call it). So if an app with no UI is missing events, `installFinish()` is not the cause; look elsewhere.
 
 Finishing the installation is a **lifecycle** step, not a security one. An app that also runs an OAuth install/uninstall endpoint still has to verify `application_token` on `ONAPPINSTALL` / `ONAPPUNINSTALL` — see [Security patterns](/docs/working-with-the-rest-api/security/). The two are unrelated, and doing this one does not cover the other.
 

--- a/docs/content/docs/2.working-with-the-rest-api/30.frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame.md
@@ -147,13 +147,15 @@ Note that this is a bare `Error`{lang="ts-type"}, not an `SdkError`{lang="ts-typ
 ::warning
 **An application with an installation interface that never calls this stays half-installed, and the portal does not deliver events to it.** Handlers bound with `event.bind` never fire, placements bound with `placement.bind` never appear, and other outgoing calls never reach your endpoints — even though each of those registration calls returned success.
 
-This is Bitrix24's documented behaviour: [What doesn't work until installation is complete](https://apidocs.bitrix24.com/settings/app-installation/installation-finish.html#what-doesnt-work-until-installation-is-complete) lists exactly `placement.bind` and `event.bind` as inert until the install is finished.
+This is Bitrix24's documented behaviour: [What doesn't work until installation is complete](https://apidocs.bitrix24.com/settings/app-installation/installation-finish.html#what-doesnt-work-until-installation-is-complete) lists exactly `placement.bind` and `event.bind` as inert until the install is finished. (That page is the authority here; the SDK cannot reproduce portal-side behaviour, so if what you see differs — for instance on a self-hosted portal — trust the `app.info` check below over this prose.)
 
 Nothing fails loudly. Registration succeeds, `imbot.register` returns a `botId`, querying the handlers lists them — and no traffic ever arrives. Every visible signal says the setup is correct, which is why this is usually debugged at the wrong layer: nginx, tunnels, TLS, routing.
 
 Call it once, from the install page, as the last step of your install flow.
 
 **This applies only to an app that has an installation interface.** An API-only app with no interface must *not* call `installFinish()` — its installation completes automatically, and the method works only inside a browser interface frame (an install callback runs server-side and cannot call it). So if an app with no UI is missing events, `installFinish()` is not the cause; look elsewhere.
+
+<!-- Keep in sync: 99.examples/20.app-installation-wizard.md, skills/b24jssdk-frame-ui/SKILL.md, skills/b24jssdk-core/SKILL.md. Source of truth for the claim: apidocs.bitrix24.com "What doesn't work until installation is complete". -->
 
 Finishing the installation is a **lifecycle** step, not a security one. An app that also runs an OAuth install/uninstall endpoint still has to verify `application_token` on `ONAPPINSTALL` / `ONAPPUNINSTALL` — see [Security patterns](/docs/working-with-the-rest-api/security/). The two are unrelated, and doing this one does not cover the other.
 

--- a/docs/content/docs/99.examples/2.frame-app-skeleton.md
+++ b/docs/content/docs/99.examples/2.frame-app-skeleton.md
@@ -26,6 +26,10 @@ A single Vue 3 component that demonstrates the four things every Bitrix24 iframe
 - `@bitrix24/b24jssdk@^1.0.0`
 - The page must be served from the URL registered as the placement handler in your Bitrix24 app card. Outside the iframe, `initializeB24Frame()` rejects.
 
+::caution
+This skeleton covers a **running** app, not an installing one. If `$b24.isInstallMode`{lang="ts-type"} is `true`{lang="ts-type"}, the app must finish its installation with `installFinish()`{lang="ts-type"} — until it does, the portal delivers **no events** to it, and bot handlers and `event.bind` handlers never fire, with nothing failing loudly to say so. See the [Installation Wizard recipe](/docs/examples/app-installation-wizard/).
+::
+
 ```bash
 pnpm add @bitrix24/b24jssdk
 ```

--- a/docs/content/docs/99.examples/20.app-installation-wizard.md
+++ b/docs/content/docs/99.examples/20.app-installation-wizard.md
@@ -72,16 +72,14 @@ async function run() {
 run().catch(console.error)
 ```
 
-`installFinish()` throws `Error('Application was previously installed. You cannot call installFinish')` when the application is no longer in install mode — guard with `isInstallMode`.
+`installFinish()`'s promise **rejects** with `Error('Application was previously installed. You cannot call installFinish')` when the application is no longer in install mode — guard with `isInstallMode`.
 
 ::warning
-**Never skipping `installFinish()` is the whole point of this recipe.** An application that does not finalise its installation stays half-installed, and the portal does not deliver events to it.
-
-The case Bitrix24 support confirmed is a chat bot: its handlers never fire. Their wording was general — *"without it, outgoing handlers do not work"* — so treat `event.bind` handlers and other outgoing calls as affected too, but note that the bot case is the one with a confirmed report behind it.
+**Never skipping `installFinish()` is the whole point of this recipe.** A wizard-style app that does not finalise its installation stays half-installed, and the portal does not deliver events to it: handlers bound with `event.bind` never fire and placements bound with `placement.bind` never appear, even though both registration calls returned success. This is [Bitrix24's documented behaviour](https://apidocs.bitrix24.com/settings/app-installation/installation-finish.html#what-doesnt-work-until-installation-is-complete).
 
 The failure is silent and misleading: registration succeeds, `imbot.register` hands back a `botId`, the handlers are listed when you query them, and nothing ever arrives. Developers routinely lose days on nginx, tunnels and TLS before finding out the application was never finished installing.
 
-This applies even to an application with **no install UI**. The install page is opened regardless, and that iframe is the only place the call can be made from — so an app with nothing to provision still needs a page whose entire job is to call `installFinish()`.
+The opposite case is worth knowing, because it is the mirror mistake: an **API-only app with no installation interface** must *not* call `installFinish()`. Its installation completes automatically, and the method works only inside a browser interface frame — so this recipe is for apps that have an install screen, not for headless ones.
 ::
 
 ### "My handlers never fire"

--- a/docs/content/docs/99.examples/20.app-installation-wizard.md
+++ b/docs/content/docs/99.examples/20.app-installation-wizard.md
@@ -1,6 +1,6 @@
 ---
 title: App Installation Wizard
-description: 'Multi-step install flow that creates user fields, registers placements, finalises the installation, and celebrates with confetti.'
+description: 'Multi-step install flow that creates user fields, registers placements, celebrates with confetti, and finalises the installation last — because the portal reloads the page in response.'
 navigation.title: Installation Wizard
 links:
   - label: example source
@@ -75,7 +75,9 @@ run().catch(console.error)
 `installFinish()` throws `Error('Application was previously installed. You cannot call installFinish')` when the application is no longer in install mode — guard with `isInstallMode`.
 
 ::warning
-**Never skipping `installFinish()` is the whole point of this recipe.** An application that does not finalise its installation stays half-installed, and the portal delivers no events to it — bot handlers, `event.bind` handlers and other outgoing calls never reach your endpoints.
+**Never skipping `installFinish()` is the whole point of this recipe.** An application that does not finalise its installation stays half-installed, and the portal does not deliver events to it.
+
+The case Bitrix24 support confirmed is a chat bot: its handlers never fire. Their wording was general — *"without it, outgoing handlers do not work"* — so treat `event.bind` handlers and other outgoing calls as affected too, but note that the bot case is the one with a confirmed report behind it.
 
 The failure is silent and misleading: registration succeeds, `imbot.register` hands back a `botId`, the handlers are listed when you query them, and nothing ever arrives. Developers routinely lose days on nginx, tunnels and TLS before finding out the application was never finished installing.
 

--- a/docs/content/docs/99.examples/20.app-installation-wizard.md
+++ b/docs/content/docs/99.examples/20.app-installation-wizard.md
@@ -61,14 +61,40 @@ async function run() {
   }
 
   await provision()
-  await $b24.installFinish()
+
+  // Celebrate BEFORE finalising: the portal reloads the page in response to
+  // installFinish(), so anything after it may never run.
   // celebrate with useConfetti() ...
+
+  await $b24.installFinish()
 }
 
 run().catch(console.error)
 ```
 
 `installFinish()` throws `Error('Application was previously installed. You cannot call installFinish')` when the application is no longer in install mode — guard with `isInstallMode`.
+
+::warning
+**Never skipping `installFinish()` is the whole point of this recipe.** An application that does not finalise its installation stays half-installed, and the portal delivers no events to it — bot handlers, `event.bind` handlers and other outgoing calls never reach your endpoints.
+
+The failure is silent and misleading: registration succeeds, `imbot.register` hands back a `botId`, the handlers are listed when you query them, and nothing ever arrives. Developers routinely lose days on nginx, tunnels and TLS before finding out the application was never finished installing.
+
+This applies even to an application with **no install UI**. The install page is opened regardless, and that iframe is the only place the call can be made from — so an app with nothing to provision still needs a page whose entire job is to call `installFinish()`.
+::
+
+### "My handlers never fire"
+
+Before checking anything on your side of the wire, ask the portal whether it considers the application installed:
+
+```ts
+const response = await $b24.actions.v2.call.make<{ INSTALLED: boolean }>({
+  method: 'app.info',
+  requestId: 'app-info-1'
+})
+console.log(response.getData()!.result.INSTALLED)
+```
+
+`INSTALLED: false` means `installFinish()` never landed, and no amount of debugging your endpoint will help until it does. `true` means the installation is complete and the problem is somewhere else.
 
 ## Full Source
 

--- a/docs/content/docs/99.examples/20.app-installation-wizard.md
+++ b/docs/content/docs/99.examples/20.app-installation-wizard.md
@@ -80,6 +80,8 @@ run().catch(console.error)
 The failure is silent and misleading: registration succeeds, `imbot.register` hands back a `botId`, the handlers are listed when you query them, and nothing ever arrives. Developers routinely lose days on nginx, tunnels and TLS before finding out the application was never finished installing.
 
 The opposite case is worth knowing, because it is the mirror mistake: an **API-only app with no installation interface** must *not* call `installFinish()`. Its installation completes automatically, and the method works only inside a browser interface frame — so this recipe is for apps that have an install screen, not for headless ones.
+
+<!-- Keep in sync: 2.working-with-the-rest-api/30.frame.md, skills/b24jssdk-frame-ui/SKILL.md, skills/b24jssdk-core/SKILL.md. -->
 ::
 
 ### "My handlers never fire"

--- a/skills/b24jssdk-core/SKILL.md
+++ b/skills/b24jssdk-core/SKILL.md
@@ -69,6 +69,21 @@ function teardown() {
 
 `initializeB24Frame()` deduplicates concurrent calls — safe to await it from multiple places.
 
+**If the app is in install mode, finish the installation.** Until `installFinish()`
+is called the portal treats the app as half-installed and delivers **no events** to
+it — bot handlers, `event.bind` handlers and other outgoing calls never arrive, with
+nothing failing loudly to say so:
+
+```ts
+if ($b24.isInstallMode) {
+  // provision whatever the app needs, then finish — the portal reloads the page
+  // in response, so this is the last statement of the flow.
+  await $b24.installFinish()
+}
+```
+
+See the `b24jssdk-frame-ui` skill for the full rule.
+
 ## B24OAuth (server side of an OAuth app)
 
 ```ts

--- a/skills/b24jssdk-core/SKILL.md
+++ b/skills/b24jssdk-core/SKILL.md
@@ -82,7 +82,9 @@ if ($b24.isInstallMode) {
 }
 ```
 
-See the `b24jssdk-frame-ui` skill for the full rule.
+See the `b24jssdk-frame-ui` skill for the full rule. Note this is a **lifecycle**
+step, not a security one — an OAuth install/uninstall endpoint still verifies
+`application_token` (see the security checklist below).
 
 ## B24OAuth (server side of an OAuth app)
 

--- a/skills/b24jssdk-frame-ui/SKILL.md
+++ b/skills/b24jssdk-frame-ui/SKILL.md
@@ -289,6 +289,11 @@ The opposite holds for an **API-only app with no installation interface**: it mu
 method works only inside a browser interface frame — so gate the call on
 `isInstallMode`, which is only ever true inside that frame.
 
+Finishing the installation is a **lifecycle** step, not a security one. An app that
+also runs an OAuth install/uninstall endpoint still has to verify `application_token`
+on `ONAPPINSTALL` / `ONAPPUNINSTALL` — see the [Security patterns](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/security/)
+page. Doing one does not cover the other.
+
 To check an app the portal is ignoring, ask whether it considers it installed:
 `app.info` returns `INSTALLED`, and `false` means `installFinish()` never landed.
 

--- a/skills/b24jssdk-frame-ui/SKILL.md
+++ b/skills/b24jssdk-frame-ui/SKILL.md
@@ -270,6 +270,8 @@ The failure is silent: registration succeeds, `imbot.register` returns a `botId`
 the handlers are listed when queried, and no traffic arrives. Generated code must
 therefore always finish the install flow.
 
+<!-- Keep in sync: docs 30.frame.md (installFinish), docs 99.examples/20.app-installation-wizard.md, skills/b24jssdk-core/SKILL.md. -->
+
 ```ts
 const $b24 = await initializeB24Frame()
 

--- a/skills/b24jssdk-frame-ui/SKILL.md
+++ b/skills/b24jssdk-frame-ui/SKILL.md
@@ -284,8 +284,10 @@ if ($b24.isInstallMode) {
 }
 ```
 
-This applies to an application with **no install UI** as well — the install page is
-opened either way, and that iframe is the only place the call can be made from.
+The opposite holds for an **API-only app with no installation interface**: it must
+*not* call `installFinish()`. Its installation completes automatically, and the
+method works only inside a browser interface frame — so gate the call on
+`isInstallMode`, which is only ever true inside that frame.
 
 To check an app the portal is ignoring, ask whether it considers it installed:
 `app.info` returns `INSTALLED`, and `false` means `installFinish()` never landed.

--- a/skills/b24jssdk-frame-ui/SKILL.md
+++ b/skills/b24jssdk-frame-ui/SKILL.md
@@ -259,10 +259,41 @@ onBeforeUnmount(() => {
 })
 ```
 
+## Install mode — finish it, or the portal sends you nothing
+
+An application is "installing" from the moment the user accepts the install dialog
+until it calls `installFinish()`. Until that call lands, the portal treats the app
+as half-installed and **delivers no events to it** — bot handlers, handlers
+registered with `event.bind`, and other outgoing calls never reach your endpoints.
+
+The failure is silent: registration succeeds, `imbot.register` returns a `botId`,
+the handlers are listed when queried, and no traffic arrives. Generated code must
+therefore always finish the install flow.
+
+```ts
+const $b24 = await initializeB24Frame()
+
+if ($b24.isInstallMode) {
+  // provision fields, register placements, seed options...
+
+  // Last statement of the flow: the portal reloads the page in response,
+  // so anything after this may never run.
+  await $b24.installFinish()
+}
+```
+
+This applies to an application with **no install UI** as well — the install page is
+opened either way, and that iframe is the only place the call can be made from.
+
+To check an app the portal is ignoring, ask whether it considers it installed:
+`app.info` returns `INSTALLED`, and `false` means `installFinish()` never landed.
+
 ## Anti-patterns
 
 - ❌ Using `B24Frame` outside a Bitrix24 placement — `initializeB24Frame()` will hang waiting for the parent handshake. Use `B24Hook` for non-frame contexts.
 - ❌ Calling slider / dialog APIs before `await initializeB24Frame()` resolves.
+- ❌ Provisioning an app in install mode and never calling `installFinish()` — the app stays half-installed and the portal delivers no events to it, with nothing failing loudly to say so.
+- ❌ Putting work after `await installFinish()` — the portal reloads the page in response, so it may never run.
 - ❌ `$b24.placement.call('setValue', { value: { id: 1 } })` — throws because `value` is not a string. Use `$b24.placement.setValue({ id: 1 })` or stringify yourself.
 - ❌ Storing secrets in `options.appSet` — placement options are visible to everyone with access to the placement.
 - ❌ Treating a resolved `parent.im*` promise as proof the call started or the chat opened — nothing answers those commands; the promise only means the message was posted.


### PR DESCRIPTION
Refs #336. Documentation and skills only — no SDK behaviour changes.

### The gap

`installFinish()` was documented as a mechanic: what it sends, when it throws. Nothing said what breaks when it is never called.

Until it lands, the portal treats the application as half-installed and **delivers no events to it** — chat-bot handlers, handlers registered with `event.bind`, and other outgoing calls never reach the app's endpoints.

The failure is silent and actively misleading. Registration succeeds, `imbot.register` returns a `botId`, the handlers are listed when queried, and no traffic arrives. Every visible signal says the setup is correct, which is why the support thread in the issue shows days spent on nginx, ngrok and TLS before anyone asked whether the app had finished installing.

### Where the warning went

Wherever a developer is standing when they hit it:

| File | What it gains |
| --- | --- |
| `2.working-with-the-rest-api/30.frame.md` | the warning on `installFinish`, plus the page-reload note |
| `99.examples/20.app-installation-wizard.md` | the warning, and a **"My handlers never fire"** troubleshooting section |
| `skills/b24jssdk-frame-ui/SKILL.md` | a full *Install mode* section and two anti-patterns |
| `skills/b24jssdk-core/SKILL.md` | the short rule next to the `B24Frame` boot snippet |

Each one carries the check that settles it in one call — `app.info` returns `INSTALLED`, and `false` means `installFinish()` never landed. That turns a multi-day hunt into a question with an answer.

### Two things the official docs say that we did not

Both came out of reading [the BX24.installFinish page](https://apidocs.bitrix24.ru/sdk/bx24-js-sdk/system-functions/bx24-install-finish.html) rather than from the issue:

**The portal reloads the page in response to the call** — restarting the app from the installer, or re-running the `init` handlers from the settings stage. Our wizard example did this:

```ts
await provision()
await $b24.installFinish()
// celebrate with useConfetti() ...
```

The confetti may never run. Reordered so the celebration happens first, with the reason in a comment.

**An application with no install UI still has to call it.** The install page is opened either way, and that iframe is the only place the call can be made from — so an app with nothing to provision still needs a page whose entire job is that one call.

### On sourcing

The event-delivery mechanism is **Bitrix24's statement**, from the support thread quoted in the issue, not something reproduced here — there is no portal in this session and the flow needs a real app installation. The docs are written accordingly: they describe the symptom, the fix and the check, and do not assert internals we have not seen. The page-reload behaviour and the no-UI requirement are from Bitrix24's own published documentation.

### Not in this PR

**The Bitrix24 REST API documentation half** (issue scope item 2) is outside this repository — `apidocs.bitrix24.ru` / `.com` are not ours to edit. I have drafted the RU and EN text plus the cross-link proposals for the bot / `event.bind` / `ONAPPINSTALL` pages, and will hand it over separately for the docs owners.

**One thing I noticed and did not fix**, to avoid widening this PR: `skills/b24jssdk-core/SKILL.md` still teaches `LoggerBrowser`, which is deprecated and scheduled for removal in 3.0.0 (#277). It belongs to #113, not here.

### Verification

`docs-lint --strict`, `docs:typecheck-blocks` (155 blocks), `skills:typecheck`, `lint:md`, `md-internal-links`, `check-v3-method-refs`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_