### PR TITLE
docs: add an API Reference section indexing the public surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Check guide internal links (AGENTS.md + .github/contributing)
         run: node scripts/md-internal-links.mjs
 
+      - name: Check the API Reference index covers every public export
+        run: node scripts/check-api-reference-index.mjs
+
       - name: Test docs-lint scripts
         run: node --test "scripts/__tests__/**/*.test.mjs"
 

--- a/docs/content/docs/3.api-reference/.navigation.yml
+++ b/docs/content/docs/3.api-reference/.navigation.yml
@@ -1,0 +1,1 @@
+title: API Reference

--- a/docs/content/docs/3.api-reference/1.index.md
+++ b/docs/content/docs/3.api-reference/1.index.md
@@ -9,9 +9,9 @@ links:
     to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/index.ts
 ---
 
-This is the index of everything `@bitrix24/b24jssdk` exports publicly, grouped by domain. Each entry says what the export is and links to its guide and its source.
+This is the index of every **value** `@bitrix24/b24jssdk` exports publicly — the classes, enums, constants and functions you can import and use at runtime — grouped by domain. Each entry says what the export is and links to its guide and its source. Pure `type` and `interface` exports are not listed here; they have their own page, the [Types overview](/docs/working-with-the-rest-api/types-index/).
 
-It deliberately does **not** restate signatures and parameter tables: those live in the guides, where they are audited against the source and their snippets are compiled in CI. This page is the map, not the territory.
+It deliberately does **not** restate signatures and parameter tables: those live in the guides, where they are audited against the source and their snippets are compiled in CI. This page is the map, not the territory. Per-symbol reference pages are a separate, later layer — tracked in [#315](https://github.com/bitrix24/b24jssdk/issues/315).
 
 ::note
 New here? Start with [Get Started](/docs/getting-started/) and pick an entry point below — that choice determines everything else.
@@ -26,7 +26,7 @@ Pick by **where your code runs** — this is the first decision, and everything 
 | [`B24Hook`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/hook/b24.ts) | Server-side webhook auth. Carries a long-lived secret — never ship it to a browser. | [guide](/docs/working-with-the-rest-api/hook/) |
 | [`B24Frame`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/b24.ts) | An app running inside a Bitrix24 placement iframe. | [guide](/docs/working-with-the-rest-api/frame/) |
 | [`initializeB24Frame`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/loader-b24frame.ts) | The only correct way to construct a `B24Frame` — performs the parent handshake. | [guide](/docs/working-with-the-rest-api/frame-initialize-b24-frame/) |
-| [`B24OAuth`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/oauth/b24.ts) | A marketplace/OAuth app, authenticated per portal with a refresh token. | [guide](/docs/working-with-the-rest-api/oauth/) |
+| [`B24OAuth`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/oauth/b24.ts) | A marketplace/OAuth app, authenticated per portal with a refresh token. Server-side only, like `B24Hook` — never ship the client secret to a browser. | [guide](/docs/working-with-the-rest-api/oauth/) |
 | [`AbstractB24`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/abstract-b24.ts) | The shared base the three entry points extend. | [guide](/docs/working-with-the-rest-api/core-http/) |
 | [`AuthHookManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/hook/auth.ts) | Auth actions behind `B24Hook`. | [guide](/docs/working-with-the-rest-api/hook/) |
 | [`AuthOAuthManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/oauth/auth.ts) | Auth actions behind `B24OAuth`, including token refresh. | [guide](/docs/working-with-the-rest-api/oauth/) |
@@ -91,7 +91,7 @@ Available on a `B24Frame` instance — the portal-side UI surface.
 | [`DialogManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/dialog.ts) | `$b24.dialog` — pick users, CRM entities, access targets. | [guide](/docs/working-with-the-rest-api/frame-dialog/) |
 | [`OptionsManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/options.ts) | `$b24.options` — persist app and per-user settings. | [guide](/docs/working-with-the-rest-api/frame-options/) |
 | [`AuthManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/auth.ts) | `$b24.auth` — the frame's auth actions. | [guide](/docs/working-with-the-rest-api/frame-auth/) |
-| [`MessageManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/message/controller.ts) | The `postMessage` bridge to the parent window. | [guide](/docs/working-with-the-rest-api/frame/) |
+| [`MessageManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/message/controller.ts) | The `postMessage` bridge to the parent window, reachable as `$b24.parent.message`. | — |
 
 ## Helper
 
@@ -101,9 +101,10 @@ Aggregated portal state — profile, app, licence, currency.
 | --- | --- | --- |
 | [`useB24Helper`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/helper/use-b24-helper.ts) | Composable that initialises and exposes the helper. | [guide](/docs/working-with-the-rest-api/helper-use-b24-helper/) |
 | [`LoadDataType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts) | Which data sets the helper loads. | [guide](/docs/working-with-the-rest-api/helper/) |
-| [`EnumAppStatus`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts) | Application status values. | [guide](/docs/working-with-the-rest-api/) |
+| [`EnumAppStatus`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts) | Application status values. | [guide](/docs/working-with-the-rest-api/helper-app-manager/) |
 | [`TypeSpecificUrl`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts) | Portal URLs the helper resolves. | [guide](/docs/working-with-the-rest-api/helper/) |
 | [`StatusDescriptions`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts) | Human-readable app-status descriptions. | [guide](/docs/working-with-the-rest-api/helper-app-manager/) |
+| [`TypeOption`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts) | The value-type discriminator `$b24.options` stores settings under. | [guide](/docs/working-with-the-rest-api/helper-options-manager/) |
 
 ## Logging
 
@@ -156,7 +157,6 @@ Typed shapes for the portal's own entities.
 | --- | --- | --- |
 | [`EnumCrmEntityTypeId`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/crm/index.ts) | CRM entity type ids. | [guide](/docs/working-with-the-rest-api/batch-rest-api-ver2/) |
 | [`DataType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/common.ts) | Generic data-type discriminator. | [guide](/docs/working-with-the-rest-api/types-common/) |
-| [`TypeOption`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/common.ts) | Option value shape. | [guide](/docs/working-with-the-rest-api/helper-options-manager/) |
 | [`CatalogProductType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/catalog/index.ts) | Catalog product types. | — |
 | [`ProductRowDiscountTypeId`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/crm/productrow.ts) | Discount types on a product row. | — |
 | [`EnumBizprocDocumentType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/bizproc/index.ts) | Business-process document types. | — |
@@ -175,7 +175,7 @@ These exports are public but have no deep-dive page of their own yet. They are
 listed here rather than quietly omitted, so the gap is a visible, closable list
 instead of something a reader discovers by failing to find it:
 
-`AppFrame` `CatalogProductImageType` `CatalogProductType` `CatalogRoundingRuleType` `CloseReasons` `EnumBitrix24Edition` `EnumBizprocBaseType` `EnumBizprocDocumentType` `EnumCrmEntityType` `EnumCrmEntityTypeShort` `ListRpcError` `LoggerBrowser` `LoggerType` `LsKeys` `MessageCommands` `ProductRowDiscountTypeId` `RpcMethod` `SenderType` `ServerMode` `SystemCommands` `convertBizprocDocumentTypeToCrmEntityTypeId` `getDocumentId` `getDocumentType` `getDocumentTypeForFilter` `getEnumCrmEntityTypeShort` `versionManager`
+`AppFrame` `CatalogProductImageType` `CatalogProductType` `CatalogRoundingRuleType` `CloseReasons` `EnumBitrix24Edition` `EnumBizprocBaseType` `EnumBizprocDocumentType` `EnumCrmEntityType` `EnumCrmEntityTypeShort` `ListRpcError` `LoggerBrowser` `LoggerType` `LsKeys` `MessageCommands` `MessageManager` `ProductRowDiscountTypeId` `RpcMethod` `SenderType` `ServerMode` `SystemCommands` `convertBizprocDocumentTypeToCrmEntityTypeId` `getDocumentId` `getDocumentType` `getDocumentTypeForFilter` `getEnumCrmEntityTypeShort` `versionManager`
 
 Most are enums and type namespaces whose meaning is evident from the source
 linked above. If you needed one of these and the source was not enough, that is

--- a/docs/content/docs/3.api-reference/1.index.md
+++ b/docs/content/docs/3.api-reference/1.index.md
@@ -1,0 +1,182 @@
+---
+title: API Reference
+description: 'Index of the public @bitrix24/b24jssdk surface, grouped by domain — every export, what it is, and where its guide and source live.'
+navigation.title: API Reference
+audited: 2026-08-24
+links:
+  - label: index.ts (the public surface)
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/index.ts
+---
+
+This is the index of everything `@bitrix24/b24jssdk` exports publicly, grouped by domain. Each entry says what the export is and links to its guide and its source.
+
+It deliberately does **not** restate signatures and parameter tables: those live in the guides, where they are audited against the source and their snippets are compiled in CI. This page is the map, not the territory.
+
+::note
+New here? Start with [Get Started](/docs/getting-started/) and pick an entry point below — that choice determines everything else.
+::
+
+## Entry points
+
+Pick by **where your code runs** — this is the first decision, and everything else follows from it.
+
+| Export | What it is | Guide |
+| --- | --- | --- |
+| [`B24Hook`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/hook/b24.ts) | Server-side webhook auth. Carries a long-lived secret — never ship it to a browser. | [guide](/docs/working-with-the-rest-api/hook/) |
+| [`B24Frame`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/b24.ts) | An app running inside a Bitrix24 placement iframe. | [guide](/docs/working-with-the-rest-api/frame/) |
+| [`initializeB24Frame`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/loader-b24frame.ts) | The only correct way to construct a `B24Frame` — performs the parent handshake. | [guide](/docs/working-with-the-rest-api/frame-initialize-b24-frame/) |
+| [`B24OAuth`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/oauth/b24.ts) | A marketplace/OAuth app, authenticated per portal with a refresh token. | [guide](/docs/working-with-the-rest-api/oauth/) |
+| [`AbstractB24`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/abstract-b24.ts) | The shared base the three entry points extend. | [guide](/docs/working-with-the-rest-api/core-http/) |
+| [`AuthHookManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/hook/auth.ts) | Auth actions behind `B24Hook`. | [guide](/docs/working-with-the-rest-api/hook/) |
+| [`AuthOAuthManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/oauth/auth.ts) | Auth actions behind `B24OAuth`, including token refresh. | [guide](/docs/working-with-the-rest-api/oauth/) |
+
+## Actions — calling the REST API
+
+The `$b24.actions.v{2,3}.*` surface. `v2` and `v3` are different dialects, not versions of one thing.
+
+| Export | What it is | Guide |
+| --- | --- | --- |
+| [`versionManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/version-manager.ts) | Routes a method to the v2 or v3 transport. | — |
+| [`ApiVersion`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24.ts) | The `restApi:v2` / `restApi:v3` discriminator. | [guide](/docs/working-with-the-rest-api/limiters/) |
+| [`HttpV2`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/v2.ts) | The v2 transport. | [guide](/docs/working-with-the-rest-api/core-http/) |
+| [`HttpV3`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/v3.ts) | The v3 transport. | [guide](/docs/working-with-the-rest-api/core-http/) |
+| [`FilterV3`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/filter-v3.ts) | Typed builder for the v3 array-of-triples filter grammar. | [guide](/docs/working-with-the-rest-api/filtering/) |
+| [`BatchRefV3`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/batch-ref-v3.ts) | `$ref` / `$refArray` markers for v3 batch cross-command substitution. | [guide](/docs/working-with-the-rest-api/batch-rest-api-ver3/) |
+
+## Results and errors
+
+Every call returns a `Result`; failures split into *soft* (returned) and *hard* (thrown).
+
+| Export | What it is | Guide |
+| --- | --- | --- |
+| [`AjaxResult`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-result.ts) | The response wrapper — `isSuccess`, `getData()`, `getErrorMessages()`. | [guide](/docs/working-with-the-rest-api/core-ajax-result/) |
+| [`Result`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/result.ts) | The base result type. | [guide](/docs/working-with-the-rest-api/core-result/) |
+| [`AjaxError`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/ajax-error.ts) | A transport-level error, with credentials redacted from `requestInfo`. | [guide](/docs/working-with-the-rest-api/errors/) |
+| [`SdkError`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/sdk-error.ts) | An SDK error carrying a stable `code` to discriminate on. | [guide](/docs/working-with-the-rest-api/errors/) |
+
+## Rate limiting
+
+The limiter stack that keeps the SDK inside the portal's request budget.
+
+| Export | What it is | Guide |
+| --- | --- | --- |
+| [`RestrictionManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/limiters/manager.ts) | Owns the limiter stack and the retry policy. | [guide](/docs/working-with-the-rest-api/limiters/) |
+| [`ParamsFactory`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/limiters/params-factory.ts) | Preset limiter configurations (`getDefault()`, `getBatchProcessing()`). | [guide](/docs/working-with-the-rest-api/limiters/) |
+| [`RateLimiter`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/limiters/rate-limiter.ts) | Request-rate limiter. | [guide](/docs/working-with-the-rest-api/limiters/) |
+| [`OperatingLimiter`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/limiters/operating-limiter.ts) | Honours the portal's `operating` budget. | [guide](/docs/working-with-the-rest-api/limiters/) |
+| [`AdaptiveDelayer`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/limiters/adaptive-delayer.ts) | Backoff between retries. | [guide](/docs/working-with-the-rest-api/limiters/) |
+
+## Realtime — Pull
+
+Push notifications from the portal.
+
+| Export | What it is | Guide |
+| --- | --- | --- |
+| [`B24PullClientManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/pullClient/index.ts) | The Pull client. | [guide](/docs/working-with-the-rest-api/pull/) |
+| [`PullStatus`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/pull.ts) | Connection status values. | [guide](/docs/working-with-the-rest-api/pull/) |
+| [`SubscriptionType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/pull.ts) | Subscription kinds. | [guide](/docs/working-with-the-rest-api/pull/) |
+| [`ConnectionType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/pull.ts) | Transport used by the client. | [guide](/docs/working-with-the-rest-api/pull/) |
+| [`CloseReasons`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/pull.ts) | Why a connection closed. | — |
+
+## Frame managers
+
+Available on a `B24Frame` instance — the portal-side UI surface.
+
+| Export | What it is | Guide |
+| --- | --- | --- |
+| [`ParentManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/parent.ts) | `$b24.parent` — control the iframe inside the portal layout. | [guide](/docs/working-with-the-rest-api/frame-parent/) |
+| [`SliderManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/slider.ts) | `$b24.slider` — open paths and app pages in a slider. | [guide](/docs/working-with-the-rest-api/frame-slider/) |
+| [`PlacementManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/placement.ts) | `$b24.placement` — the context the user opened the app from. | [guide](/docs/working-with-the-rest-api/frame-placement/) |
+| [`DialogManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/dialog.ts) | `$b24.dialog` — pick users, CRM entities, access targets. | [guide](/docs/working-with-the-rest-api/frame-dialog/) |
+| [`OptionsManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/options.ts) | `$b24.options` — persist app and per-user settings. | [guide](/docs/working-with-the-rest-api/frame-options/) |
+| [`AuthManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/auth.ts) | `$b24.auth` — the frame's auth actions. | [guide](/docs/working-with-the-rest-api/frame-auth/) |
+| [`MessageManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/message/controller.ts) | The `postMessage` bridge to the parent window. | [guide](/docs/working-with-the-rest-api/frame/) |
+
+## Helper
+
+Aggregated portal state — profile, app, licence, currency.
+
+| Export | What it is | Guide |
+| --- | --- | --- |
+| [`useB24Helper`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/helper/use-b24-helper.ts) | Composable that initialises and exposes the helper. | [guide](/docs/working-with-the-rest-api/helper-use-b24-helper/) |
+| [`LoadDataType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts) | Which data sets the helper loads. | [guide](/docs/working-with-the-rest-api/helper/) |
+| [`EnumAppStatus`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts) | Application status values. | [guide](/docs/working-with-the-rest-api/) |
+| [`TypeSpecificUrl`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts) | Portal URLs the helper resolves. | [guide](/docs/working-with-the-rest-api/helper/) |
+| [`StatusDescriptions`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/b24-helper.ts) | Human-readable app-status descriptions. | [guide](/docs/working-with-the-rest-api/helper-app-manager/) |
+
+## Logging
+
+Monolog-style logging. `Logger.log()` never throws and never rejects.
+
+| Export | What it is | Guide |
+| --- | --- | --- |
+| [`LoggerFactory`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/logger-factory.ts) | Build a configured logger — start here. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`Logger`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/logger.ts) | The logger implementation. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`AbstractLogger`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/abstract-logger.ts) | Base class implementing the level convenience methods. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`NullLogger`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/null-logger.ts) | No-op logger; the SDK's default. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`LogLevel`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/logger.ts) | Severity levels, DEBUG through EMERGENCY. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`ConsoleHandler`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/handler/console-handler.ts) | Writes to the browser console. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`ConsoleV2Handler`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/handler/console-v2-handler.ts) | Improved console handler. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`MemoryHandler`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/handler/memory-handler.ts) | Keeps records in memory — useful in tests. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`StreamHandler`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/handler/stream-handler.ts) | Writes to a Node stream. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`TelegramHandler`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/handler/telegram-handler.ts) | Sends records to a Telegram chat. | [guide](/docs/working-with-the-rest-api/logger-telegram/) |
+| [`ConsolaAdapter`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/handler/consola-adapter.ts) | Bridges to Consola. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`WinstonAdapter`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/handler/winston-adapter.ts) | Bridges to Winston. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`LineFormatter`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/formatter/line-formatter.ts) | Formats a record as a line. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`JsonFormatter`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/formatter/json-formatter.ts) | Formats a record as JSON. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`TelegramFormatter`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/formatter/telegram-formatter.ts) | Formats a record for Telegram HTML. | [guide](/docs/working-with-the-rest-api/logger-telegram/) |
+| [`memoryUsageProcessor`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/processor/memory-usage-processor.ts) | Adds memory usage to a record. | [guide](/docs/working-with-the-rest-api/logger/) |
+| [`pidProcessor`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/logger/processor/pid-processor.ts) | Adds the process id to a record. | [guide](/docs/working-with-the-rest-api/logger/) |
+
+## Tools
+
+Small utilities the SDK uses and re-exports.
+
+| Export | What it is | Guide |
+| --- | --- | --- |
+| [`Type`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/type.ts) | Runtime type guards. | [guide](/docs/working-with-the-rest-api/tools-type/) |
+| [`Text`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/text.ts) | String, id and date helpers. | [guide](/docs/working-with-the-rest-api/tools-text/) |
+| [`Browser`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/browser.ts) | Browser and platform detection. | [guide](/docs/working-with-the-rest-api/tools-browser/) |
+| [`useFormatter`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/use-formatters.ts) | Number and date formatting. | [guide](/docs/working-with-the-rest-api/tools-use-formatters/) |
+| [`Environment`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/environment.ts) | Where the code is running. | [guide](/docs/working-with-the-rest-api/tools-environment/) |
+| [`getEnvironment`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/environment.ts) | Resolve the current environment. | [guide](/docs/working-with-the-rest-api/tools-environment/) |
+| [`omit`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/index.ts) | Object helper — drop keys. | [guide](/docs/working-with-the-rest-api/tools-object-helpers/) |
+| [`pick`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/index.ts) | Object helper — keep keys. | [guide](/docs/working-with-the-rest-api/tools-object-helpers/) |
+| [`isArrayOfArray`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/index.ts) | Array shape guard. | [guide](/docs/working-with-the-rest-api/tools-object-helpers/) |
+| [`getEnumValue`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/tools/index.ts) | Enum lookup helper. | [guide](/docs/working-with-the-rest-api/tools-object-helpers/) |
+| [`B24LangList`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/language/list.ts) | Supported portal languages. | [guide](/docs/working-with-the-rest-api/core-lang-list/) |
+| [`B24LocaleMap`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/language/list.ts) | Locale mapping. | [guide](/docs/working-with-the-rest-api/core-lang-list/) |
+
+## Domain types
+
+Typed shapes for the portal's own entities.
+
+| Export | What it is | Guide |
+| --- | --- | --- |
+| [`EnumCrmEntityTypeId`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/crm/index.ts) | CRM entity type ids. | [guide](/docs/working-with-the-rest-api/batch-rest-api-ver2/) |
+| [`DataType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/common.ts) | Generic data-type discriminator. | [guide](/docs/working-with-the-rest-api/types-common/) |
+| [`TypeOption`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/common.ts) | Option value shape. | [guide](/docs/working-with-the-rest-api/helper-options-manager/) |
+| [`CatalogProductType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/catalog/index.ts) | Catalog product types. | — |
+| [`ProductRowDiscountTypeId`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/crm/productrow.ts) | Discount types on a product row. | — |
+| [`EnumBizprocDocumentType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/bizproc/index.ts) | Business-process document types. | — |
+| [`getDocumentType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/bizproc/index.ts) | Build a bizproc document type. | — |
+| [`getDocumentId`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/bizproc/index.ts) | Build a bizproc document id. | — |
+
+## Everything else
+
+Also exported, and reachable from the groups above or from the guides — listed so this page stays a complete index of the public surface:
+
+`AppFrame` `CatalogProductImageType` `CatalogRoundingRuleType` `EnumBitrix24Edition` `EnumBizprocBaseType` `EnumCrmEntityType` `EnumCrmEntityTypeShort` `ListRpcError` `LoggerBrowser` `LoggerType` `LsKeys` `MessageCommands` `RefreshTokenError` `RpcMethod` `SenderType` `ServerMode` `SystemCommands` `convertBizprocDocumentTypeToCrmEntityTypeId` `getDocumentTypeForFilter` `getEnumCrmEntityTypeShort`
+
+## Not yet covered by a guide
+
+These exports are public but have no deep-dive page of their own yet. They are
+listed here rather than quietly omitted, so the gap is a visible, closable list
+instead of something a reader discovers by failing to find it:
+
+`AppFrame` `CatalogProductImageType` `CatalogProductType` `CatalogRoundingRuleType` `CloseReasons` `EnumBitrix24Edition` `EnumBizprocBaseType` `EnumBizprocDocumentType` `EnumCrmEntityType` `EnumCrmEntityTypeShort` `ListRpcError` `LoggerBrowser` `LoggerType` `LsKeys` `MessageCommands` `ProductRowDiscountTypeId` `RpcMethod` `SenderType` `ServerMode` `SystemCommands` `convertBizprocDocumentTypeToCrmEntityTypeId` `getDocumentId` `getDocumentType` `getDocumentTypeForFilter` `getEnumCrmEntityTypeShort` `versionManager`
+
+Most are enums and type namespaces whose meaning is evident from the source
+linked above. If you needed one of these and the source was not enough, that is
+worth an issue — it tells us which page to write next.

--- a/docs/content/docs/3.api-reference/1.index.md
+++ b/docs/content/docs/3.api-reference/1.index.md
@@ -27,7 +27,7 @@ Pick by **where your code runs** — this is the first decision, and everything 
 | [`B24Frame`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/frame/b24.ts) | An app running inside a Bitrix24 placement iframe. | [guide](/docs/working-with-the-rest-api/frame/) |
 | [`initializeB24Frame`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/loader-b24frame.ts) | The only correct way to construct a `B24Frame` — performs the parent handshake. | [guide](/docs/working-with-the-rest-api/frame-initialize-b24-frame/) |
 | [`B24OAuth`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/oauth/b24.ts) | A marketplace/OAuth app, authenticated per portal with a refresh token. Server-side only, like `B24Hook` — never ship the client secret to a browser. | [guide](/docs/working-with-the-rest-api/oauth/) |
-| [`AbstractB24`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/abstract-b24.ts) | The shared base the three entry points extend. | [guide](/docs/working-with-the-rest-api/core-http/) |
+| [`AbstractB24`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/abstract-b24.ts) | The shared base the three entry points extend — where the deprecated `b24.callMethod()`-style shortcuts live. | [guide](/docs/working-with-the-rest-api/choosing-the-right-method/) |
 | [`AuthHookManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/hook/auth.ts) | Auth actions behind `B24Hook`. | [guide](/docs/working-with-the-rest-api/hook/) |
 | [`AuthOAuthManager`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/oauth/auth.ts) | Auth actions behind `B24OAuth`, including token refresh. | [guide](/docs/working-with-the-rest-api/oauth/) |
 
@@ -155,7 +155,7 @@ Typed shapes for the portal's own entities.
 
 | Export | What it is | Guide |
 | --- | --- | --- |
-| [`EnumCrmEntityTypeId`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/crm/index.ts) | CRM entity type ids. | [guide](/docs/working-with-the-rest-api/batch-rest-api-ver2/) |
+| [`EnumCrmEntityTypeId`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/crm/entity-type.ts) | CRM entity type ids. | [guide](/docs/working-with-the-rest-api/batch-rest-api-ver2/) |
 | [`DataType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/common.ts) | Generic data-type discriminator. | [guide](/docs/working-with-the-rest-api/types-common/) |
 | [`CatalogProductType`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/catalog/index.ts) | Catalog product types. | — |
 | [`ProductRowDiscountTypeId`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/types/crm/productrow.ts) | Discount types on a product row. | — |

--- a/docs/content/docs/3.api-reference/1.index.md
+++ b/docs/content/docs/3.api-reference/1.index.md
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-description: 'Index of the public @bitrix24/b24jssdk surface, grouped by domain — every export, what it is, and where its guide and source live.'
+description: 'Index of the public @bitrix24/b24jssdk surface, grouped by domain — every value export, what it is, and where its guide and source live.'
 navigation.title: API Reference
 audited: 2026-08-24
 links:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "docs:build": "nuxt build docs",
     "docs:generate": "nuxt generate docs",
     "docs:preview": "nuxt preview docs",
-    "docs:lint": "pnpm run docs:lint-pages && pnpm run docs:lint-links",
+    "docs:lint": "pnpm run docs:lint-pages && pnpm run docs:lint-links && pnpm run docs:lint-api-index",
     "docs:typecheck": "pnpm --filter ./docs typecheck",
     "docs:typecheck-blocks": "node scripts/docs-typecheck.mjs",
     "skills:typecheck": "tsc -p skills/b24jssdk-recipes/tsconfig.json",
@@ -69,6 +69,7 @@
     "docs:lint-pages": "node scripts/docs-lint.mjs",
     "docs:lint-pages:strict": "node scripts/docs-lint.mjs --strict",
     "docs:lint-links": "node scripts/docs-link-check.mjs",
+    "docs:lint-api-index": "node scripts/check-api-reference-index.mjs",
     "docs:lint:test": "node --test \"scripts/__tests__/**/*.test.mjs\"",
     "typecheck": "pnpm run package-jssdk:typecheck && pnpm run package-jssdk-nuxt:typecheck && pnpm run docs:typecheck && pnpm run playground-nuxt:typecheck && pnpm run playground-cli:typecheck && pnpm run docs:typecheck-blocks && pnpm run skills:typecheck && pnpm run contributing:typecheck",
     "release:bump": "node scripts/bump-version.mjs"

--- a/scripts/__tests__/check-api-reference-index.test.mjs
+++ b/scripts/__tests__/check-api-reference-index.test.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// Fixture tests for scripts/check-api-reference-index.mjs.
+//
+// The script is the only thing pinning the API Reference index page against the
+// code, so its two halves — resolving the value-export surface out of the
+// `export * from` barrel chain, and scraping the names the page claims — each
+// need to be wrong-proof themselves. A parser that silently under-collects
+// would turn the gate into a no-op exactly when it matters.
+//
+// Run with: node --test scripts/__tests__/check-api-reference-index.test.mjs
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { collectValueExports, collectPageNames } from '../check-api-reference-index.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const SCRIPT = resolve(__dirname, '..', 'check-api-reference-index.mjs')
+
+function withFixture(files, run) {
+  const root = mkdtempSync(join(tmpdir(), 'api-ref-index-'))
+  try {
+    for (const [relPath, contents] of Object.entries(files)) {
+      const file = join(root, ...relPath.split('/'))
+      mkdirSync(dirname(file), { recursive: true })
+      writeFileSync(file, contents, 'utf8')
+    }
+    return run(root)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test('collects value declarations and skips type-only ones', () => {
+  withFixture({
+    'index.ts': [
+      'export class Alpha {}',
+      'export abstract class Beta {}',
+      'export const gamma = 1',
+      'export function delta() {}',
+      'export async function epsilon() {}',
+      'export enum Zeta { A }',
+      // must NOT be collected — the page's scope is value exports only.
+      'export interface Eta { a: string }',
+      'export type Theta = string'
+    ].join('\n')
+  }, (root) => {
+    const names = collectValueExports(join(root, 'index.ts'))
+    assert.deepEqual(
+      [...names].sort(),
+      ['Alpha', 'Beta', 'Zeta', 'delta', 'epsilon', 'gamma']
+    )
+  })
+})
+
+test('follows `export * from` through both file and directory barrels', () => {
+  withFixture({
+    'index.ts': 'export * from \'./leaf\'\nexport * from \'./nested\'\n',
+    'leaf.ts': 'export const leafValue = 1\n',
+    // a directory barrel — resolved as nested/index.ts
+    'nested/index.ts': 'export * from \'./deep\'\n',
+    'nested/deep.ts': 'export class Deep {}\n'
+  }, (root) => {
+    const names = collectValueExports(join(root, 'index.ts'))
+    assert.deepEqual([...names].sort(), ['Deep', 'leafValue'])
+  })
+})
+
+test('records the exported name of an aliased re-export, not the local one', () => {
+  // `PullClient as B24PullClientManager` in the real barrel: the page must list
+  // the name consumers import, so the alias is what counts.
+  withFixture({
+    'index.ts': 'export { PullClient as B24PullClientManager, Plain } from \'./impl\'\n',
+    'impl.ts': 'export class PullClient {}\nexport class Plain {}\n'
+  }, (root) => {
+    const names = collectValueExports(join(root, 'index.ts'))
+    assert.ok(names.has('B24PullClientManager'))
+    assert.ok(names.has('Plain'))
+    assert.ok(!names.has('PullClient'), 'the local name is not the public one')
+  })
+})
+
+test('skips type-only re-export forms', () => {
+  withFixture({
+    'index.ts': [
+      'export type { TypeOnly } from \'./impl\'',
+      'export { type Inline, RealValue } from \'./impl\''
+    ].join('\n'),
+    'impl.ts': 'export class RealValue {}\n'
+  }, (root) => {
+    const names = collectValueExports(join(root, 'index.ts'))
+    assert.deepEqual([...names], ['RealValue'])
+  })
+})
+
+test('survives a cyclic barrel graph', () => {
+  withFixture({
+    'index.ts': 'export * from \'./a\'\nexport const root = 1\n',
+    'a.ts': 'export * from \'./b\'\nexport const a = 1\n',
+    'b.ts': 'export * from \'./a\'\nexport const b = 1\n'
+  }, (root) => {
+    const names = collectValueExports(join(root, 'index.ts'))
+    assert.deepEqual([...names].sort(), ['a', 'b', 'root'])
+  })
+})
+
+test('throws — rather than silently under-collecting — on an unresolvable barrel', () => {
+  withFixture({
+    'index.ts': 'export * from \'./gone\'\n'
+  }, (root) => {
+    assert.throws(
+      () => collectValueExports(join(root, 'index.ts')),
+      /cannot resolve/
+    )
+  })
+})
+
+test('scrapes both backticked and linked names off a page', () => {
+  const names = collectPageNames([
+    '| [`Linked`](https://github.com/bitrix24/b24jssdk/blob/main/x.ts) | what | — |',
+    '| [Bare](https://github.com/bitrix24/b24jssdk/blob/main/y.ts) | what | — |',
+    'Prose mentioning `Backticked` and `$b24`.'
+  ].join('\n'))
+  assert.ok(names.has('Linked'))
+  assert.ok(names.has('Bare'))
+  assert.ok(names.has('Backticked'))
+})
+
+test('the real repo passes, and reports the export count', () => {
+  const run = spawnSync(process.execPath, [SCRIPT], { cwd: REPO_ROOT, encoding: 'utf8' })
+  assert.equal(run.status, 0, run.stderr)
+  assert.match(run.stdout, /public value export\(s\) — all present/)
+})

--- a/scripts/__tests__/check-api-reference-index.test.mjs
+++ b/scripts/__tests__/check-api-reference-index.test.mjs
@@ -145,6 +145,91 @@ test('ignores `export default` — a default is not re-exported by `export *`', 
   })
 })
 
+test('a bare re-export of a type-only name is not counted as a value', () => {
+  // `export { Foo } from './impl'` carries no `type` marker even when the target
+  // declares `Foo` as a type. Trusting the re-export site would force the page
+  // to list a name no consumer can import at runtime.
+  withFixture({
+    'index.ts': 'export { OnlyType, RealClass } from \'./impl\'\n',
+    'impl.ts': 'export type OnlyType = string\nexport class RealClass {}\n'
+  }, (root) => {
+    const names = collectValueExports(join(root, 'index.ts'))
+    assert.deepEqual([...names], ['RealClass'])
+  })
+})
+
+test('an aliased re-export is checked against the target under its LOCAL name', () => {
+  withFixture({
+    'index.ts': 'export { PullClient as B24PullClientManager } from \'./impl\'\n',
+    'impl.ts': 'export class PullClient {}\n'
+  }, (root) => {
+    const names = collectValueExports(join(root, 'index.ts'))
+    assert.deepEqual([...names], ['B24PullClientManager'])
+  })
+})
+
+test('a declaration inside a comment or template literal is not an export', () => {
+  // This codebase writes doc examples at column zero inside JSDoc blocks, so a
+  // line-anchored match would collect them and fail the page for not listing a
+  // name that does not exist.
+  withFixture({
+    'index.ts': [
+      '/**',
+      ' * @example',
+      'export const documentedButNotReal = 1',
+      ' */',
+      '// export const commentedOut = 2',
+      'const snippet = `',
+      'export const insideATemplate = 3',
+      '`',
+      'export const real = 4'
+    ].join('\n')
+  }, (root) => {
+    const names = collectValueExports(join(root, 'index.ts'))
+    assert.deepEqual([...names], ['real'])
+  })
+})
+
+test('rejects a multi-declarator export rather than dropping the later names', () => {
+  // `export const a = 1, b = 2` binds two names; the declaration regex sees only
+  // the first. Silently losing `b` is the one failure mode a completeness gate
+  // must not have, so the walk refuses the form.
+  withFixture({
+    'index.ts': 'export const first = 1, second = 2\n'
+  }, (root) => {
+    assert.throws(
+      () => collectValueExports(join(root, 'index.ts')),
+      /multi-declarator export is not supported/
+    )
+  })
+})
+
+test('a generic type annotation is not mistaken for a multi-declarator', () => {
+  // The real `export const StatusDescriptions: Record<Status, string> = {` in
+  // types/b24-helper.ts — the comma sits inside angle brackets, not between
+  // declarators. A false alarm here would redden CI over correct code.
+  withFixture({
+    'index.ts': [
+      'export const StatusDescriptions: Record<Status, string> = {',
+      '  F: \'Free\',',
+      '  D: \'Demo\'',
+      '}'
+    ].join('\n')
+  }, (root) => {
+    const names = collectValueExports(join(root, 'index.ts'))
+    assert.deepEqual([...names], ['StatusDescriptions'])
+  })
+})
+
+test('a multi-line object initializer does not trip the multi-declarator guard', () => {
+  withFixture({
+    'index.ts': 'export const config = {\n  a: 1,\n  b: 2\n}\n'
+  }, (root) => {
+    const names = collectValueExports(join(root, 'index.ts'))
+    assert.deepEqual([...names], ['config'])
+  })
+})
+
 test('reads names from table rows and flat lists, not from prose', () => {
   const names = collectPageNames([
     '| [`Linked`](https://github.com/bitrix24/b24jssdk/blob/main/x.ts) | what | — |',

--- a/scripts/__tests__/check-api-reference-index.test.mjs
+++ b/scripts/__tests__/check-api-reference-index.test.mjs
@@ -121,15 +121,97 @@ test('throws — rather than silently under-collecting — on an unresolvable ba
   })
 })
 
-test('scrapes both backticked and linked names off a page', () => {
+test('rejects `export * as ns` rather than silently skipping it', () => {
+  // The form binds a namespace object instead of re-exporting names, so a
+  // permissive parser would under-collect and quietly weaken the gate.
+  withFixture({
+    'index.ts': 'export * as tools from \'./impl\'\n',
+    'impl.ts': 'export const inner = 1\n'
+  }, (root) => {
+    assert.throws(
+      () => collectValueExports(join(root, 'index.ts')),
+      /export \* as tools/
+    )
+  })
+})
+
+test('ignores `export default` — a default is not re-exported by `export *`', () => {
+  withFixture({
+    'index.ts': 'export * from \'./impl\'\n',
+    'impl.ts': 'export default class FormatterNumbers {}\nexport const named = 1\n'
+  }, (root) => {
+    const names = collectValueExports(join(root, 'index.ts'))
+    assert.deepEqual([...names], ['named'])
+  })
+})
+
+test('reads names from table rows and flat lists, not from prose', () => {
   const names = collectPageNames([
     '| [`Linked`](https://github.com/bitrix24/b24jssdk/blob/main/x.ts) | what | — |',
     '| [Bare](https://github.com/bitrix24/b24jssdk/blob/main/y.ts) | what | — |',
-    'Prose mentioning `Backticked` and `$b24`.'
+    '',
+    '`FlatOne` `FlatTwo`',
+    '',
+    'Prose mentioning `NotAClaim` and the `isSuccess` flag.'
   ].join('\n'))
-  assert.ok(names.has('Linked'))
-  assert.ok(names.has('Bare'))
-  assert.ok(names.has('Backticked'))
+  assert.deepEqual([...names].sort(), ['Bare', 'FlatOne', 'FlatTwo', 'Linked'])
+  // The point of the restriction: prose backticks are not claims, so a future
+  // export named `isSuccess` cannot pass the gate unlisted.
+  assert.ok(!names.has('isSuccess'))
+  assert.ok(!names.has('NotAClaim'))
+})
+
+function runAgainst(root) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      API_REFERENCE_INDEX_ENTRY: join(root, 'index.ts'),
+      API_REFERENCE_INDEX_PAGE: join(root, 'page.md')
+    }
+  })
+}
+
+test('fails, naming the export, when the page omits one', () => {
+  withFixture({
+    'index.ts': 'export class Listed {}\nexport class Forgotten {}\n',
+    'page.md': '| [`Listed`](https://github.com/x) | what | — |\n'
+  }, (root) => {
+    const run = runAgainst(root)
+    assert.equal(run.status, 1)
+    assert.match(run.stderr, /does not list/)
+    assert.match(run.stderr, /- Forgotten/)
+  })
+})
+
+test('fails, naming the row, when the page lists something no longer exported', () => {
+  // The direction a one-way check misses: rename an export and the old row
+  // survives beside the new one, with every gate green.
+  withFixture({
+    'index.ts': 'export class RenamedTo {}\n',
+    'page.md': [
+      '| [`RenamedTo`](https://github.com/x) | what | — |',
+      '| [`RenamedFrom`](https://github.com/x) | stale | — |'
+    ].join('\n')
+  }, (root) => {
+    const run = runAgainst(root)
+    assert.equal(run.status, 1)
+    assert.match(run.stderr, /not public exports/)
+    assert.match(run.stderr, /- RenamedFrom/)
+  })
+})
+
+test('reports both directions at once', () => {
+  withFixture({
+    'index.ts': 'export class Added {}\n',
+    'page.md': '| [`Removed`](https://github.com/x) | stale | — |\n'
+  }, (root) => {
+    const run = runAgainst(root)
+    assert.equal(run.status, 1)
+    assert.match(run.stderr, /- Added/)
+    assert.match(run.stderr, /- Removed/)
+  })
 })
 
 test('the real repo passes, and reports the export count', () => {

--- a/scripts/check-api-reference-index.mjs
+++ b/scripts/check-api-reference-index.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Pins `docs/content/docs/3.api-reference/1.index.md` against the code.
+ *
+ * That page's whole value proposition is *completeness*: it claims to list every
+ * value the package exports. Nothing else in the repo notices when that stops
+ * being true — `docs-lint.mjs` only checks a page's `audited:` stamp against the
+ * files named in its `links:` frontmatter, and this page names one barrel
+ * (`index.ts`) that almost never changes. So adding, renaming or removing an
+ * export anywhere under the 50-odd re-exported modules would leave the index
+ * quietly wrong, and every gate green (#315 review).
+ *
+ * This script closes that gap. It resolves the public value surface statically
+ * from `packages/jssdk/src/index.ts` — following `export * from` chains — and
+ * asserts every name appears on the page. Deliberately source-based, not
+ * `dist/`-based: `dist/` is gitignored, absent in a fresh clone, and a stale
+ * local build silently validates the page against yesterday's surface.
+ *
+ * Only *value* exports are checked. Pure `type` / `interface` exports are out of
+ * scope by the page's own stated scope — they live in the Types overview.
+ *
+ * Usage: node scripts/check-api-reference-index.mjs
+ * Exits 1 and names the offending exports when the page and the code disagree.
+ */
+import { readFileSync, existsSync } from 'node:fs'
+import { dirname, resolve, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const ENTRY = join(ROOT, 'packages/jssdk/src/index.ts')
+const PAGE = join(ROOT, 'docs/content/docs/3.api-reference/1.index.md')
+
+/**
+ * Resolve a relative specifier to a real `.ts` file, handling the two forms the
+ * SDK uses: `./x` → `x.ts`, and `./x` → `x/index.ts` (a directory barrel).
+ */
+function resolveSpecifier(fromFile, specifier) {
+  const base = resolve(dirname(fromFile), specifier)
+  for (const candidate of [`${base}.ts`, join(base, 'index.ts')]) {
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
+/**
+ * Collect the value exports a single file contributes, recursing through
+ * `export * from` barrels. `seen` guards against a cyclic barrel graph.
+ */
+export function collectValueExports(entry, seen = new Set(), read = readFileSync) {
+  if (seen.has(entry)) {
+    return new Set()
+  }
+  seen.add(entry)
+
+  const names = new Set()
+  const source = String(read(entry, 'utf8'))
+
+  // `export * from './x'` — recurse into the barrel.
+  for (const match of source.matchAll(/^\s*export\s+\*\s+from\s+['"]([^'"]+)['"]/gm)) {
+    const target = resolveSpecifier(entry, match[1])
+    if (!target) {
+      throw new Error(`${entry}: cannot resolve \`export * from '${match[1]}'\``)
+    }
+    for (const name of collectValueExports(target, seen, read)) {
+      names.add(name)
+    }
+  }
+
+  // `export { A, B as C }` — with or without `from`. `export type { … }` is a
+  // pure type re-export and is skipped wholesale.
+  for (const match of source.matchAll(/^\s*export\s+(type\s+)?\{([^}]*)\}/gm)) {
+    if (match[1]) {
+      continue
+    }
+    for (const rawEntry of match[2].split(',')) {
+      const spec = rawEntry.trim()
+      if (spec === '') {
+        continue
+      }
+      // A per-specifier `type` prefix (`export { type Foo, Bar }`) is type-only.
+      if (/^type\s/.test(spec)) {
+        continue
+      }
+      const exported = spec.includes(' as ') ? spec.split(/\s+as\s+/)[1] : spec
+      if (exported && exported !== 'default') {
+        names.add(exported.trim())
+      }
+    }
+  }
+
+  // Direct value declarations. `interface` and `type` are excluded by omission.
+  const DECLARATIONS
+    = /^\s*export\s+(?:declare\s+)?(?:abstract\s+)?(?:default\s+)?(?:async\s+)?(?:class|const|let|var|function|enum)\s+([A-Za-z_$][\w$]*)/gm
+  for (const match of source.matchAll(DECLARATIONS)) {
+    names.add(match[1])
+  }
+
+  return names
+}
+
+/** Every backtick-quoted identifier on the page — its claimed vocabulary. */
+export function collectPageNames(markdown) {
+  const names = new Set()
+  for (const match of markdown.matchAll(/`([A-Z_$][\w$]*)`/gi)) {
+    names.add(match[1])
+  }
+  // Table rows link the name rather than backtick it in some places; catch the
+  // linked form too: `[`Name`](url)` is already covered, but a bare `[Name](url)`
+  // is not.
+  for (const match of markdown.matchAll(/\[`?([A-Za-z_$][\w$]*)`?\]\(https:\/\/github\.com/g)) {
+    names.add(match[1])
+  }
+  return names
+}
+
+function main() {
+  const exported = collectValueExports(ENTRY)
+  const onPage = collectPageNames(readFileSync(PAGE, 'utf8'))
+
+  const missing = [...exported].filter(name => !onPage.has(name)).sort()
+
+  if (missing.length > 0) {
+    console.error(
+      `docs/content/docs/3.api-reference/1.index.md is missing ${missing.length} public export(s):\n`
+      + missing.map(name => `  - ${name}`).join('\n')
+      + '\n\nThe page claims to index every value export. Add each name to the '
+      + 'right domain table (with a source link and a guide link, or `—`), or to '
+      + 'the "Everything else" list if it is reachable from a group above.'
+    )
+    process.exit(1)
+  }
+
+  console.log(`api-reference index: ${exported.size} public value export(s) — all present.`)
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  main()
+}

--- a/scripts/check-api-reference-index.mjs
+++ b/scripts/check-api-reference-index.mjs
@@ -52,17 +52,37 @@ function resolveSpecifier(fromFile, specifier) {
 }
 
 /**
+ * Blank out comments and template-literal bodies before matching.
+ *
+ * Every pattern below is line-anchored text matching, so an example line inside
+ * a JSDoc block — `export const foo = …` at column zero, which is exactly how
+ * this codebase writes doc examples — would otherwise be collected as a real
+ * export and the page failed for not listing it. Same for a snippet inside a
+ * template literal.
+ *
+ * Newlines are preserved so line numbers and line-start anchors still line up;
+ * only the content is replaced with spaces.
+ */
+function stripCommentsAndStrings(source) {
+  const blank = text => text.replaceAll(/[^\n]/g, ' ')
+  return source
+    .replaceAll(/\/\*[\s\S]*?\*\//g, blank)
+    .replaceAll(/\/\/[^\n]*/g, blank)
+    .replaceAll(/`(?:[^`\\]|\\[\s\S])*`/g, blank)
+}
+
+/**
  * Collect the value exports a single file contributes, recursing through
  * `export * from` barrels. `seen` guards against a cyclic barrel graph.
  */
-export function collectValueExports(entry, seen = new Set(), read = readFileSync) {
+export function collectValueExports(entry, seen = new Set()) {
   if (seen.has(entry)) {
     return new Set()
   }
   seen.add(entry)
 
   const names = new Set()
-  const source = String(read(entry, 'utf8'))
+  const source = stripCommentsAndStrings(readFileSync(entry, 'utf8'))
 
   // `export * as ns from './x'` binds one namespace object rather than
   // re-exporting names, so the walk below would silently skip it and
@@ -82,17 +102,35 @@ export function collectValueExports(entry, seen = new Set(), read = readFileSync
     if (!target) {
       throw new Error(`${entry}: cannot resolve \`export * from '${match[1]}'\``)
     }
-    for (const name of collectValueExports(target, seen, read)) {
+    for (const name of collectValueExports(target, seen)) {
       names.add(name)
     }
   }
 
   // `export { A, B as C }` — with or without `from`. `export type { … }` is a
   // pure type re-export and is skipped wholesale.
-  for (const match of source.matchAll(/^\s*export\s+(type\s+)?\{([^}]*)\}/gm)) {
+  const REEXPORTS = /^\s*export\s+(type\s+)?\{([^}]*)\}\s*(?:from\s+['"]([^'"]+)['"])?/gm
+  for (const match of source.matchAll(REEXPORTS)) {
     if (match[1]) {
       continue
     }
+
+    // With a `from`, the `type` keyword at THIS site says nothing about what the
+    // target actually declares: `export { Foo } from './impl'` re-exports a
+    // type-only `Foo` without any marker. Resolving the target and keeping only
+    // the names it exports as values is what stops the gate demanding a page row
+    // for something no consumer can import at runtime.
+    let targetValues = null
+    if (match[3]) {
+      const target = resolveSpecifier(entry, match[3])
+      if (!target) {
+        throw new Error(`${entry}: cannot resolve \`export { … } from '${match[3]}'\``)
+      }
+      // A fresh `seen` — the target's own exports are needed here even if the
+      // barrel walk already visited it for its side of the surface.
+      targetValues = collectValueExports(target, new Set())
+    }
+
     for (const rawEntry of match[2].split(',')) {
       const spec = rawEntry.trim()
       if (spec === '') {
@@ -102,10 +140,15 @@ export function collectValueExports(entry, seen = new Set(), read = readFileSync
       if (/^type\s/.test(spec)) {
         continue
       }
-      const exported = spec.includes(' as ') ? spec.split(/\s+as\s+/)[1] : spec
-      if (exported && exported !== 'default') {
-        names.add(exported.trim())
+      const [local, aliased] = spec.split(/\s+as\s+/)
+      const exported = (aliased ?? local).trim()
+      if (exported === '' || exported === 'default') {
+        continue
       }
+      if (targetValues && !targetValues.has(local.trim())) {
+        continue
+      }
+      names.add(exported)
     }
   }
 
@@ -119,7 +162,51 @@ export function collectValueExports(entry, seen = new Set(), read = readFileSync
     names.add(match[1])
   }
 
+  assertNoMultiDeclarator(entry, source)
+
   return names
+}
+
+/**
+ * `export const a = 1, b = 2` binds two names; DECLARATIONS above captures only
+ * the first, so the second would go missing from the surface without anything
+ * saying so. The SDK has no such statement today, and rather than grow a
+ * bracket-aware declarator splitter for a form nobody uses, this refuses it —
+ * matching how the walk treats `export * as ns`. Silent under-collection is the
+ * one failure mode a completeness gate must not have.
+ *
+ * Detection scans a single line for a comma at bracket depth zero. A multi-line
+ * initializer (an object or array literal) cannot produce one, since the line
+ * ends before the depth returns to zero, so it raises no false alarm.
+ *
+ * Angle brackets count as nesting so a generic type annotation — the real
+ * `export const StatusDescriptions: Record<Status, string> = {` in
+ * `types/b24-helper.ts` — is not mistaken for a second declarator. The cost is
+ * that a bare `>` (a comparison, an arrow) drives the depth negative and stops
+ * detection for the rest of that line. That is the safe direction to err: this
+ * guard failing to fire merely restores the old behaviour, while a false alarm
+ * would redden CI over correct code.
+ */
+function assertNoMultiDeclarator(entry, source) {
+  for (const line of source.split('\n')) {
+    if (!/^\s*export\s+(?:declare\s+)?(?:const|let|var)\s/.test(line)) {
+      continue
+    }
+    let depth = 0
+    for (const char of line) {
+      if ('([{<'.includes(char)) {
+        depth += 1
+      } else if (')]}>'.includes(char)) {
+        depth -= 1
+      } else if (char === ',' && depth === 0) {
+        throw new Error(
+          `${entry}: multi-declarator export is not supported by this checker:\n  ${line.trim()}\n`
+          + 'Split it into one `export const` per name, or teach collectValueExports '
+          + 'to read every declarator.'
+        )
+      }
+    }
+  }
 }
 
 /**

--- a/scripts/check-api-reference-index.mjs
+++ b/scripts/check-api-reference-index.mjs
@@ -12,9 +12,14 @@
  *
  * This script closes that gap. It resolves the public value surface statically
  * from `packages/jssdk/src/index.ts` — following `export * from` chains — and
- * asserts every name appears on the page. Deliberately source-based, not
- * `dist/`-based: `dist/` is gitignored, absent in a fresh clone, and a stale
- * local build silently validates the page against yesterday's surface.
+ * compares it against the page in **both** directions: an export the page omits
+ * is a gap, and a name the page lists that is no longer exported is a stale row
+ * left behind by a rename or a removal. A one-directional check would have
+ * caught only the first, leaving a renamed export listed twice.
+ *
+ * Deliberately source-based, not `dist/`-based: `dist/` is gitignored, absent in
+ * a fresh clone, and a stale local build silently validates the page against
+ * yesterday's surface.
  *
  * Only *value* exports are checked. Pure `type` / `interface` exports are out of
  * scope by the page's own stated scope — they live in the Types overview.
@@ -27,8 +32,10 @@ import { dirname, resolve, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
-const ENTRY = join(ROOT, 'packages/jssdk/src/index.ts')
-const PAGE = join(ROOT, 'docs/content/docs/3.api-reference/1.index.md')
+// Overridable so the fixture tests can drive the real entry point end to end,
+// including its exit codes and messages, against a synthetic tree.
+const ENTRY = process.env.API_REFERENCE_INDEX_ENTRY ?? join(ROOT, 'packages/jssdk/src/index.ts')
+const PAGE = process.env.API_REFERENCE_INDEX_PAGE ?? join(ROOT, 'docs/content/docs/3.api-reference/1.index.md')
 
 /**
  * Resolve a relative specifier to a real `.ts` file, handling the two forms the
@@ -56,6 +63,18 @@ export function collectValueExports(entry, seen = new Set(), read = readFileSync
 
   const names = new Set()
   const source = String(read(entry, 'utf8'))
+
+  // `export * as ns from './x'` binds one namespace object rather than
+  // re-exporting names, so the walk below would silently skip it and
+  // under-collect. The SDK does not use the form today; if it ever does, this
+  // says so loudly instead of quietly weakening the gate.
+  const namespaceReexport = /^\s*export\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from/m.exec(source)
+  if (namespaceReexport) {
+    throw new Error(
+      `${entry}: \`export * as ${namespaceReexport[1]} from …\` is not supported by this checker. `
+      + 'Teach collectValueExports to record the namespace binding before using the form.'
+    )
+  }
 
   // `export * from './x'` — recurse into the barrel.
   for (const match of source.matchAll(/^\s*export\s+\*\s+from\s+['"]([^'"]+)['"]/gm)) {
@@ -90,9 +109,12 @@ export function collectValueExports(entry, seen = new Set(), read = readFileSync
     }
   }
 
-  // Direct value declarations. `interface` and `type` are excluded by omission.
+  // Direct value declarations. `interface` and `type` are excluded by omission,
+  // and so is `export default`: a default is not re-exported by `export *`, so
+  // demanding a page entry for one would fail the gate over a name consumers
+  // cannot import by that name at all.
   const DECLARATIONS
-    = /^\s*export\s+(?:declare\s+)?(?:abstract\s+)?(?:default\s+)?(?:async\s+)?(?:class|const|let|var|function|enum)\s+([A-Za-z_$][\w$]*)/gm
+    = /^\s*export\s+(?:declare\s+)?(?:abstract\s+)?(?:async\s+)?(?:class|const|let|var|function|enum)\s+([A-Za-z_$][\w$]*)/gm
   for (const match of source.matchAll(DECLARATIONS)) {
     names.add(match[1])
   }
@@ -100,18 +122,40 @@ export function collectValueExports(entry, seen = new Set(), read = readFileSync
   return names
 }
 
-/** Every backtick-quoted identifier on the page — its claimed vocabulary. */
+/**
+ * The names the page *claims* are exports — read from structured positions only,
+ * never from prose.
+ *
+ * Two positions count: the leading linked cell of a domain-table row, and a
+ * line consisting solely of backticked names (the "Everything else" and "Not yet
+ * covered by a guide" lists). Scraping every backtick on the page instead would
+ * be far laxer than it looks: the prose already contains `v2`, `isSuccess`,
+ * `getData`, `postMessage` and friends, so a future export sharing one of those
+ * names would satisfy the gate without ever being listed.
+ *
+ * Restricting to structured positions is also what makes the check
+ * bidirectional — a name found here is a deliberate claim, so it can be held
+ * against the real surface and fail when an export is renamed or removed.
+ */
 export function collectPageNames(markdown) {
   const names = new Set()
-  for (const match of markdown.matchAll(/`([A-Z_$][\w$]*)`/gi)) {
+
+  // A domain-table row: `| [`Name`](source) | description | guide |`.
+  for (const match of markdown.matchAll(/^\|\s*\[`?([A-Z_$][\w$]*)`?\]\(/gim)) {
     names.add(match[1])
   }
-  // Table rows link the name rather than backtick it in some places; catch the
-  // linked form too: `[`Name`](url)` is already covered, but a bare `[Name](url)`
-  // is not.
-  for (const match of markdown.matchAll(/\[`?([A-Za-z_$][\w$]*)`?\]\(https:\/\/github\.com/g)) {
-    names.add(match[1])
+
+  // A flat name list — a line that is nothing but backticked identifiers.
+  for (const line of markdown.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed === '' || !/^(?:`[A-Z_$][\w$]*`\s*)+$/i.test(trimmed)) {
+      continue
+    }
+    for (const match of trimmed.matchAll(/`([A-Z_$][\w$]*)`/gi)) {
+      names.add(match[1])
+    }
   }
+
   return names
 }
 
@@ -120,19 +164,35 @@ function main() {
   const onPage = collectPageNames(readFileSync(PAGE, 'utf8'))
 
   const missing = [...exported].filter(name => !onPage.has(name)).sort()
+  const stale = [...onPage].filter(name => !exported.has(name)).sort()
 
+  const problems = []
   if (missing.length > 0) {
-    console.error(
-      `docs/content/docs/3.api-reference/1.index.md is missing ${missing.length} public export(s):\n`
+    problems.push(
+      `${missing.length} public export(s) the page does not list:\n`
       + missing.map(name => `  - ${name}`).join('\n')
-      + '\n\nThe page claims to index every value export. Add each name to the '
-      + 'right domain table (with a source link and a guide link, or `—`), or to '
-      + 'the "Everything else" list if it is reachable from a group above.'
+      + '\n  Add each to the right domain table (with a source link, and a guide '
+      + 'link or `—`), or to the "Everything else" list if it is reachable from a '
+      + 'group above.'
+    )
+  }
+  if (stale.length > 0) {
+    problems.push(
+      `${stale.length} name(s) the page lists that are not public exports:\n`
+      + stale.map(name => `  - ${name}`).join('\n')
+      + '\n  The export was renamed or removed; drop the row, or point it at the '
+      + 'current name.'
+    )
+  }
+
+  if (problems.length > 0) {
+    console.error(
+      `docs/content/docs/3.api-reference/1.index.md is out of sync with the code.\n\n${problems.join('\n\n')}`
     )
     process.exit(1)
   }
 
-  console.log(`api-reference index: ${exported.size} public value export(s) — all present.`)
+  console.log(`api-reference index: ${exported.size} public value export(s) — all present, none stale.`)
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {


### PR DESCRIPTION
Refs #315. **Does not close it** — this is the index layer, not the per-symbol reference the acceptance criteria describe.

There were **59** task-oriented guides but no single place cataloguing what the SDK actually exports, so finding a capability by name meant guessing which guide it lived in.

Adds `docs/content/docs/3.api-reference/` — a landing page grouping all **96** runtime value exports by domain (entry points, actions, results/errors, rate limiting, realtime, frame managers, helper, logging, tools, domain types), each naming the export with one line on what it is and links to its guide and its source.

### The decision: index, not generated reference

Recorded in full [on the issue](https://github.com/bitrix24/b24jssdk/issues/315#issuecomment-5394575986) (acceptance criterion 4). The short version, with the number that settled it:

**JSDoc coverage on the built `.d.ts` is 88 / 137 top-level declarations — 64%.** A `typedoc` / `api-extractor` reference would therefore ship 49 declarations as bare signatures with no prose, sitting beside 59 hand-audited pages that already explain most of them better.

It also fights the repo's own gates: generated pages can't carry a meaningful `audited:` stamp (the date would be a build artefact — precisely what `docs-lint --strict` exists to prevent), and extractor-emitted snippets aren't written to compile under `docs:typecheck-blocks`.

Writing 96 full entries by hand is the opposite failure: weeks of retyping the guides, and 96 new places to drift.

So: an **index** that routes to the existing audited detail rather than restating it. The upgrade path is noted — once JSDoc nears 100%, generated per-symbol pages can slot in underneath without changing the page's shape.

### It names the gap

The page lists the **26 exports with no guide of their own**. Naming them turns an unknown into a closable list, instead of something a reader finds out by failing to find it.

### The gate — `scripts/check-api-reference-index.mjs`

The page's whole value proposition is completeness, and nothing pinned it against the code. `docs-lint` only checks a page's `audited:` stamp against the files named in its `links:` frontmatter, and this page names one barrel that almost never changes — so an export added anywhere under the 50-odd re-exported modules would leave the index quietly wrong with every gate green.

The script resolves the public value surface statically from `packages/jssdk/src/index.ts`, following the `export * from` chains, and compares it against the page **in both directions**: an export the page omits is a gap, and a name the page lists that is no longer exported is a stale row left by a rename. It finds exactly 96, matching `Object.keys()` on a fresh runtime build.

Source-based rather than `dist/`-based on purpose: `dist` is gitignored, absent in a fresh clone, and a stale local build silently validates the page against yesterday's surface.

Wired into `docs:lint` and the `docs-lint` CI job, with **19 fixture tests** covering the barrel walk, aliased re-exports, type-only forms, cyclic barrels, comment and template-literal exclusion, multi-declarator rejection, and both failure directions end to end.

### Review

Two full panel rounds (five reviewers each) plus `/code-review`. Between them they found and fixed:

- six wrong or mis-targeted links on the page (`MessageManager`, `EnumAppStatus`, `AbstractB24`, `EnumCrmEntityTypeId`, `TypeOption`, plus `TypeOption` grouped under the wrong domain);
- a scope claim of "every export" on a page that lists only value exports, and the same claim left behind in the frontmatter a round later;
- `B24OAuth` missing the server-side-only caveat its sibling `B24Hook` carried, which invited the reader to conclude OAuth was the safe one to wire up client-side;
- three parser bugs in the gate itself — a type-only re-export counted as a value, a declaration inside a JSDoc `@example` collected as real, and a multi-declarator silently dropping later names.

### Follow-up

#384 — nothing keeps the "Not yet covered by a guide" list honest as guides get written; that list is designed to shrink, and shrinking is what nothing checks.

### Gates

`docs-lint --strict`, `docs-link-check`, `md-internal-links`, `docs:typecheck-blocks`, `lint:md`, `check-v3-method-refs`, the 67 `scripts/__tests__` cases, and a full docs build — all clean. CI green on every job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_