### PR TITLE
docs: announce that Node 20 is dropped in 3.0.0

### DIFF
--- a/docs/app/app.vue
+++ b/docs/app/app.vue
@@ -75,7 +75,7 @@ provide('files', files)
         ]"
       >
         <template v-if="!route.path.startsWith('/examples')">
-          <!-- <Banner /> -->
+          <Banner />
 
           <Header />
         </template>

--- a/docs/app/components/Banner.vue
+++ b/docs/app/components/Banner.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-import EnterpriseIcon from '@bitrix24/b24icons-vue/solid/EnterpriseIcon'
+import AlertIcon from '@bitrix24/b24icons-vue/outline/AlertIcon'
 </script>
 
 <template>
   <B24Banner
-    id="migration-v1-jsSdk-banner"
-    title="Version 1.0.1 is now available! Looking for a migration guide?"
-    to="/docs/getting-started/migration/v1/"
-    :icon="EnterpriseIcon"
+    id="node20-drop-3-0-0-banner"
+    title="Node 20 support ends in 3.0.0 — move to Node 22 or newer"
+    to="/docs/getting-started/migration/v3/#runtime-node-20-is-dropped-in-300"
+    :icon="AlertIcon"
     close
-    color="air-primary-copilot"
+    color="air-primary-alert"
   />
 </template>

--- a/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
+++ b/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
@@ -24,6 +24,10 @@ Before you begin, make sure you have the latest version of Node.js installed.
 We support version Node.js `^20.0.0 || >=22.0.0` (Node 18 is EOL and no longer supported).
 ::
 
+::warning
+**Node 20 is dropped in the next major (`3.0.0`).** It reached end-of-life on 2026-04-30, and the SDK already tests only Node 22 and 24. `3.0.0` will require `>=22.0.0` — move to Node 22 (the active LTS) or newer before upgrading. See the [v3 migration guide](/docs/getting-started/migration/v3/#runtime-node-20-is-dropped-in-300).
+::
+
 Then run the following command to install the library:
 
 ::steps{level="3"}

--- a/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
+++ b/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
@@ -25,7 +25,7 @@ We support version Node.js `^20.0.0 || >=22.0.0` (Node 18 is EOL and no longer s
 ::
 
 ::warning
-**Node 20 is dropped in the next major (`3.0.0`).** It reached end-of-life on 2026-04-30, and the SDK already tests only Node 22 and 24. `3.0.0` will require `>=22.0.0` — move to Node 22 (the active LTS) or newer before upgrading. See the [v3 migration guide](/docs/getting-started/migration/v3/#runtime-node-20-is-dropped-in-300).
+**Node 20 is dropped in the next major (`3.0.0`).** It reached end-of-life on 2026-04-30, and the SDK already tests only Node 22 and 24. `3.0.0` will require `>=22.0.0` — move to Node 22 (LTS) or newer before upgrading. See the [v3 migration guide](/docs/getting-started/migration/v3/#runtime-node-20-is-dropped-in-300).
 ::
 
 Then run the following command to install the library:

--- a/docs/content/docs/1.getting-started/3.migration/2.v3.md
+++ b/docs/content/docs/1.getting-started/3.migration/2.v3.md
@@ -96,6 +96,25 @@ Replaced by the universal [`Logger` / `LoggerFactory`](/docs/working-with-the-re
 + $logger.info('response', { someInfo: dataList })
 ```
 
+## Runtime: Node 20 is dropped in 3.0.0
+
+`3.0.0` raises the Node floor. `engines.node` moves from `^20.0.0 || >=22.0.0` to
+`>=22.0.0`, so **Node 20 is no longer supported**.
+
+Node 20 reached end-of-life on 2026-04-30 — it no longer receives security fixes —
+and the SDK already tests only Node 22 and 24 in CI, so `2.x` advertises Node 20
+without exercising it. `3.0.0` closes that gap by dropping it.
+
+What this means for you:
+
+- On **Node 22 or newer**, nothing changes.
+- On **Node 20**, `npm install` will print an `EBADENGINE` warning, and under
+  `engine-strict=true` (or pnpm's default for a workspace) the install fails
+  outright. Move to Node 22 (the active LTS) or newer before upgrading to `3.0.0`.
+
+This is a packaging floor, not an API change: no code has to change, only the Node
+version you run on. There is nothing to migrate in your source.
+
 ## How to find every call site
 
 The deprecated symbols emit a `JSSDK_CORE_DEPRECATED_METHOD` warning at runtime, and `LoggerBrowser` logs `@deprecated: use Logger`. A quick static check:

--- a/docs/content/docs/1.getting-started/3.migration/2.v3.md
+++ b/docs/content/docs/1.getting-started/3.migration/2.v3.md
@@ -110,10 +110,13 @@ What this means for you:
 - On **Node 22 or newer**, nothing changes.
 - On **Node 20**, `npm install` will print an `EBADENGINE` warning, and under
   `engine-strict=true` (or pnpm's default for a workspace) the install fails
-  outright. Move to Node 22 (the active LTS) or newer before upgrading to `3.0.0`.
+  outright. Move to Node 22 (LTS) or newer before upgrading to `3.0.0`.
 
 This is a packaging floor, not an API change: no code has to change, only the Node
 version you run on. There is nothing to migrate in your source.
+
+No `3.0.0` date is set yet — this is documented ahead of time so you can plan the
+runtime move, not because a release is imminent.
 
 ## How to find every call site
 


### PR DESCRIPTION
Refs #312. The `engines` change itself is deferred to 3.0.0 — this is the announcement.

### Why now

#312 splits into two halves: **announce** the Node 20 removal now, **do** it at the next major. This is the announcement.

- **We advertise a runtime we don't support.** `engines.node` is `^20.0.0 || >=22.0.0`. Node 20 reached EOL **2026-04-30**, so it no longer gets security fixes.
- **The advertisement is hollow.** CI's `test` matrix runs only on **22 + 24**; Node 20 is advertised-but-untested. #312 says the fix is to drop it from `engines`, not grow the matrix backward.
- **The removal is breaking, so it waits for 3.0.0** — `EBADENGINE` for a Node 20 consumer, hard fail under `engine-strict`. Consumers deserve lead time, which this gives.

### What changed

| File | Change |
| --- | --- |
| `3.migration/2.v3.md` | New **"Runtime: Node 20 is dropped in 3.0.0"** section, with the floor move, the `EBADENGINE` / `engine-strict` consequence, and a "no 3.0.0 date set yet — plan ahead" note |
| `2.installation/4.nodejs.md` | Forward-looking note next to the current support statement, linking to the migration section |
| `app/components/Banner.vue` | Repointed the (previously commented-out) site banner at the Node 20 announcement — "Node 20 support ends in 3.0.0 — move to Node 22 or newer" |
| `app/app.vue` | Enabled `<Banner />` so the announcement is visible site-wide, dismissible |

Framed as a **packaging floor, not an API change**: nothing to migrate in source, only the Node version you run on.

### Not here

The `engines` edits, `README-AI.md`, `skills/b24jssdk-core/SKILL.md`, `docker-compose.yml` and the release-note line — #312's "do at the next major" list, tracked in the 3.0.0 bucket with #277/#279.

### Review

`/code-review` + five reviewers. Fixes folded in: "active LTS" → "Node 22 (LTS)" (Node 22 is Maintenance LTS as of 2026-08, Node 24 is active); "no date set yet" caveat. Verified with a full docs build (`pnpm --filter ./docs build`, exit 0) — the banner compiles — plus `docs-lint --strict`, `docs-link-check` (the cross-page anchor resolves and is enforced), `lint:md`, `md-internal-links`.

Two follow-ups worth filing separately (QA / prior CTO note): a check pinning `engines.node` to the migration doc's stated floor (#312 today, enforced at 3.0.0), and a 3.0.0 scope-freeze / timeline issue as the breaking-change bucket (#277/#279/#312) grows.
