### PR TITLE
fix(core): throw SdkError, not bare Error, across the public entry points

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/30.frame.md
+++ b/docs/content/docs/2.working-with-the-rest-api/30.frame.md
@@ -140,9 +140,7 @@ This matters for a command whose promise you discarded. `parent.closeApplication
 installFinish(): Promise<any>
 ```
 
-Sends `setInstallFinish` to the parent. The returned promise **rejects** with `Error('Application was previously installed. You cannot call installFinish')`{lang="ts-type"} when called outside install mode — guard with `isInstallMode`.
-
-Note that this is a bare `Error`{lang="ts-type"}, not an `SdkError`{lang="ts-type"}, so it carries no `code` to match on. That inconsistency is tracked in [#155](https://github.com/bitrix24/b24jssdk/issues/155); until it is resolved, do not write a `catch` that keys off `error.code` here.
+Sends `setInstallFinish` to the parent. The returned promise **rejects** with an `SdkError`{lang="ts-type"} whose `code` is `JSSDK_FRAME_INSTALL_ALREADY_FINISHED`{lang="ts-type"} (message: `Application was previously installed. You cannot call installFinish`) when called outside install mode — guard with `isInstallMode`.
 
 ::warning
 **An application with an installation interface that never calls this stays half-installed, and the portal does not deliver events to it.** Handlers bound with `event.bind` never fire, placements bound with `placement.bind` never appear, and other outgoing calls never reach your endpoints — even though each of those registration calls returned success.

--- a/docs/content/docs/2.working-with-the-rest-api/40.oauth.md
+++ b/docs/content/docs/2.working-with-the-rest-api/40.oauth.md
@@ -167,7 +167,7 @@ Remove with `$b24.removeCustomRefreshAuth()`.
 initIsAdmin(requestId?: string): Promise<void>
 ```
 
-Calls the `profile` REST method once and caches whether the authenticated user has admin rights. Required before reading [`auth.isAdmin`](#getter-auth) — the getter throws `Error('isAdmin not init. You need call B24OAuth::initIsAdmin().')` when called too early.
+Calls the `profile` REST method once and caches whether the authenticated user has admin rights. Required before reading [`auth.isAdmin`](#getter-auth) — the getter throws an `SdkError`{lang="ts-type"} whose `code` is `JSSDK_OAUTH_IS_ADMIN_NOT_INIT`{lang="ts-type"} (message: `isAdmin not init. You need call B24OAuth::initIsAdmin().`) when called too early.
 
 // @check-ignore: B24OAuth-specific method, ambient $b24 is typed as B24Frame
 ```ts

--- a/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
+++ b/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
@@ -49,6 +49,20 @@ These codes propagate through the promise rejection path. Wrap your calls in `tr
 | `PULL_DISPOSED` | `PullClient.start()` called after `destroy()` — create a new instance. |
 | `JSSDK_FRAME_DISPOSED` | A frame command was still waiting on the parent window when `B24Frame.destroy()` ran — nothing can answer it now. |
 | `JSSDK_FRAME_BAD_PAYLOAD` | The parent window answered a frame command with a payload that is not valid JSON. |
+| `JSSDK_FRAME_APP_SID_NOT_INIT` | `getAppSid()` before the frame handshake completed — the parent never delivered an `appSid`. |
+| `JSSDK_FRAME_INSTALL_ALREADY_FINISHED` | `installFinish()` called outside install mode — guard with `isInstallMode`. |
+| `JSSDK_HOOK_URL_EMPTY` | `B24Hook.fromWebhookUrl()` — the URL is empty. |
+| `JSSDK_HOOK_URL_INVALID` | `B24Hook.fromWebhookUrl()` — the URL does not parse. The message never echoes the URL: it carries the secret. |
+| `JSSDK_HOOK_URL_NOT_HTTPS` | `B24Hook.fromWebhookUrl()` — webhooks require HTTPS. |
+| `JSSDK_HOOK_URL_MALFORMED` | `B24Hook.fromWebhookUrl()` — the path is not `/rest/<userId>/<secret>` or `/rest/api/<userId>/<secret>`. |
+| `JSSDK_HOOK_URL_USER_ID_NOT_NUMERIC` | `B24Hook.fromWebhookUrl()` — the userId segment is not numeric (a transposed URL puts the secret there; the message never echoes it). |
+| `JSSDK_OAUTH_TOKEN_REFRESH_FAILED` | The OAuth server answered the token refresh with an error payload. |
+| `JSSDK_OAUTH_TOKEN_REFRESH_BAD_STATUS` | The token refresh returned a non-200 status (carried as `status`). |
+| `JSSDK_OAUTH_TOKEN_REFRESH_NO_DATA` | The token refresh produced no authorization data. |
+| `JSSDK_OAUTH_IS_ADMIN_NOT_INIT` | `isAdmin` read before `B24OAuth.initIsAdmin()` populated it. |
+| `JSSDK_OAUTH_PROFILE_FAILED` | The `profile` call behind `initIsAdmin()` failed; the description carries the portal's error text. |
+| `JSSDK_HELPER_NOT_INIT` | A `useB24Helper()` accessor before `initB24Helper()`. |
+| `JSSDK_HELPER_PULL_CLIENT_NOT_INIT` | A Pull accessor before `usePullClient()`. |
 
 ## Soft Errors (returned in `AjaxResult`)
 

--- a/docs/content/docs/99.examples/1.dashboard-deals-csv.md
+++ b/docs/content/docs/99.examples/1.dashboard-deals-csv.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Export deals to CSV'
 description: 'Stream every CRM deal that matches a date filter into a CSV file using a webhook and FetchListV2.'
-audited: 2026-08-18
+audited: 2026-08-24
 category: 'examples'
 featured: true
 cookbookOrder: 2

--- a/docs/content/docs/99.examples/2.frame-app-skeleton.md
+++ b/docs/content/docs/99.examples/2.frame-app-skeleton.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Frame app skeleton'
 description: 'Minimum viable Bitrix24 iframe app: init handshake, set title, persist app state, open a slider, close cleanly.'
-audited: 2026-08-18
+audited: 2026-08-24
 category: 'examples'
 featured: true
 cookbookOrder: 4

--- a/docs/content/docs/99.examples/20.app-installation-wizard.md
+++ b/docs/content/docs/99.examples/20.app-installation-wizard.md
@@ -72,7 +72,7 @@ async function run() {
 run().catch(console.error)
 ```
 
-`installFinish()`'s promise **rejects** with `Error('Application was previously installed. You cannot call installFinish')` when the application is no longer in install mode — guard with `isInstallMode`.
+`installFinish()`'s promise **rejects** with an `SdkError` — `code: 'JSSDK_FRAME_INSTALL_ALREADY_FINISHED'` — when the application is no longer in install mode; guard with `isInstallMode`.
 
 ::warning
 **Never skipping `installFinish()` is the whole point of this recipe.** A wizard-style app that does not finalise its installation stays half-installed, and the portal does not deliver events to it: handlers bound with `event.bind` never fire and placements bound with `placement.bind` never appear, even though both registration calls returned success. This is [Bitrix24's documented behaviour](https://apidocs.bitrix24.com/settings/app-installation/installation-finish.html#what-doesnt-work-until-installation-is-complete).

--- a/docs/content/docs/99.examples/3.webhook-cli-node.md
+++ b/docs/content/docs/99.examples/3.webhook-cli-node.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Webhook CLI smoke test'
 description: 'A 30-line Node script that authenticates against a Bitrix24 portal via inbound webhook and prints the calling user — useful as the first thing you run after creating a webhook.'
-audited: 2026-07-02
+audited: 2026-08-24
 category: 'examples'
 featured: true
 cookbookOrder: 1

--- a/docs/content/docs/99.examples/4.bulk-update-deals.md
+++ b/docs/content/docs/99.examples/4.bulk-update-deals.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Bulk update deals'
 description: 'Migrate thousands of CRM deals to a new stage using BatchByChunkV2 — automatic chunking, partial-error handling, and a single progress line.'
-audited: 2026-06-28
+audited: 2026-08-24
 category: 'examples'
 featured: true
 cookbookOrder: 3

--- a/docs/content/docs/99.examples/5.pull-subscribe-frame.md
+++ b/docs/content/docs/99.examples/5.pull-subscribe-frame.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Subscribe to Pull events'
 description: 'Open a live channel from a Bitrix24 frame app and react to push events using useB24Helper + the Pull client.'
-audited: 2026-08-18
+audited: 2026-08-24
 category: 'examples'
 featured: true
 cookbookOrder: 5

--- a/packages/jssdk/src/frame/b24.ts
+++ b/packages/jssdk/src/frame/b24.ts
@@ -1,3 +1,4 @@
+import { SdkError } from '../core/sdk-error'
 import type { LoggerInterface } from '../logger'
 import type { B24LangList } from '../core/language/list'
 import type { AuthActions, MessageInitData, B24FrameQueryParams } from '../types/auth'
@@ -181,7 +182,7 @@ export class B24Frame extends AbstractB24 implements TypeB24 {
    */
   public async installFinish(): Promise<any> {
     if (!this.isInstallMode) {
-      return Promise.reject(new Error('Application was previously installed. You cannot call installFinish'))
+      return Promise.reject(new SdkError({ code: 'JSSDK_FRAME_INSTALL_ALREADY_FINISHED', description: 'Application was previously installed. You cannot call installFinish', status: 0 }))
     }
 
     return this.#messageManager.send(MessageCommands.setInstallFinish, {})

--- a/packages/jssdk/src/frame/frame.ts
+++ b/packages/jssdk/src/frame/frame.ts
@@ -1,3 +1,4 @@
+import { SdkError } from '../core/sdk-error'
 import type { B24FrameQueryParams, MessageInitData } from '../types/auth'
 import { B24LangList } from '../core/language/list'
 import { ApiVersion } from '../types/b24'
@@ -76,7 +77,7 @@ export class AppFrame {
    */
   getAppSid(): string {
     if (null === this.#appSid) {
-      throw new Error(`Not init appSid`)
+      throw new SdkError({ code: 'JSSDK_FRAME_APP_SID_NOT_INIT', description: 'Not init appSid', status: 0 })
     }
 
     return this.#appSid

--- a/packages/jssdk/src/helper/use-b24-helper.ts
+++ b/packages/jssdk/src/helper/use-b24-helper.ts
@@ -1,3 +1,4 @@
+import { SdkError } from '../core/sdk-error'
 import { B24HelperManager } from './helper-manager'
 import { LoadDataType } from '../types/b24-helper'
 import type { TypeB24 } from '../types/b24'
@@ -41,9 +42,11 @@ export const useB24Helper = () => {
 
   const getB24Helper = (): B24HelperManager => {
     if (null === $b24Helper) {
-      throw new Error(
-        'B24HelperManager is not initialized. You need to call initB24Helper first.'
-      )
+      throw new SdkError({
+        code: 'JSSDK_HELPER_NOT_INIT',
+        description: 'B24HelperManager is not initialized. You need to call initB24Helper first.',
+        status: 0
+      })
     }
 
     return $b24Helper
@@ -51,9 +54,11 @@ export const useB24Helper = () => {
 
   const usePullClient = () => {
     if (null === $b24Helper) {
-      throw new Error(
-        'B24HelperManager is not initialized. You need to call initB24Helper first.'
-      )
+      throw new SdkError({
+        code: 'JSSDK_HELPER_NOT_INIT',
+        description: 'B24HelperManager is not initialized. You need to call initB24Helper first.',
+        status: 0
+      })
     }
 
     $b24Helper.usePullClient()
@@ -65,9 +70,11 @@ export const useB24Helper = () => {
     moduleId: string = 'application'
   ) => {
     if (!$isInitPullClient) {
-      throw new Error(
-        'PullClient is not initialized. You need to call usePullClient first.'
-      )
+      throw new SdkError({
+        code: 'JSSDK_HELPER_PULL_CLIENT_NOT_INIT',
+        description: 'PullClient is not initialized. You need to call usePullClient first.',
+        status: 0
+      })
     }
 
     $b24Helper?.subscribePullClient(callback, moduleId)
@@ -75,9 +82,11 @@ export const useB24Helper = () => {
 
   const startPullClient = () => {
     if (!$isInitPullClient) {
-      throw new Error(
-        'PullClient is not initialized. You need to call usePullClient first.'
-      )
+      throw new SdkError({
+        code: 'JSSDK_HELPER_PULL_CLIENT_NOT_INIT',
+        description: 'PullClient is not initialized. You need to call usePullClient first.',
+        status: 0
+      })
     }
 
     $b24Helper?.startPullClient()

--- a/packages/jssdk/src/hook/b24.ts
+++ b/packages/jssdk/src/hook/b24.ts
@@ -1,3 +1,4 @@
+import { SdkError } from '../core/sdk-error'
 import type { AuthActions, B24HookParams } from '../types/auth'
 import type { RestrictionParams } from '../types/limiters'
 import type { TypeB24, ApiVersion } from '../types/b24'
@@ -107,7 +108,7 @@ export class B24Hook extends AbstractB24 implements TypeB24 {
     options?: { restrictionParams?: Partial<RestrictionParams> }
   ): B24Hook {
     if (!url.trim()) {
-      throw new Error('Webhook URL cannot be empty')
+      throw new SdkError({ code: 'JSSDK_HOOK_URL_EMPTY', description: 'Webhook URL cannot be empty', status: 0 })
     }
 
     let parsedUrl: URL
@@ -116,11 +117,11 @@ export class B24Hook extends AbstractB24 implements TypeB24 {
       parsedUrl = new URL(url.replace('/rest/api', '/rest'))
     } catch {
       // Don't echo the URL — it carries the webhook secret in its path (#43).
-      throw new Error('Invalid webhook URL format')
+      throw new SdkError({ code: 'JSSDK_HOOK_URL_INVALID', description: 'Invalid webhook URL format', status: 0 })
     }
 
     if (parsedUrl.protocol !== 'https:') {
-      throw new Error('Webhook requires HTTPS protocol')
+      throw new SdkError({ code: 'JSSDK_HOOK_URL_NOT_HTTPS', description: 'Webhook requires HTTPS protocol', status: 0 })
     }
 
     const pathParts = parsedUrl.pathname.split('/').filter(Boolean)
@@ -132,7 +133,7 @@ export class B24Hook extends AbstractB24 implements TypeB24 {
     )
 
     if (!isValidFormat) {
-      throw new Error('Webhook URL must follow format: /rest/<userId>/<secret> or /rest/api/<userId>/<secret>')
+      throw new SdkError({ code: 'JSSDK_HOOK_URL_MALFORMED', description: 'Webhook URL must follow format: /rest/<userId>/<secret> or /rest/api/<userId>/<secret>', status: 0 })
     }
 
     // Determine the position of userId and secret depending on the format
@@ -144,7 +145,7 @@ export class B24Hook extends AbstractB24 implements TypeB24 {
 
     if (!/^\d+$/.test(userIdStr)) {
       // Don't echo the segment — in a transposed URL it could be the secret (#43).
-      throw new Error('User ID must be numeric in webhook URL')
+      throw new SdkError({ code: 'JSSDK_HOOK_URL_USER_ID_NOT_NUMERIC', description: 'User ID must be numeric in webhook URL', status: 0 })
     }
     const userId = Number.parseInt(userIdStr, 10)
 

--- a/packages/jssdk/src/hook/b24.ts
+++ b/packages/jssdk/src/hook/b24.ts
@@ -101,7 +101,10 @@ export class B24Hook extends AbstractB24 implements TypeB24 {
    * @param url - Full webhook URL as shown in the Bitrix24 admin panel.
    * @param options - Optional restriction parameters (rate limits, etc.).
    * @returns A ready-to-use `B24Hook` instance.
-   * @throws {Error} If the URL is empty, not HTTPS, or has an invalid format.
+   * @throws {SdkError} If the URL is empty (`JSSDK_HOOK_URL_EMPTY`), unparseable
+   *     (`JSSDK_HOOK_URL_INVALID`), not HTTPS (`JSSDK_HOOK_URL_NOT_HTTPS`),
+   *     malformed (`JSSDK_HOOK_URL_MALFORMED`), or the userId segment is not
+   *     numeric (`JSSDK_HOOK_URL_USER_ID_NOT_NUMERIC`).
    */
   public static fromWebhookUrl(
     url: string,

--- a/packages/jssdk/src/oauth/auth.ts
+++ b/packages/jssdk/src/oauth/auth.ts
@@ -1,3 +1,4 @@
+import { SdkError } from '../core/sdk-error'
 import type { AxiosInstance } from 'axios'
 import type { AuthActions, AuthData, B24OAuthParams, B24OAuthSecret, CallbackRefreshAuth, CustomRefreshAuth, HandlerRefreshAuth, TypeDescriptionError, TypeDescriptionErrorV3 } from '../types/auth'
 import type { TypeHttp } from '../types/http'
@@ -110,10 +111,10 @@ export class AuthOAuthManager implements AuthActions {
         )
 
         if (response.data.error) {
-          throw new Error(`Token update error: ${response.data.error}`)
+          throw new SdkError({ code: 'JSSDK_OAUTH_TOKEN_REFRESH_FAILED', description: `Token update error: ${response.data.error}`, status: 0 })
         }
         if (response.status !== 200) {
-          throw new Error(`Token update error status code: ${response.status}`)
+          throw new SdkError({ code: 'JSSDK_OAUTH_TOKEN_REFRESH_BAD_STATUS', description: `Token update error status code: ${response.status}`, status: response.status })
         }
 
         /**
@@ -123,7 +124,7 @@ export class AuthOAuthManager implements AuthActions {
       }
 
       if (!payload) {
-        throw new Error('Unable to obtain authorization update data')
+        throw new SdkError({ code: 'JSSDK_OAUTH_TOKEN_REFRESH_NO_DATA', description: 'Unable to obtain authorization update data', status: 0 })
       }
 
       this.#authOptions.accessToken = payload.access_token
@@ -187,6 +188,13 @@ export class AuthOAuthManager implements AuthActions {
 
       // Both `instanceof Error` branches above have already rethrown, so `error`
       // here is always a non-Error value — carry it as the cause verbatim.
+      // Deliberately a bare Error, not SdkError: this is the last-resort catch for a
+      // NON-Error thrown value, and its job is to carry that value through
+      // transparently as the standard `.cause` (#320, regression-tested in
+      // error-cause.unit.spec.ts). SdkError exposes the original via the
+      // non-enumerable `originalError`, not `.cause`, so wrapping here would drop
+      // the tested `.cause` contract for no gain — a stable `.code` adds nothing
+      // to a "something non-Error was thrown" fallback (#155 reasoned exception).
       throw new Error(`Strange error: ${String(error)}`, { cause: error })
     }
   }
@@ -231,7 +239,7 @@ export class AuthOAuthManager implements AuthActions {
    */
   get isAdmin(): boolean {
     if (null === this.#isAdmin) {
-      throw new Error('isAdmin not init. You need call B24OAuth::initIsAdmin().')
+      throw new SdkError({ code: 'JSSDK_OAUTH_IS_ADMIN_NOT_INIT', description: 'isAdmin not init. You need call B24OAuth::initIsAdmin().', status: 0 })
     }
 
     return this.#isAdmin
@@ -249,7 +257,7 @@ export class AuthOAuthManager implements AuthActions {
     if (http.apiVersion === ApiVersion.v3) {
       const response = await http.call('profile', {}, requestId)
       if (!response.isSuccess) {
-        throw new Error(response.getErrorMessages().join(';'))
+        throw new SdkError({ code: 'JSSDK_OAUTH_PROFILE_FAILED', description: response.getErrorMessages().join(';'), status: 0 })
       }
 
       const data: { profile: { id: number, admin: boolean } } = response.getData()!.result as any
@@ -265,7 +273,7 @@ export class AuthOAuthManager implements AuthActions {
     // region ver2 ////
     const response = await http.call('profile', {}, requestId)
     if (!response.isSuccess) {
-      throw new Error(response.getErrorMessages().join(';'))
+      throw new SdkError({ code: 'JSSDK_OAUTH_PROFILE_FAILED', description: response.getErrorMessages().join(';'), status: 0 })
     }
 
     const data: { ID: number, ADMIN: boolean } = response.getData()!.result as any

--- a/packages/jssdk/src/oauth/auth.ts
+++ b/packages/jssdk/src/oauth/auth.ts
@@ -195,6 +195,11 @@ export class AuthOAuthManager implements AuthActions {
       // non-enumerable `originalError`, not `.cause`, so wrapping here would drop
       // the tested `.cause` contract for no gain — a stable `.code` adds nothing
       // to a "something non-Error was thrown" fallback (#155 reasoned exception).
+      // Trade-off, stated plainly: unlike SdkError.originalError, `.cause` is
+      // ENUMERABLE — a property-walking serializer (Sentry et al.) WILL see the
+      // carried value. This is the one throw site where the #189 non-enumerability
+      // guarantee does not apply, reachable only when third-party code threw a
+      // non-Error value.
       throw new Error(`Strange error: ${String(error)}`, { cause: error })
     }
   }

--- a/packages/jssdk/src/oauth/b24.ts
+++ b/packages/jssdk/src/oauth/b24.ts
@@ -2,6 +2,7 @@ import type { AuthActions, B24OAuthParams, B24OAuthSecret, CallbackRefreshAuth, 
 import type { RestrictionParams } from '../types/limiters'
 import type { TypeB24, ApiVersion } from '../types/b24'
 import { AbstractB24 } from '../core/abstract-b24'
+import { SdkError } from '../core/sdk-error'
 import { HttpV2 } from '../core/http/v2'
 import { HttpV3 } from '../core/http/v3'
 import { AuthOAuthManager } from './auth'
@@ -63,8 +64,18 @@ export class B24OAuth extends AbstractB24 implements TypeB24 {
     try {
       const version = versionManager.automaticallyObtainApiVersion(method)
       const client = this.getHttpClient(version)
-      return this.#authOAuthManager.initIsAdmin(client, requestId)
-    } catch {
+      return await this.#authOAuthManager.initIsAdmin(client, requestId)
+    } catch (error) {
+      // Fail closed, but not silently. The admin flag defaults to `false`
+      // (`AuthOAuthManager.initIsAdmin` sets it before the call), so a failed
+      // `profile` request leaves the safe least-privilege value — this method
+      // deliberately does not throw, so wiring it into init cannot take the app
+      // down. But swallowing the error entirely made "not an admin" and
+      // "the profile call failed" indistinguishable (#155); the failure is now
+      // surfaced to the logger so it is at least visible.
+      this.getLogger().error('initIsAdmin: profile lookup failed; treating the user as non-admin', {
+        code: error instanceof SdkError ? error.code : 'JSSDK_OAUTH_IS_ADMIN_LOOKUP_FAILED'
+      }).catch(() => {})
       return
     }
   }

--- a/packages/jssdk/src/oauth/b24.ts
+++ b/packages/jssdk/src/oauth/b24.ts
@@ -64,16 +64,19 @@ export class B24OAuth extends AbstractB24 implements TypeB24 {
     try {
       const version = versionManager.automaticallyObtainApiVersion(method)
       const client = this.getHttpClient(version)
-      return await this.#authOAuthManager.initIsAdmin(client, requestId)
+      // Deliberately NOT awaited inside the try: the async half — the `profile`
+      // request itself — has always propagated its rejection to the caller
+      // (now as JSSDK_OAUTH_PROFILE_FAILED), and awaiting here would silently
+      // widen this catch to swallow it, making failures LESS visible — the
+      // opposite of #155's intent.
+      return this.#authOAuthManager.initIsAdmin(client, requestId)
     } catch (error) {
-      // Fail closed, but not silently. The admin flag defaults to `false`
-      // (`AuthOAuthManager.initIsAdmin` sets it before the call), so a failed
-      // `profile` request leaves the safe least-privilege value — this method
-      // deliberately does not throw, so wiring it into init cannot take the app
-      // down. But swallowing the error entirely made "not an admin" and
-      // "the profile call failed" indistinguishable (#155); the failure is now
-      // surfaced to the logger so it is at least visible.
-      this.getLogger().error('initIsAdmin: profile lookup failed; treating the user as non-admin', {
+      // This catch therefore covers only the synchronous setup (version
+      // resolution, client lookup). It used to be `catch { return }`, which hid
+      // even that; the failure is now surfaced to the logger before returning.
+      // Fail closed: the admin flag defaults to `false` (least privilege), so
+      // returning leaves the safe value (#155).
+      this.getLogger().error('initIsAdmin: setup failed before the profile call; treating the user as non-admin', {
         code: error instanceof SdkError ? error.code : 'JSSDK_OAUTH_IS_ADMIN_LOOKUP_FAILED'
       }).catch(() => {})
       return

--- a/test/integration/core/sdkerror-public-entrypoints.unit.spec.ts
+++ b/test/integration/core/sdkerror-public-entrypoints.unit.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * #155 — public entry points throw `SdkError` with a stable `code`, not a bare
+ * `Error`. Consumers are told to discriminate on `SdkError.code`; these paths
+ * used to break that contract with `throw new Error(...)`.
+ *
+ * `SdkError.formatErrorMessage` returns the `description` verbatim, so converting
+ * a bare throw to an SdkError with the same description keeps `error.message`
+ * identical — the conversion is additive (`instanceof Error` still holds, a new
+ * `.code` appears), not a breaking message change. These assertions pin the code
+ * on each path so a future edit cannot silently drop back to a bare Error.
+ *
+ * Portal-free (jsSdk:unit).
+ */
+import { describe, it, expect } from 'vitest'
+import { B24Hook } from '../../../packages/jssdk/src/'
+import { SdkError } from '../../../packages/jssdk/src/core/sdk-error'
+
+/** Run `fn`, return the thrown value (fails the test if nothing throws). */
+function caught(fn: () => unknown): unknown {
+  try {
+    fn()
+  } catch (e) {
+    return e
+  }
+  throw new Error('expected the call to throw, but it did not')
+}
+
+describe('#155 B24Hook.fromWebhookUrl throws SdkError with a stable code', () => {
+  const cases: Array<[string, string, string]> = [
+    ['empty URL', '   ', 'JSSDK_HOOK_URL_EMPTY'],
+    ['unparseable URL', 'rest/1/secret', 'JSSDK_HOOK_URL_INVALID'],
+    ['non-https URL', 'http://x.bitrix24.com/rest/1/secret/', 'JSSDK_HOOK_URL_NOT_HTTPS'],
+    ['malformed path', 'https://x.bitrix24.com/nope/', 'JSSDK_HOOK_URL_MALFORMED'],
+    ['non-numeric userId', 'https://x.bitrix24.com/rest/notanumber/secret/', 'JSSDK_HOOK_URL_USER_ID_NOT_NUMERIC']
+  ]
+
+  it.each(cases)('%s → SdkError %s', (_label, url, code) => {
+    const error = caught(() => B24Hook.fromWebhookUrl(url))
+    expect(error).toBeInstanceOf(SdkError)
+    // still an Error — instanceof and try/catch are unchanged.
+    expect(error).toBeInstanceOf(Error)
+    expect((error as SdkError).code).toBe(code)
+  })
+
+  it('keeps the message text identical to the pre-conversion bare Error', () => {
+    // SdkError.formatErrorMessage returns the description verbatim (no code
+    // prefix), so a consumer matching on message text is not broken.
+    const error = caught(() => B24Hook.fromWebhookUrl('   ')) as SdkError
+    expect(error.message).toBe('Webhook URL cannot be empty')
+  })
+})

--- a/test/integration/core/sdkerror-public-entrypoints.unit.spec.ts
+++ b/test/integration/core/sdkerror-public-entrypoints.unit.spec.ts
@@ -84,3 +84,60 @@ describe('#155 the other converted entry points carry stable codes too', () => {
     expect((error as SdkError).code).toBe('JSSDK_OAUTH_IS_ADMIN_NOT_INIT')
   })
 })
+
+describe('#155 frame and remaining helper/oauth codes', () => {
+  it('AppFrame.getAppSid() before the handshake → JSSDK_FRAME_APP_SID_NOT_INIT', async () => {
+    const { AppFrame } = await import('../../../packages/jssdk/src/frame/frame')
+    // No APP_SID in the query params — the parent never delivered one.
+    const frame = new AppFrame({ DOMAIN: 'portal.bitrix24.com', PROTOCOL: true, LANG: 'en', APP_SID: null } as never)
+    const error = caught(() => frame.getAppSid())
+    expect(error).toBeInstanceOf(SdkError)
+    expect((error as SdkError).code).toBe('JSSDK_FRAME_APP_SID_NOT_INIT')
+    expect((error as SdkError).message).toBe('Not init appSid')
+  })
+
+  it('usePullClient() before initB24Helper → JSSDK_HELPER_NOT_INIT', async () => {
+    const { useB24Helper } = await import('../../../packages/jssdk/src/helper/use-b24-helper')
+    const { usePullClient } = useB24Helper()
+    const error = caught(() => usePullClient())
+    expect(error).toBeInstanceOf(SdkError)
+    expect((error as SdkError).code).toBe('JSSDK_HELPER_NOT_INIT')
+  })
+
+  it('startPullClient() before usePullClient → JSSDK_HELPER_PULL_CLIENT_NOT_INIT', async () => {
+    const { useB24Helper } = await import('../../../packages/jssdk/src/helper/use-b24-helper')
+    const { startPullClient } = useB24Helper()
+    const error = caught(() => startPullClient())
+    expect(error).toBeInstanceOf(SdkError)
+    expect((error as SdkError).code).toBe('JSSDK_HELPER_PULL_CLIENT_NOT_INIT')
+  })
+
+  it('initIsAdmin() with a failing profile call rejects with JSSDK_OAUTH_PROFILE_FAILED', async () => {
+    const { AuthOAuthManager } = await import('../../../packages/jssdk/src/oauth/auth')
+    const { ApiVersion } = await import('../../../packages/jssdk/src/types/b24')
+    const mgr = new AuthOAuthManager({
+      domain: 'https://portal.bitrix24.com',
+      clientEndpoint: 'https://portal.bitrix24.com/rest/',
+      serverEndpoint: 'https://oauth.bitrix24.tech/rest/',
+      expires: 0, expiresIn: 3600,
+      accessToken: 'A', refreshToken: 'R',
+      memberId: 'm', scope: 's', status: 'L'
+    } as never, { clientId: 'id', clientSecret: 'secret' } as never)
+
+    // A TypeHttp stub whose profile call soft-fails with the portal's own text.
+    const http = {
+      apiVersion: ApiVersion.v2,
+      call: async () => ({
+        isSuccess: false,
+        getErrorMessages: () => ['insufficient_scope', 'profile denied']
+      })
+    } as never
+
+    const error = await mgr.initIsAdmin(http).then(() => null, (e: unknown) => e)
+    expect(error).toBeInstanceOf(SdkError)
+    expect((error as SdkError).code).toBe('JSSDK_OAUTH_PROFILE_FAILED')
+    // description carries the portal's own error text, joined — the caller can
+    // still read why.
+    expect((error as SdkError).message).toBe('insufficient_scope;profile denied')
+  })
+})

--- a/test/integration/core/sdkerror-public-entrypoints.unit.spec.ts
+++ b/test/integration/core/sdkerror-public-entrypoints.unit.spec.ts
@@ -49,3 +49,38 @@ describe('#155 B24Hook.fromWebhookUrl throws SdkError with a stable code', () =>
     expect(error.message).toBe('Webhook URL cannot be empty')
   })
 })
+
+describe('#155 the other converted entry points carry stable codes too', () => {
+  it('useB24Helper.getB24Helper() before init → JSSDK_HELPER_NOT_INIT', async () => {
+    const { useB24Helper } = await import('../../../packages/jssdk/src/helper/use-b24-helper')
+    const { getB24Helper } = useB24Helper()
+    const error = caught(() => getB24Helper())
+    expect(error).toBeInstanceOf(SdkError)
+    expect((error as SdkError).code).toBe('JSSDK_HELPER_NOT_INIT')
+    // message parity with the pre-conversion bare Error
+    expect((error as SdkError).message).toBe('B24HelperManager is not initialized. You need to call initB24Helper first.')
+  })
+
+  it('useB24Helper.useSubscribePullClient() before usePullClient → JSSDK_HELPER_PULL_CLIENT_NOT_INIT', async () => {
+    const { useB24Helper } = await import('../../../packages/jssdk/src/helper/use-b24-helper')
+    const { useSubscribePullClient } = useB24Helper()
+    const error = caught(() => useSubscribePullClient(() => {}))
+    expect(error).toBeInstanceOf(SdkError)
+    expect((error as SdkError).code).toBe('JSSDK_HELPER_PULL_CLIENT_NOT_INIT')
+  })
+
+  it('AuthOAuthManager.isAdmin before initIsAdmin → JSSDK_OAUTH_IS_ADMIN_NOT_INIT', async () => {
+    const { AuthOAuthManager } = await import('../../../packages/jssdk/src/oauth/auth')
+    const mgr = new AuthOAuthManager({
+      domain: 'https://portal.bitrix24.com',
+      clientEndpoint: 'https://portal.bitrix24.com/rest/',
+      serverEndpoint: 'https://oauth.bitrix24.tech/rest/',
+      expires: 0, expiresIn: 3600,
+      accessToken: 'A', refreshToken: 'R',
+      memberId: 'm', scope: 's', status: 'L'
+    } as never, { clientId: 'id', clientSecret: 'secret' } as never)
+    const error = caught(() => mgr.isAdmin)
+    expect(error).toBeInstanceOf(SdkError)
+    expect((error as SdkError).code).toBe('JSSDK_OAUTH_IS_ADMIN_NOT_INIT')
+  })
+})


### PR DESCRIPTION
Closes #155.

`AGENTS.md` mandates *"Errors use `SdkError`… no bare throws"*, but bare `throw new Error(...)` remained in `B24Hook.fromWebhookUrl`, `B24Frame.getAppSid` / `installFinish`, the OAuth `AuthManager`, and the helper composable. Consumers are told to discriminate on `SdkError.code`; these paths broke that contract.

### The conversion is additive, not breaking

`SdkError.formatErrorMessage` returns the `description` verbatim — no code prefix. So converting `throw new Error('Webhook URL cannot be empty')` to an `SdkError` with the same description keeps `error.message` **byte-identical**, `instanceof Error` still holds, and a `.code` simply appears. A message-matching consumer is not broken; a code-matching one now works.

| Site | Code(s) |
| --- | --- |
| `B24Hook.fromWebhookUrl` | `JSSDK_HOOK_URL_EMPTY` / `_INVALID` / `_NOT_HTTPS` / `_MALFORMED` / `_USER_ID_NOT_NUMERIC` |
| `B24Frame.getAppSid` | `JSSDK_FRAME_APP_SID_NOT_INIT` |
| `B24Frame.installFinish` | `JSSDK_FRAME_INSTALL_ALREADY_FINISHED` |
| OAuth token refresh | `JSSDK_OAUTH_TOKEN_REFRESH_FAILED` / `_BAD_STATUS` / `_NO_DATA` |
| OAuth admin flag | `JSSDK_OAUTH_IS_ADMIN_NOT_INIT`, `JSSDK_OAUTH_PROFILE_FAILED` |
| helper composable | `JSSDK_HELPER_NOT_INIT`, `JSSDK_HELPER_PULL_CLIENT_NOT_INIT` |

### Two judgment calls, made deliberately

**`B24OAuth.initIsAdmin` no longer swallows silently.** It was `catch { return }`, so *"not an admin"* and *"the profile call failed"* were indistinguishable (#155's bonus finding). It now **logs** the failure before returning. The no-throw contract is kept **on purpose**: the admin flag defaults to `false` (least privilege), so a failed `profile` call fails closed, and wiring this into init must not take the app down. Making the caller able to distinguish the two would mean rethrowing — a separate, behaviour-changing decision I did not take unilaterally.

**The `refreshAuth` "Strange error" last-resort catch stays a bare `Error` with `{ cause }`.** Its job is to carry an arbitrary **non-Error** thrown value through transparently as the standard `.cause` (#320, regression-tested in `error-cause.unit.spec.ts`). `SdkError` exposes the original via the non-enumerable `originalError`, **not** `.cause`, so wrapping here would drop the tested `.cause` contract for no gain — a stable `.code` adds nothing to a "something non-Error was thrown" fallback. Documented inline as a reasoned exception; converting it broke the spec, which is what surfaced the decision.

### Docs / follow-up

`installFinish` now rejects an `SdkError`, so the frame reference and the installation-wizard recipe — which #377 wrote as *"a bare `Error`, tracked in #155"* — are updated to name the code. That resolves the code half of #379 (its message-pinning test still wants the frame harness).

### Verification

New spec `sdkerror-public-entrypoints.unit.spec.ts` pins every hook code and asserts message parity. Full suite **470 passing** (was 464 — the 6 new plus the `error-cause` spec still green, which is the proof the `.cause` exception was necessary). `eslint` (one pre-existing warning in `docs/server/api/ai.post.ts`), full `typecheck` (all eight passes), `docs-lint --strict`, `docs:typecheck-blocks`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_