### PR TITLE
fix(skills): collapse duplicated recipe helpers (baseStage, safeEqual) and guard against new copies

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/79.security.md
+++ b/docs/content/docs/2.working-with-the-rest-api/79.security.md
@@ -1,7 +1,7 @@
 ---
 title: Security for event-receiver apps
 description: 'Two hardening patterns for any server that receives Bitrix24 outbound events or OAuth install/uninstall callbacks: reply 200 before you verify, and compare application_token in constant time.'
-audited: 2026-08-23
+audited: 2026-08-24
 navigation.title: Security
 links:
   - label: Recipe 7 — webhook handler (source)
@@ -72,14 +72,23 @@ The [webhook handler recipe](/docs/examples/webhook-handler/) replies with a sma
 
 Bitrix24 includes an `application_token` in the `auth` block of every event. It is the shared secret that proves the request really came from your portal — without checking it, anyone who learns the URL can replay arbitrary events.
 
-Compare it with a **constant-time** function. A plain `===` (or `!=`) returns as soon as it hits the first differing byte, so an attacker can recover the token one character at a time by measuring response latency. Node's `crypto.timingSafeEqual` compares in constant time, but it **throws when the two buffers differ in length** — so pre-check the length first (which also avoids leaking length):
+Compare it with a **constant-time** function. A plain `===` (or `!=`) returns as soon as it hits the first differing byte, so an attacker can recover the token one character at a time by measuring response latency. Node's `crypto.timingSafeEqual` compares in constant time, but it **throws when the two buffers differ in length** — so pre-check the length first:
+
+The helper is spelled out here because you should read it before trusting it. The
+recipes themselves import one shared copy from
+[`lib/crypto.ts`](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-recipes/lib/crypto.ts)
+rather than each carrying their own — a constant-time compare that drifts in one
+of several forks is a vulnerability that reads like a refactor.
 
 ```ts
 import { type Request, type Response } from 'express'
 import { timingSafeEqual } from 'node:crypto'
 
-// Constant-time compare. `timingSafeEqual` throws on a length mismatch, so we
-// pre-check length first — this also avoids leaking length via the exception.
+// Constant-time compare. `timingSafeEqual` throws on a length mismatch, so the
+// length pre-check is what turns that throw into a plain `false`. It does not
+// hide the length — the early return is length-dependent — but a token's length
+// is not the secret. Do not "fix" that by padding: you would then be comparing
+// the padding rather than the token.
 function safeEqual(a: string, b: string): boolean {
   const ab = Buffer.from(a, 'utf8')
   const bb = Buffer.from(b, 'utf8')

--- a/docs/content/docs/99.examples/1.crm-analytics.md
+++ b/docs/content/docs/99.examples/1.crm-analytics.md
@@ -64,7 +64,15 @@ const STAGE_NAMES: Record<string, string> = {
   LOSE: 'Lost'
 }
 
-const baseStage = (s: string) => (s.includes(':') ? s.split(':')[1] : s)
+// Inlined here so this listing reads standalone. The recipe file imports it
+// from `lib/funnel.ts`, the single tested copy — see the note below.
+const baseStage = (s: string): string => {
+  if (!s.includes(':')) return s
+  const suffix = s.split(':')[1]
+  // Fall back to the input rather than returning '' for a malformed 'C2:', so
+  // an unparseable stage stays visible instead of collapsing into an empty key.
+  return suffix || s
+}
 
 interface DealRow {
   id: number

--- a/docs/content/docs/99.examples/1.crm-analytics.md
+++ b/docs/content/docs/99.examples/1.crm-analytics.md
@@ -64,8 +64,8 @@ const STAGE_NAMES: Record<string, string> = {
   LOSE: 'Lost'
 }
 
-// Inlined here so this listing reads standalone. The recipe file imports it
-// from `lib/funnel.ts`, the single tested copy — see the note below.
+// Inlined here so this listing reads standalone. The recipe file itself imports
+// this from `lib/funnel.ts`, which is the single tested copy.
 const baseStage = (s: string): string => {
   if (!s.includes(':')) return s
   const suffix = s.split(':')[1]

--- a/skills/b24jssdk-recipes/SKILL.md
+++ b/skills/b24jssdk-recipes/SKILL.md
@@ -33,6 +33,11 @@ primitive, or logic with edge cases a test pins. It is not for shared plumbing: 
 are recipes, and every extraction costs a reader the ability to lift one file and run
 it. When in doubt, leave the code in the recipe.
 
+Worked example of the rule: `bootB24()` is byte-identical in eleven of the twelve
+recipes and stays that way on purpose. It has no edge cases to pin and no security
+weight, and it is the first thing a reader needs to see when they open a recipe —
+hiding it behind an import would cost more than the duplication does.
+
 | File | Exports | Used by |
 | --- | --- | --- |
 | `lib/funnel.ts` | `baseStage`, `analyseFunnel`, `DealRow`, `StageStat` | recipes 01, 03, 06 |

--- a/skills/b24jssdk-recipes/SKILL.md
+++ b/skills/b24jssdk-recipes/SKILL.md
@@ -28,6 +28,11 @@ All recipes use the canonical **`$b24.actions.v{2,3}.*.make()`** surface. The le
 
 Pure, I/O-free helpers extracted from recipes so they can be unit-tested without a live portal.
 
+`lib/` is for helpers where a second hand-written copy is a *defect* — a security
+primitive, or logic with edge cases a test pins. It is not for shared plumbing: these
+are recipes, and every extraction costs a reader the ability to lift one file and run
+it. When in doubt, leave the code in the recipe.
+
 | File | Exports | Used by |
 | --- | --- | --- |
 | `lib/funnel.ts` | `baseStage`, `analyseFunnel`, `DealRow`, `StageStat` | recipes 01, 03, 06 |

--- a/skills/b24jssdk-recipes/SKILL.md
+++ b/skills/b24jssdk-recipes/SKILL.md
@@ -30,9 +30,13 @@ Pure, I/O-free helpers extracted from recipes so they can be unit-tested without
 
 | File | Exports | Used by |
 | --- | --- | --- |
-| `lib/funnel.ts` | `baseStage`, `analyseFunnel`, `DealRow`, `StageStat` | recipe 01 |
+| `lib/funnel.ts` | `baseStage`, `analyseFunnel`, `DealRow`, `StageStat` | recipes 01, 03, 06 |
 
-`baseStage(s)` strips the multi-funnel category prefix (`"C2:WON"` → `"WON"`).  
+`baseStage(s)` strips the multi-funnel category prefix (`"C2:WON"` → `"WON"`), falling
+back to the original string when the part after the colon is empty (`"C2:"` → `"C2:"`).
+Import it from `lib/funnel` rather than re-declaring it in a recipe — recipes 03 and 06
+used to carry their own copy that returned `""` for that case, so the behaviour under
+test was not the behaviour they ran.  
 `analyseFunnel(deals)` groups deals by raw `stageId` key, summing counts and opportunity amounts.
 
 ## Boot snippet (shared by all recipes)

--- a/skills/b24jssdk-recipes/SKILL.md
+++ b/skills/b24jssdk-recipes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: b24jssdk-recipes
-description: End-to-end mini-apps built on the canonical b24jssdk actions.v{2,3}.* surface — CRM analytics, ERP sync, Telegram bot, mass mailing, task automation, AI assistant, web search + LLM, Disk files, webhook handler, error-handling cookbook, event registration, OAuth install handshake. Each recipe is a self-contained TypeScript program using B24Hook on the server side. Load when the user asks for a working example or a starting template.
+description: End-to-end mini-apps built on the canonical b24jssdk actions.v{2,3}.* surface — CRM analytics, ERP sync, Telegram bot, mass mailing, task automation, AI assistant, web search + LLM, Disk files, webhook handler, error-handling cookbook, event registration, OAuth install handshake. Each recipe is a single TypeScript program using B24Hook on the server side. Load when the user asks for a working example or a starting template.
 ---
 
 # b24jssdk recipes
@@ -31,13 +31,20 @@ Pure, I/O-free helpers extracted from recipes so they can be unit-tested without
 | File | Exports | Used by |
 | --- | --- | --- |
 | `lib/funnel.ts` | `baseStage`, `analyseFunnel`, `DealRow`, `StageStat` | recipes 01, 03, 06 |
+| `lib/crypto.ts` | `safeEqual` | recipes 07, 12 |
 
 `baseStage(s)` strips the multi-funnel category prefix (`"C2:WON"` → `"WON"`), falling
 back to the original string when the part after the colon is empty (`"C2:"` → `"C2:"`).
-Import it from `lib/funnel` rather than re-declaring it in a recipe — recipes 03 and 06
-used to carry their own copy that returned `""` for that case, so the behaviour under
-test was not the behaviour they ran.  
+Import it from `lib/funnel` rather than re-declaring it in a recipe: 03 and 06 each
+carried their own copy that returned `""` for that case. No recipe's control flow
+actually differed — neither `""` nor `"C2:"` matches a stage key — but the copies had
+drifted from the tested one unnoticed, and the next divergence might not be harmless.  
 `analyseFunnel(deals)` groups deals by raw `stageId` key, summing counts and opportunity amounts.
+
+`safeEqual(a, b)` is a constant-time compare for secrets and tokens. It had the same
+two-copy problem as `baseStage`, in recipes 07 and 12. Never re-declare this one: a
+constant-time compare that drifts in one of two forks is a vulnerability that reads
+like a refactor, and `===` on a token is the bug it exists to prevent.
 
 ## Boot snippet (shared by all recipes)
 
@@ -79,6 +86,11 @@ CRM v3-style methods (`crm.item.list`) use camelCase fields: `stageId`, `assigne
 ```bash
 # 1. Install: at the repo root or in a fresh project
 pnpm add @bitrix24/b24jssdk
+# Copying a single recipe out of this repo? Some recipes import a shared
+# helper and need it copied alongside, keeping the ../lib/ path:
+#   recipes 1, 3, 6:  lib/funnel.ts  (baseStage)
+#   recipes 7, 12:    lib/crypto.ts  (safeEqual)
+# Every other recipe is standalone.
 # Recipe-specific deps as needed:
 #   recipe 4: pnpm add node-cron
 #   recipe 6: pnpm add grammy node-cron

--- a/skills/b24jssdk-recipes/examples/03-task-automation.ts
+++ b/skills/b24jssdk-recipes/examples/03-task-automation.ts
@@ -17,6 +17,7 @@ import {
   Logger,
   type TypeB24
 } from '@bitrix24/b24jssdk'
+import { baseStage } from '../lib/funnel'
 
 const logger = Logger.create('TaskAuto')
 logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO, { useStyles: false }))
@@ -55,8 +56,6 @@ const STAGE_TASKS: Record<string, TaskTemplate> = {
     priority: 1
   }
 }
-
-const baseStage = (s: string) => (s.includes(':') ? s.split(':')[1] : s)
 
 interface DealRow {
   id: number

--- a/skills/b24jssdk-recipes/examples/06-telegram-bot.ts
+++ b/skills/b24jssdk-recipes/examples/06-telegram-bot.ts
@@ -21,6 +21,7 @@ import {
   Logger,
   type TypeB24
 } from '@bitrix24/b24jssdk'
+import { baseStage } from '../lib/funnel'
 import { Bot } from 'grammy'
 import cron from 'node-cron'
 
@@ -49,8 +50,6 @@ interface DealRow {
 // deployment seed this from persistent storage (file / Redis) or initialise
 // it with the current max(id) on first run to skip historical deals.
 let lastSeenDealId = 0
-
-const baseStage = (s: string) => (s.includes(':') ? s.split(':')[1] : s)
 
 async function fetchNewDeals($b24: TypeB24): Promise<DealRow[]> {
   const res = await $b24.actions.v2.call.make<{ items: DealRow[] }>({

--- a/skills/b24jssdk-recipes/examples/07-webhook-handler.ts
+++ b/skills/b24jssdk-recipes/examples/07-webhook-handler.ts
@@ -32,22 +32,10 @@ import {
   type TypeB24
 } from '@bitrix24/b24jssdk'
 import express, { type Request, type Response } from 'express'
-import { timingSafeEqual } from 'node:crypto'
+import { safeEqual } from '../lib/crypto'
 
 const logger = Logger.create('Webhook')
 logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO, { useStyles: false }))
-
-/**
- * Constant-time string compare. Use for any secret / token comparison so
- * an attacker can't recover the value by measuring response latency.
- * Returns false when lengths differ (does not leak length either).
- */
-function safeEqual(a: string, b: string): boolean {
-  const ab = Buffer.from(a, 'utf8')
-  const bb = Buffer.from(b, 'utf8')
-  if (ab.length !== bb.length) return false
-  return timingSafeEqual(ab, bb)
-}
 
 function bootB24(): TypeB24 {
   const url = process.env.B24_HOOK

--- a/skills/b24jssdk-recipes/examples/12-oauth-install.ts
+++ b/skills/b24jssdk-recipes/examples/12-oauth-install.ts
@@ -37,21 +37,10 @@ import {
 import express, { type Request, type Response } from 'express'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
-import { timingSafeEqual } from 'node:crypto'
+import { safeEqual } from '../lib/crypto'
 
 const logger = Logger.create('OAuthInstall')
 logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO, { useStyles: false }))
-
-/**
- * Constant-time string compare. Use for any token comparison so an attacker
- * can't recover the secret by measuring response latency.
- */
-function safeEqual(a: string, b: string): boolean {
-  const ab = Buffer.from(a, 'utf8')
-  const bb = Buffer.from(b, 'utf8')
-  if (ab.length !== bb.length) return false
-  return timingSafeEqual(ab, bb)
-}
 
 const SECRET: B24OAuthSecret = {
   clientId: process.env.B24_CLIENT_ID ?? '',

--- a/skills/b24jssdk-recipes/lib/crypto.ts
+++ b/skills/b24jssdk-recipes/lib/crypto.ts
@@ -1,0 +1,24 @@
+/**
+ * Security helpers shared by the recipes that verify a secret.
+ * Isolated here so they can be unit-tested, and so there is exactly one copy:
+ * a constant-time compare that drifts in one of two forks is a vulnerability
+ * that looks like a refactor.
+ */
+import { timingSafeEqual } from 'node:crypto'
+
+/**
+ * Constant-time string compare. Use for any secret / token comparison so an
+ * attacker can't recover the value by measuring response latency.
+ *
+ * Returns false when the lengths differ. That early return is itself
+ * length-dependent, but comparing buffers of unequal length is not something
+ * `timingSafeEqual` permits — it throws — and a token's length is not the
+ * secret. Do not "fix" it by padding: that would compare the padding, not the
+ * token.
+ */
+export function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8')
+  const bb = Buffer.from(b, 'utf8')
+  if (ab.length !== bb.length) return false
+  return timingSafeEqual(ab, bb)
+}

--- a/skills/b24jssdk-recipes/lib/funnel.ts
+++ b/skills/b24jssdk-recipes/lib/funnel.ts
@@ -17,7 +17,13 @@ export interface StageStat {
 
 /**
  * Strip multi-funnel prefix: "C2:WON" → "WON", "WON" → "WON".
- * Falls back to the original string if the part after the colon is empty.
+ *
+ * Falls back to the original string if the part after the colon is empty, so a
+ * malformed "C2:" stays "C2:" rather than collapsing to "". Keep that fallback:
+ * an empty key silently merges every unparseable stage into one bucket and can
+ * collide with a real empty-string key, whereas the original value fails a
+ * lookup visibly. Bitrix24 does not emit a prefix with an empty status, so this
+ * guards a malformed input rather than a live API shape.
  */
 export const baseStage = (s: string): string => {
   if (!s.includes(':')) return s

--- a/test/integration/skills-recipes/crm-analytics-funnel.unit.spec.ts
+++ b/test/integration/skills-recipes/crm-analytics-funnel.unit.spec.ts
@@ -3,8 +3,6 @@
  * No Bitrix24 portal required — these are pure functions with no I/O.
  */
 import { describe, it, expect } from 'vitest'
-import { readFileSync, readdirSync } from 'node:fs'
-import { join, resolve } from 'node:path'
 import {
   baseStage,
   analyseFunnel,
@@ -25,6 +23,13 @@ describe('baseStage', () => {
 
   it('handles the first category (C1:)', () => {
     expect(baseStage('C1:EXECUTING')).toBe('EXECUTING')
+  })
+
+  it('keeps only the first segment when the id carries a second colon', () => {
+    // `split(':')[1]` takes one segment, so anything past a second colon is
+    // dropped. Bitrix24 stage ids are `C{n}:{STATUS}` with no further colons,
+    // so this pins the truncation as known and accepted, not as a surprise.
+    expect(baseStage('C2:WON:EXTRA')).toBe('WON')
   })
 
   it('falls back to the original string when the suffix is empty ("C2:")', () => {
@@ -102,40 +107,5 @@ describe('analyseFunnel', () => {
     ]
     const result = analyseFunnel(deals)
     expect(result.get('WON')).toEqual({ count: 2, total: 4500 })
-  })
-})
-
-/**
- * #64a — the helpers above are only worth testing if they are the ones the
- * recipes actually run.
- *
- * Recipes 03 and 06 each carried their own inline `baseStage`, written as
- * `s.includes(':') ? s.split(':')[1] : s`. That copy returns `''` for `'C2:'`,
- * where the tested copy in `lib/funnel.ts` returns `'C2:'` — so the case pinned
- * at line 30 above was pinning behaviour no shipped recipe had. Nothing caught
- * it, because a duplicate is invisible to a test that imports the original.
- *
- * These guards keep the collapse from silently coming undone.
- */
-describe('#64a — recipes use the tested helper, not a private copy', () => {
-  const examplesDir = resolve(__dirname, '../../../skills/b24jssdk-recipes/examples')
-  const exampleFiles = readdirSync(examplesDir).filter(name => name.endsWith('.ts'))
-
-  it('finds the recipe files (guards against an empty sweep passing vacuously)', () => {
-    expect(exampleFiles.length).toBeGreaterThan(0)
-  })
-
-  it.each(exampleFiles)('%s declares no baseStage of its own', (name) => {
-    const source = readFileSync(join(examplesDir, name), 'utf8')
-    // Any local binding of the name — `const`/`let`/`function` — is a second copy.
-    expect(source).not.toMatch(/(?:const|let|var|function)\s+baseStage\b/)
-  })
-
-  it.each(exampleFiles)('%s imports baseStage from lib/funnel if it uses it', (name) => {
-    const source = readFileSync(join(examplesDir, name), 'utf8')
-    if (!/\bbaseStage\s*\(/.test(source)) {
-      return
-    }
-    expect(source).toMatch(/import\s*\{[^}]*\bbaseStage\b[^}]*\}\s*from\s*'\.\.\/lib\/funnel'/)
   })
 })

--- a/test/integration/skills-recipes/crm-analytics-funnel.unit.spec.ts
+++ b/test/integration/skills-recipes/crm-analytics-funnel.unit.spec.ts
@@ -3,6 +3,8 @@
  * No Bitrix24 portal required — these are pure functions with no I/O.
  */
 import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 import {
   baseStage,
   analyseFunnel,
@@ -100,5 +102,40 @@ describe('analyseFunnel', () => {
     ]
     const result = analyseFunnel(deals)
     expect(result.get('WON')).toEqual({ count: 2, total: 4500 })
+  })
+})
+
+/**
+ * #64a — the helpers above are only worth testing if they are the ones the
+ * recipes actually run.
+ *
+ * Recipes 03 and 06 each carried their own inline `baseStage`, written as
+ * `s.includes(':') ? s.split(':')[1] : s`. That copy returns `''` for `'C2:'`,
+ * where the tested copy in `lib/funnel.ts` returns `'C2:'` — so the case pinned
+ * at line 30 above was pinning behaviour no shipped recipe had. Nothing caught
+ * it, because a duplicate is invisible to a test that imports the original.
+ *
+ * These guards keep the collapse from silently coming undone.
+ */
+describe('#64a — recipes use the tested helper, not a private copy', () => {
+  const examplesDir = resolve(__dirname, '../../../skills/b24jssdk-recipes/examples')
+  const exampleFiles = readdirSync(examplesDir).filter(name => name.endsWith('.ts'))
+
+  it('finds the recipe files (guards against an empty sweep passing vacuously)', () => {
+    expect(exampleFiles.length).toBeGreaterThan(0)
+  })
+
+  it.each(exampleFiles)('%s declares no baseStage of its own', (name) => {
+    const source = readFileSync(join(examplesDir, name), 'utf8')
+    // Any local binding of the name — `const`/`let`/`function` — is a second copy.
+    expect(source).not.toMatch(/(?:const|let|var|function)\s+baseStage\b/)
+  })
+
+  it.each(exampleFiles)('%s imports baseStage from lib/funnel if it uses it', (name) => {
+    const source = readFileSync(join(examplesDir, name), 'utf8')
+    if (!/\bbaseStage\s*\(/.test(source)) {
+      return
+    }
+    expect(source).toMatch(/import\s*\{[^}]*\bbaseStage\b[^}]*\}\s*from\s*'\.\.\/lib\/funnel'/)
   })
 })

--- a/test/integration/skills-recipes/crypto.unit.spec.ts
+++ b/test/integration/skills-recipes/crypto.unit.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Behavioural tests for `skills/b24jssdk-recipes/lib/crypto.ts`.
+ *
+ * `safeEqual` was extracted from recipes 07 and 12 (#64a), where it guards an
+ * `application_token` and an OAuth secret. The hygiene spec proves the recipes
+ * import this copy rather than forking it; these prove the copy is correct.
+ *
+ * The case that matters most is the length mismatch: `node:crypto`'s
+ * `timingSafeEqual` *throws* on unequal-length buffers rather than returning
+ * false, so a compare that forgot the pre-check would not quietly return the
+ * wrong answer — it would blow up inside a webhook handler. Pinning "returns
+ * false, does not throw" is pinning the reason the wrapper exists.
+ *
+ * Pure functions, no portal — jsSdk:unit.
+ */
+import { describe, it, expect } from 'vitest'
+import { safeEqual } from '../../../skills/b24jssdk-recipes/lib/crypto'
+
+describe('safeEqual', () => {
+  it('is true for identical strings', () => {
+    expect(safeEqual('s3cret-token', 's3cret-token')).toBe(true)
+  })
+
+  it('is false for same-length strings that differ', () => {
+    expect(safeEqual('s3cret-token', 's3cret-tokeN')).toBe(false)
+    // Differing in the first byte must be no different from the last — that is
+    // the property the constant-time compare buys.
+    expect(safeEqual('abcdef', 'Xbcdef')).toBe(false)
+    expect(safeEqual('abcdef', 'abcdeX')).toBe(false)
+  })
+
+  it('is false — never throws — when the lengths differ', () => {
+    // timingSafeEqual itself throws ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH here.
+    // The wrapper exists to turn that into a plain false.
+    expect(() => safeEqual('short', 'considerably-longer')).not.toThrow()
+    expect(safeEqual('short', 'considerably-longer')).toBe(false)
+    expect(safeEqual('considerably-longer', 'short')).toBe(false)
+    // A prefix is the shape an attacker probing one byte at a time produces.
+    expect(safeEqual('s3cret', 's3cret-token')).toBe(false)
+  })
+
+  it('is true for two empty strings', () => {
+    expect(safeEqual('', '')).toBe(true)
+  })
+
+  it('is false when only one side is empty', () => {
+    expect(safeEqual('', 'token')).toBe(false)
+    expect(safeEqual('token', '')).toBe(false)
+  })
+
+  it('compares by UTF-8 bytes, so multibyte characters are handled', () => {
+    expect(safeEqual('ключ', 'ключ')).toBe(true)
+    expect(safeEqual('ключ', 'клюя')).toBe(false)
+    // 'é' is two UTF-8 bytes and 'e' is one: a length mismatch in bytes even
+    // though both strings are one character. Must still be false, not a throw.
+    expect(safeEqual('é', 'e')).toBe(false)
+  })
+})

--- a/test/integration/skills-recipes/recipe-hygiene.unit.spec.ts
+++ b/test/integration/skills-recipes/recipe-hygiene.unit.spec.ts
@@ -38,6 +38,13 @@ const stripComments = (source: string) => source
 const readCode = (name: string) => stripComments(readFileSync(join(examplesDir, name), 'utf8'))
 
 /**
+ * Escape a literal for embedding in a RegExp. The module paths below contain
+ * `.` and `/`; escaping only the leading `../` would rely on the rest never
+ * gaining a metacharacter, which is an invariant nothing enforces.
+ */
+const escapeRegExp = (literal: string) => literal.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+
+/**
  * One row per helper that recipes must import rather than re-declare.
  * `bodyShape` is what every copy seen in the wild has looked like — matching it
  * is what stops a rename from walking straight past the name check.
@@ -65,7 +72,7 @@ describe('#64a — recipes use the tested helpers, not private copies', () => {
     // Tolerant of quote style and an explicit `.js` extension — both are
     // correct, and a guard that rejected them would be a false alarm.
     const importOf = new RegExp(
-      String.raw`import\s*\{[^}]*\b${name}\b[^}]*\}\s*from\s*['"]${module.replace('../', String.raw`\.\./`)}(?:\.js)?['"]`
+      String.raw`import\s*\{[^}]*\b${name}\b[^}]*\}\s*from\s*['"]${escapeRegExp(module)}(?:\.js)?['"]`
     )
 
     it.each(exampleFiles)(`%s declares no ${name} of its own`, (file) => {

--- a/test/integration/skills-recipes/recipe-hygiene.unit.spec.ts
+++ b/test/integration/skills-recipes/recipe-hygiene.unit.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * #64a — recipe hygiene: every shared helper has exactly one copy.
+ *
+ * The bug that motivated this: `baseStage` existed three times. Recipes 03 and
+ * 06 each carried `s.includes(':') ? s.split(':')[1] : s`, which returns `''`
+ * for `'C2:'`, while the tested copy in `lib/funnel.ts` returns `'C2:'`. So the
+ * suite was pinning behaviour no shipped recipe had.
+ *
+ * No recipe's control flow actually differed — neither `''` nor `'C2:'` matches
+ * a stage key, so both fell through the same way. The point is not that this
+ * drift bit, but that it went unnoticed: a duplicate is invisible to a test
+ * that imports the original, so nothing could have caught it. The next
+ * divergence might not be harmless, and for `safeEqual` — a constant-time
+ * compare — it would be a vulnerability that looks like a refactor.
+ *
+ * These are source-text guards, so be honest about the ceiling: they catch a
+ * verbatim copy and a rename of one, because they check the helper's body shape
+ * as well as its name. They cannot catch an independent re-implementation that
+ * reaches the same result by different syntax (`s.slice(s.indexOf(':') + 1)`
+ * would slip past). That is inherent to matching text rather than behaviour —
+ * treat these as a ratchet against the copy-paste that actually happened, not
+ * as proof that no fourth copy can ever exist.
+ *
+ * Pure text inspection, no portal — jsSdk:unit.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const examplesDir = resolve(__dirname, '../../../skills/b24jssdk-recipes/examples')
+const exampleFiles = readdirSync(examplesDir).filter(name => name.endsWith('.ts'))
+
+/** Blank out comments so a prose mention is never read as code. */
+const stripComments = (source: string) => source
+  .replaceAll(/\/\*[\s\S]*?\*\//g, ' ')
+  .replaceAll(/\/\/[^\n]*/g, ' ')
+
+const readCode = (name: string) => stripComments(readFileSync(join(examplesDir, name), 'utf8'))
+
+/**
+ * One row per helper that recipes must import rather than re-declare.
+ * `bodyShape` is what every copy seen in the wild has looked like — matching it
+ * is what stops a rename from walking straight past the name check.
+ */
+const SHARED_HELPERS = [
+  {
+    name: 'baseStage',
+    module: '../lib/funnel',
+    bodyShape: /\.split\(\s*['"`]:['"`]\s*\)\s*\[\s*1\s*\]/
+  },
+  {
+    name: 'safeEqual',
+    module: '../lib/crypto',
+    bodyShape: /\btimingSafeEqual\s*\(/
+  }
+] as const
+
+describe('#64a — recipes use the tested helpers, not private copies', () => {
+  it('finds the recipe files (an empty sweep would pass everything vacuously)', () => {
+    expect(exampleFiles.length).toBeGreaterThan(0)
+  })
+
+  describe.each(SHARED_HELPERS)('$name', ({ name, module, bodyShape }) => {
+    const declaration = new RegExp(String.raw`(?:const|let|var|function)\s+${name}\b`)
+    // Tolerant of quote style and an explicit `.js` extension — both are
+    // correct, and a guard that rejected them would be a false alarm.
+    const importOf = new RegExp(
+      String.raw`import\s*\{[^}]*\b${name}\b[^}]*\}\s*from\s*['"]${module.replace('../', String.raw`\.\./`)}(?:\.js)?['"]`
+    )
+
+    it.each(exampleFiles)(`%s declares no ${name} of its own`, (file) => {
+      expect(readCode(file)).not.toMatch(declaration)
+    })
+
+    it.each(exampleFiles)(`%s does not re-implement ${name} under another name`, (file) => {
+      expect(readCode(file)).not.toMatch(bodyShape)
+    })
+
+    it.each(exampleFiles)(`%s imports ${name} from ${module} if it uses it`, (file) => {
+      const code = readCode(file)
+      if (!new RegExp(String.raw`\b${name}\s*\(`).test(code)) {
+        return
+      }
+      expect(code).toMatch(importOf)
+    })
+  })
+})

--- a/test/integration/skills-recipes/recipe-hygiene.unit.spec.ts
+++ b/test/integration/skills-recipes/recipe-hygiene.unit.spec.ts
@@ -48,6 +48,12 @@ const escapeRegExp = (literal: string) => literal.replaceAll(/[.*+?^${}()|[\]\\]
  * One row per helper that recipes must import rather than re-declare.
  * `bodyShape` is what every copy seen in the wild has looked like — matching it
  * is what stops a rename from walking straight past the name check.
+ *
+ * `safeEqual`'s shape probe is deliberately the broad `timingSafeEqual(`, which
+ * also fires on a recipe calling that primitive directly for some other reason.
+ * That is intended, not a false positive: a recipe needing a constant-time
+ * compare should get it from `lib/crypto`, so being stopped here is the right
+ * outcome — and the failure points at the module to use.
  */
 const SHARED_HELPERS = [
   {
@@ -85,6 +91,11 @@ describe('#64a — recipes use the tested helpers, not private copies', () => {
 
     it.each(exampleFiles)(`%s imports ${name} from ${module} if it uses it`, (file) => {
       const code = readCode(file)
+      // Keyed on the literal call-site name, so an aliased import
+      // (`import { safeEqual as safeEq }`) makes this a no-op rather than a
+      // failure. That is fine — an alias still resolves to the shared copy, so
+      // there is nothing to catch — but do not read a pass here as proof the
+      // file was checked. The two guards above are the ones that bite.
       if (!new RegExp(String.raw`\b${name}\s*\(`).test(code)) {
         return
       }


### PR DESCRIPTION
Refs #64. Prerequisite for the rest of that issue — **does not close it**.

## Two helpers, each with copies that had drifted

### `baseStage` — three copies

| Copy | `'C2:'` → |
| --- | --- |
| `lib/funnel.ts` — the tested one | `'C2:'` |
| `examples/03-task-automation.ts` — inline | `''` |
| `examples/06-telegram-bot.ts` — inline | `''` |

The inline form is `s.includes(':') ? s.split(':')[1] : s`; when the suffix is empty, `split(':')[1]` is `''`. `lib/funnel.ts` deliberately falls back to the input. That case is **pinned by an existing test**, so the suite was asserting behaviour no shipped recipe had.

**To be accurate about the stakes:** no recipe's control flow actually differed. Neither `''` nor `'C2:'` matches a stage key, so both fell through identically. The point is that the drift went unnoticed — a duplicate is invisible to a test that imports the original, so nothing could have caught it.

A **fourth** copy was published on the docs site: `docs/content/docs/99.examples/1.crm-analytics.md` embeds recipe 01's source including the pre-fix helper, while the recipe it links to imports from `lib/funnel`. Fixed.

### `safeEqual` — two copies, and this one matters

Found by the QA reviewer. A **constant-time secret compare**, byte-identical in `examples/07-webhook-handler.ts` and `examples/12-oauth-install.ts`, differing only in JSDoc. Same defect class, in the one place where drift is not cosmetic: a constant-time compare that diverges in one of two forks is a vulnerability that reads like a refactor.

Extracted to `lib/crypto.ts`, and given the behavioural tests it never had — including the case that justifies the wrapper: `timingSafeEqual` *throws* on a length mismatch, so "returns false, does not throw" is the whole reason it exists.

The security guide (`79.security.md`) also claimed the length pre-check "avoids leaking length". It does not — the early return is length-dependent. Corrected, with the note that padding is not the fix.

## Recipes are no longer all standalone

`SKILL.md`'s frontmatter called every recipe "self-contained". That stopped being true before this PR (recipe 01 already imported from `lib/`) and now covers five of twelve. The claim is corrected and the Running section lists which lib file to copy with which recipe.

`SKILL.md` now also states what `lib/` is *for*: helpers where a second hand-written copy is a defect — a security primitive, or logic with edge cases a test pins — not shared plumbing. Every extraction costs a reader the ability to lift one file and run it.

## Guards

`test/integration/skills-recipes/recipe-hygiene.unit.spec.ts`, table-driven over both helpers, sweeping `examples/` by directory so a future recipe is covered on arrival. Per helper: no local binding of the name; no re-implementation matching the body shape; and an import from the shared module if it is called. Plus one test that the sweep found files at all.

Each was verified by mutation: duplicating, renaming, and dropping the import all redden the right guards.

**Stated ceiling, not overclaimed:** these are source-text guards. They catch a copy and a rename of one. They cannot catch an independent re-implementation reaching the same result by other syntax (`s.slice(s.indexOf(':') + 1)` slips past). That is inherent to matching text rather than behaviour, and the docblock says so.

## What is left on #64

`tick`, `toOAuthParams` and `escape` still have no tests. This PR deliberately covers only the duplication, because writing those tests against helpers the recipes don't actually run would have repeated the same mistake at four times the scale.

## Gates

`skills:typecheck`, `docs:typecheck-blocks` (155 blocks), `docs-lint --strict`, `docs-link-check`, `check-v3-method-refs`, `check-api-reference-index`, `lint:md`, eslint, and 92 recipe unit tests — all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_