### PR TITLE
test(skills): cover tick, escape, toOAuthParams and handleUninstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,13 @@ jobs:
         # dedicated environment with secrets. See .github/contributing/testing.md.
         run: pnpm run package-jssdk:test:run-unit
 
+      - name: Run skill-recipe unit tests
+        # The recipes under skills/b24jssdk-recipes are shipped as guidance an
+        # agent will copy, so their internals get the same treatment as SDK
+        # code (#64). Held in their own vitest project because they are the
+        # only specs importing the recipes' opt-in packages.
+        run: pnpm run skills:test
+
       - name: Security audit
         # Audit prod + dev dependencies at the `moderate` threshold. Dev deps
         # execute during lint/typecheck/docs builds in CI, so a vulnerable one

--- a/docs/content/docs/2.working-with-the-rest-api/79.security.md
+++ b/docs/content/docs/2.working-with-the-rest-api/79.security.md
@@ -1,7 +1,7 @@
 ---
 title: Security for event-receiver apps
 description: 'Two hardening patterns for any server that receives Bitrix24 outbound events or OAuth install/uninstall callbacks: reply 200 before you verify, and compare application_token in constant time.'
-audited: 2026-08-24
+audited: 2026-08-25
 navigation.title: Security
 links:
   - label: Recipe 7 — webhook handler (source)

--- a/docs/content/docs/99.examples/12.oauth-install.md
+++ b/docs/content/docs/99.examples/12.oauth-install.md
@@ -42,6 +42,11 @@ pnpm add express
 export PORT=3001                             # default
 export B24_CLIENT_ID='local.abc123'          # from your Bitrix24 dev console
 export B24_CLIENT_SECRET='...'
+
+# Optional. Where the OAuth tokens are written. Defaults to
+# .oauth-store.json in the working directory, which is rarely where you
+# want portal credentials to live on a real server.
+export B24_OAUTH_STORE='/var/lib/myapp/tokens.json'
 ```
 
 In the Bitrix24 dev console:
@@ -70,7 +75,7 @@ curl https://your-server.example.com/portal/<memberId>/profile
 ## Notes
 
 - **Persistence is a JSON file** for demo purposes (`.oauth-store.json`). Replace with Postgres / Redis / your real datastore for production.
-- **`application_token`** — Bitrix24 sends this with both install and uninstall events. The recipe stores it but does not verify it on uninstall — in production, compare the value before removing credentials to protect against spoofed uninstall calls.
+- **`application_token`** — Bitrix24 sends this with both install and uninstall events. The recipe records it at install and compares it in constant time before removing anything on uninstall, so a spoofed uninstall call cannot wipe a portal's credentials. The install event carries no such secret to check against — it is where `application_token` is issued — so treat `/install` as unauthenticated and keep it behind whatever network controls your deployment allows.
 - **`setCallbackRefreshAuth`** is wired at every `clientForMember()` call. This ensures the storage always has the latest token pair after the SDK auto-refreshes a 401.
 - **Always return `2xx` first** on the install / uninstall endpoints, then process. Bitrix24 has no automatic retry (failed/slow deliveries are dropped; slow handlers get deprioritized) — see [Security patterns](/docs/working-with-the-rest-api/security/).
 - For multiple workers serving the same portal, use a transactional store (Postgres `ON CONFLICT UPDATE`) so concurrent refreshes don't lose tokens.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "docs:typecheck-blocks": "node scripts/docs-typecheck.mjs",
     "skills:typecheck": "tsc -p skills/b24jssdk-recipes/tsconfig.json",
     "package-jssdk:test:run-unit": "vitest run --project jsSdk:unit",
+    "skills:test": "vitest run --project skills:unit",
     "package-jssdk:test": "vitest --project jsSdk:integration",
     "package-jssdk:test:run": "vitest run --project jsSdk:integration --project jsSdk:contributing-snippets",
     "package-jssdk:test-contributing-snippets": "vitest run --project jsSdk:contributing-snippets",

--- a/skills/b24jssdk-recipes/SKILL.md
+++ b/skills/b24jssdk-recipes/SKILL.md
@@ -49,9 +49,18 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 `npx tsx 06-telegram-bot.ts` still runs exactly as before — the guard is only false
 when the file is *imported*, which is what the unit tests do to exercise `tick`'s
 cursor logic and the uninstall token check without opening a Telegram connection or
-binding a port. Keep it when copying those two recipes; add it to a recipe you want
-to write tests against. The exported `function`s in those files are exported for the
-same reason, and `export` is inert when the file runs directly.
+binding a port. Keep it when copying those two recipes. Before adding it to a third, prefer the
+`lib/` route above: extract the logic and test it there. Reach for the guard only when
+the function cannot reasonably leave the recipe — `tick` closes over a live bot and the
+poll cursor, `handleUninstall` is an Express handler — because two shapes of recipe is
+already one more than ideal, and the guard spreading to all twelve would quietly retire
+the `lib/` convention. The exported `function`s in those files are exported for the same
+reason, and `export` is inert when the file runs directly.
+
+One deployment caveat: the guard compares `import.meta.url` against `process.argv[1]`.
+Under an exotic launcher that rewrites either — a wrapper CLI, some loader shims — the
+comparison can come out false, and the process would exit 0 having started nothing.
+Check for the recipe's startup log line rather than trusting the exit code.
 
 | File | Exports | Used by |
 | --- | --- | --- |
@@ -123,6 +132,9 @@ pnpm add @bitrix24/b24jssdk
 #   recipe 8: pnpm add openai
 #   recipe 9: pnpm add openai
 #   recipe 12: pnpm add express
+# Recipe 12 also honours B24_OAUTH_STORE — where to write the OAuth token
+# store. Defaults to .oauth-store.json in the working directory, which is
+# rarely where portal credentials should live on a real server.
 
 # 2. Set env
 export B24_HOOK='https://YOUR_PORTAL.bitrix24.com/rest/1/k32t88gf3azpmwv3'

--- a/skills/b24jssdk-recipes/SKILL.md
+++ b/skills/b24jssdk-recipes/SKILL.md
@@ -38,6 +38,21 @@ recipes and stays that way on purpose. It has no edge cases to pin and no securi
 weight, and it is the first thing a reader needs to see when they open a recipe —
 hiding it behind an import would cost more than the duplication does.
 
+Recipes 06 and 12 end with a guard instead of a bare `main()` call:
+
+```ts
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(...)
+}
+```
+
+`npx tsx 06-telegram-bot.ts` still runs exactly as before — the guard is only false
+when the file is *imported*, which is what the unit tests do to exercise `tick`'s
+cursor logic and the uninstall token check without opening a Telegram connection or
+binding a port. Keep it when copying those two recipes; add it to a recipe you want
+to write tests against. The exported `function`s in those files are exported for the
+same reason, and `export` is inert when the file runs directly.
+
 | File | Exports | Used by |
 | --- | --- | --- |
 | `lib/funnel.ts` | `baseStage`, `analyseFunnel`, `DealRow`, `StageStat` | recipes 01, 03, 06 |

--- a/skills/b24jssdk-recipes/examples/06-telegram-bot.ts
+++ b/skills/b24jssdk-recipes/examples/06-telegram-bot.ts
@@ -21,6 +21,7 @@ import {
   Logger,
   type TypeB24
 } from '@bitrix24/b24jssdk'
+import { pathToFileURL } from 'node:url'
 import { baseStage } from '../lib/funnel'
 import { Bot } from 'grammy'
 import cron from 'node-cron'
@@ -90,7 +91,7 @@ async function fetchContactName($b24: TypeB24, contactId?: number): Promise<stri
   return `${c.name ?? ''} ${c.lastName ?? ''}`.trim() || 'Anonymous'
 }
 
-function format(deal: DealRow, contactName: string): string {
+export function format(deal: DealRow, contactName: string): string {
   return [
     '🆕 <b>New deal</b>',
     '',
@@ -102,11 +103,11 @@ function format(deal: DealRow, contactName: string): string {
   ].join('\n')
 }
 
-function escape(s: string): string {
+export function escape(s: string): string {
   return s.replace(/[<>&]/g, c => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]!))
 }
 
-async function tick($b24: TypeB24, bot: Bot, chatId: string) {
+export async function tick($b24: TypeB24, bot: Bot, chatId: string) {
   logger.info(`[${new Date().toISOString()}] checking new deals…`)
   const deals = await fetchNewDeals($b24)
   if (deals.length === 0) {
@@ -155,9 +156,15 @@ async function main() {
   await bot.start()
 }
 
-main().catch((e: unknown) => {
-  // Raw console.error so structured-logger formatting can't hide the trace.
-  console.error('\n[recipe failed]', e instanceof Error ? `${e.name}: ${e.message}` : String(e))
-  if (e instanceof Error && e.stack) console.error(e.stack)
-  process.exit(1)
-})
+// Start the bot only when this file IS the program being run. Importing it —
+// which the unit tests do, to exercise `tick`'s cursor logic — must not open a
+// Telegram connection or start polling the portal. `npx tsx 06-telegram-bot.ts`
+// still runs normally.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((e: unknown) => {
+    // Raw console.error so structured-logger formatting can't hide the trace.
+    console.error('\n[recipe failed]', e instanceof Error ? `${e.name}: ${e.message}` : String(e))
+    if (e instanceof Error && e.stack) console.error(e.stack)
+    process.exit(1)
+  })
+}

--- a/skills/b24jssdk-recipes/examples/06-telegram-bot.ts
+++ b/skills/b24jssdk-recipes/examples/06-telegram-bot.ts
@@ -103,6 +103,15 @@ export function format(deal: DealRow, contactName: string): string {
   ].join('\n')
 }
 
+/**
+ * Escape portal text for Telegram's HTML parse mode.
+ *
+ * `<`, `>` and `&` are the full set Telegram requires — in element TEXT. Quotes
+ * are deliberately left alone because `format()` never builds an attribute out
+ * of portal data. If you add one — an `<a href="…">` around a deal title, say —
+ * this must gain `"` and `'` handling first, or the title becomes an injection
+ * point. `telegram-escape.unit.spec.ts` pins that assumption.
+ */
 export function escape(s: string): string {
   return s.replace(/[<>&]/g, c => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]!))
 }

--- a/skills/b24jssdk-recipes/examples/12-oauth-install.ts
+++ b/skills/b24jssdk-recipes/examples/12-oauth-install.ts
@@ -37,6 +37,7 @@ import {
 import express, { type Request, type Response } from 'express'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { safeEqual } from '../lib/crypto'
 
 const logger = Logger.create('OAuthInstall')
@@ -52,7 +53,10 @@ const SECRET: B24OAuthSecret = {
 //  Replace with your real datastore (Postgres, Redis, etc.) in production.
 // ────────────────────────────────────────────────────────────────────────
 
-const STORE_FILE = path.join(process.cwd(), '.oauth-store.json')
+// Overridable so a deployment can put the token store somewhere other than the
+// working directory — and so the unit tests can point it at a temp file instead
+// of writing real-looking credentials into the repo.
+const STORE_FILE = process.env.B24_OAUTH_STORE ?? path.join(process.cwd(), '.oauth-store.json')
 
 // B24OAuthParams already carries applicationToken; aliasing for clarity at storage boundary.
 type StoredCredentials = B24OAuthParams
@@ -132,7 +136,7 @@ interface UninstallEventPayload {
   }
 }
 
-function toOAuthParams(auth: InstallEventPayload['auth']): B24OAuthParams {
+export function toOAuthParams(auth: InstallEventPayload['auth']): B24OAuthParams {
   return {
     applicationToken: auth.application_token,
     userId: Number(auth.user_id),
@@ -171,7 +175,7 @@ async function handleInstall(req: Request, res: Response) {
   logger.info(`[${payload.event}] member=${params.memberId}`)
 }
 
-async function handleUninstall(req: Request, res: Response) {
+export async function handleUninstall(req: Request, res: Response) {
   const payload = req.body as UninstallEventPayload
   // Always 200 — even on bad payloads — so Bitrix24 doesn't retry for 24h.
   res.status(200).send('ok')
@@ -327,9 +331,14 @@ async function main() {
   })
 }
 
-main().catch((e: unknown) => {
-  // Raw console.error so structured-logger formatting can't hide the trace.
-  console.error('\n[recipe failed]', e instanceof Error ? `${e.name}: ${e.message}` : String(e))
-  if (e instanceof Error && e.stack) console.error(e.stack)
-  process.exit(1)
-})
+// Start the server only when this file IS the program being run. Importing it —
+// which the unit tests do, to exercise the uninstall token check — must not bind
+// a port. `npx tsx 12-oauth-install.ts` still runs normally.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((e: unknown) => {
+    // Raw console.error so structured-logger formatting can't hide the trace.
+    console.error('\n[recipe failed]', e instanceof Error ? `${e.name}: ${e.message}` : String(e))
+    if (e instanceof Error && e.stack) console.error(e.stack)
+    process.exit(1)
+  })
+}

--- a/skills/b24jssdk-recipes/examples/12-oauth-install.ts
+++ b/skills/b24jssdk-recipes/examples/12-oauth-install.ts
@@ -13,6 +13,8 @@
  *   PORT=3001 (default)
  *   B24_CLIENT_ID=local.abc123        # from your Bitrix24 dev console
  *   B24_CLIENT_SECRET=...
+ *   B24_OAUTH_STORE=/var/lib/myapp/tokens.json   # optional; default is
+ *                                                # .oauth-store.json in cwd
  * Run:
  *   npx tsx 12-oauth-install.ts
  *

--- a/test/integration/skills-recipes/oauth-install.unit.spec.ts
+++ b/test/integration/skills-recipes/oauth-install.unit.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * #64 — `toOAuthParams()` and `handleUninstall()` from recipe 12-oauth-install.ts.
+ *
+ * `toOAuthParams` maps Bitrix24's all-strings event payload onto the SDK's
+ * typed `B24OAuthParams`. Every numeric field goes through `Number()` and the
+ * status through a whitelist lookup, so the interesting cases are the ones
+ * where the portal sends something unexpected.
+ *
+ * `handleUninstall` is a security boundary: the endpoint is reachable by
+ * anyone, and it deletes stored portal credentials. It is guarded by a
+ * constant-time comparison of `application_token` against the value recorded at
+ * install. The two branches that must not regress are "no stored credentials →
+ * idempotent no-op" and "token mismatch → refuse to delete".
+ *
+ * No portal, no network, no listening socket — the recipe's store is pointed at
+ * a temp file through B24_OAUTH_STORE. jsSdk:unit.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const authPayload = (over: Record<string, string> = {}) => ({
+  access_token: 'at-1',
+  expires: '1893456000',
+  expires_in: '3600',
+  scope: 'crm,user',
+  domain: 'acme.bitrix24.com',
+  server_endpoint: 'https://oauth.bitrix.info/rest/',
+  status: 'L',
+  client_endpoint: 'https://acme.bitrix24.com/rest/',
+  member_id: 'member-abc',
+  user_id: '7',
+  refresh_token: 'rt-1',
+  application_token: 'app-token-secret',
+  ...over
+})
+
+let storeDir: string
+let storeFile: string
+
+/** Fresh module with the store pointed at a temp file (STORE_FILE is read at load). */
+async function loadRecipe() {
+  vi.resetModules()
+  process.env.B24_OAUTH_STORE = storeFile
+  return await import('../../../skills/b24jssdk-recipes/examples/12-oauth-install')
+}
+
+const writeStore = (data: unknown) => writeFileSync(storeFile, JSON.stringify(data), 'utf8')
+const readStore = () => JSON.parse(readFileSync(storeFile, 'utf8'))
+
+/** Express-shaped response recording what the handler replied. */
+function fakeRes() {
+  const state = { code: 0, body: '' }
+  const res = {
+    status(code: number) {
+      state.code = code
+      return res
+    },
+    send(body: string) {
+      state.body = body
+      return res
+    }
+  }
+  return { res, state }
+}
+
+beforeEach(() => {
+  storeDir = mkdtempSync(join(tmpdir(), 'b24-oauth-'))
+  storeFile = join(storeDir, 'store.json')
+})
+afterEach(() => {
+  rmSync(storeDir, { recursive: true, force: true })
+  delete process.env.B24_OAUTH_STORE
+})
+
+describe('toOAuthParams (recipe 12)', () => {
+  it('maps the snake_case event payload onto the SDK shape', async () => {
+    const { toOAuthParams } = await loadRecipe()
+    const out = toOAuthParams(authPayload() as never)
+
+    expect(out).toMatchObject({
+      applicationToken: 'app-token-secret',
+      userId: 7,
+      memberId: 'member-abc',
+      accessToken: 'at-1',
+      refreshToken: 'rt-1',
+      expires: 1893456000,
+      expiresIn: 3600,
+      scope: 'crm,user',
+      domain: 'acme.bitrix24.com',
+      clientEndpoint: 'https://acme.bitrix24.com/rest/',
+      serverEndpoint: 'https://oauth.bitrix.info/rest/'
+    })
+  })
+
+  it('coerces the numeric fields, which arrive as strings', async () => {
+    const { toOAuthParams } = await loadRecipe()
+    const out = toOAuthParams(authPayload({ user_id: '42', expires_in: '3600' }) as never)
+    expect(out.userId).toBe(42)
+    expect(typeof out.userId).toBe('number')
+    expect(typeof out.expiresIn).toBe('number')
+  })
+
+  it('keeps a recognised status', async () => {
+    const { toOAuthParams } = await loadRecipe()
+    // 'L' is EnumAppStatus.Local — a real value, so it survives the lookup.
+    expect(toOAuthParams(authPayload({ status: 'L' }) as never).status).toBe('L')
+    expect(toOAuthParams(authPayload({ status: 'D' }) as never).status).toBe('D')
+  })
+
+  it('falls back to Free for an unknown status', async () => {
+    const { toOAuthParams } = await loadRecipe()
+    // The fallback is what stops an unrecognised portal status from producing
+    // an object that fails type expectations downstream.
+    expect(toOAuthParams(authPayload({ status: 'ZZZ' }) as never).status).toBe('F')
+    expect(toOAuthParams(authPayload({ status: '' }) as never).status).toBe('F')
+  })
+
+  it('produces NaN — not 0 — for a missing numeric field', async () => {
+    const { toOAuthParams } = await loadRecipe()
+    // Documented consequence of `Number(undefined)`. Pinned because NaN is
+    // visibly broken downstream, whereas a silent 0 would read as "expired at
+    // the epoch" and be much harder to trace back here.
+    const out = toOAuthParams({ ...authPayload(), user_id: undefined, expires: undefined } as never)
+    expect(out.userId).toBeNaN()
+    expect(out.expires).toBeNaN()
+  })
+})
+
+describe('handleUninstall (recipe 12)', () => {
+  const uninstallReq = (over: Record<string, string> = {}) => ({
+    body: {
+      event: 'ONAPPUNINSTALL',
+      auth: { member_id: 'member-abc', application_token: 'app-token-secret', ...over }
+    }
+  })
+
+  it('always answers 200, so Bitrix24 does not retry for 24h', async () => {
+    const { handleUninstall } = await loadRecipe()
+    writeStore({})
+    const { res, state } = fakeRes()
+
+    await handleUninstall({ body: {} } as never, res as never)
+
+    expect(state.code).toBe(200)
+    expect(state.body).toBe('ok')
+  })
+
+  it('deletes the credentials when the token matches', async () => {
+    const { handleUninstall } = await loadRecipe()
+    writeStore({ 'member-abc': { applicationToken: 'app-token-secret', accessToken: 'at-1' } })
+    const { res } = fakeRes()
+
+    await handleUninstall(uninstallReq() as never, res as never)
+
+    expect(readStore()).toEqual({})
+  })
+
+  it('is idempotent when no credentials are stored for the member', async () => {
+    const { handleUninstall } = await loadRecipe()
+    writeStore({ 'someone-else': { applicationToken: 'other' } })
+    const { res, state } = fakeRes()
+
+    await handleUninstall(uninstallReq({ member_id: 'unknown-member' }) as never, res as never)
+
+    expect(state.code).toBe(200)
+    // Nothing removed, and no crash on the missing key.
+    expect(readStore()).toEqual({ 'someone-else': { applicationToken: 'other' } })
+  })
+
+  it('refuses to delete when the application_token does not match', async () => {
+    // The attack this guards: anyone who can reach /uninstall and guess a
+    // member_id could otherwise wipe that portal's credentials.
+    const { handleUninstall } = await loadRecipe()
+    writeStore({ 'member-abc': { applicationToken: 'app-token-secret', accessToken: 'at-1' } })
+    const { res, state } = fakeRes()
+
+    await handleUninstall(uninstallReq({ application_token: 'wrong-token' }) as never, res as never)
+
+    expect(state.code).toBe(200)
+    expect(readStore()).toEqual({
+      'member-abc': { applicationToken: 'app-token-secret', accessToken: 'at-1' }
+    })
+  })
+
+  it('refuses a token that is a prefix of the real one', async () => {
+    // Length mismatch goes through safeEqual's early return; it must be a
+    // refusal, not a throw that leaves the handler half-done.
+    const { handleUninstall } = await loadRecipe()
+    writeStore({ 'member-abc': { applicationToken: 'app-token-secret' } })
+    const { res } = fakeRes()
+
+    await handleUninstall(uninstallReq({ application_token: 'app-token' }) as never, res as never)
+
+    expect(readStore()['member-abc']).toBeTruthy()
+  })
+
+  it('ignores a payload with no member_id or token, without writing the store', async () => {
+    const { handleUninstall } = await loadRecipe()
+    const { res, state } = fakeRes()
+
+    await handleUninstall({ body: { event: 'ONAPPUNINSTALL', auth: {} } } as never, res as never)
+
+    expect(state.code).toBe(200)
+    // Bailed before touching persistence — the file was never created.
+    expect(existsSync(storeFile)).toBe(false)
+  })
+})

--- a/test/integration/skills-recipes/oauth-install.unit.spec.ts
+++ b/test/integration/skills-recipes/oauth-install.unit.spec.ts
@@ -196,6 +196,26 @@ describe('handleUninstall (recipe 12)', () => {
     expect(readStore()['member-abc']).toBeTruthy()
   })
 
+  it('ignores a payload carrying only one of member_id / token', async () => {
+    // The bail is `!memberId || !receivedToken`. With both absent, `||` and
+    // `&&` agree, so only an asymmetric payload can tell them apart — and an
+    // `&&` here would fall through to the token check with an undefined token.
+    const { handleUninstall } = await loadRecipe()
+    writeStore({ 'member-abc': { applicationToken: 'app-token-secret' } })
+
+    await handleUninstall(
+      { body: { event: 'ONAPPUNINSTALL', auth: { member_id: 'member-abc' } } } as never,
+      fakeRes().res as never
+    )
+    expect(readStore()['member-abc']).toBeTruthy()
+
+    await handleUninstall(
+      { body: { event: 'ONAPPUNINSTALL', auth: { application_token: 'app-token-secret' } } } as never,
+      fakeRes().res as never
+    )
+    expect(readStore()['member-abc']).toBeTruthy()
+  })
+
   it('ignores a payload with no member_id or token, without writing the store', async () => {
     const { handleUninstall } = await loadRecipe()
     const { res, state } = fakeRes()

--- a/test/integration/skills-recipes/telegram-escape.unit.spec.ts
+++ b/test/integration/skills-recipes/telegram-escape.unit.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * #64 — `escape()` from recipe 06-telegram-bot.ts.
+ *
+ * This is the recipe's injection boundary: its output is interpolated into a
+ * message sent with `parse_mode: 'HTML'`, and the input is a CRM deal title or
+ * contact name — portal data, i.e. attacker-influenced if anyone can create a
+ * deal. An escape that misses a character lets a deal titled `<b>` reshape the
+ * notification, and Telegram rejects malformed entities outright, so a miss is
+ * both a spoofing vector and an outage.
+ *
+ * Pure function, no portal — jsSdk:unit.
+ */
+import { describe, it, expect } from 'vitest'
+import { escape, format } from '../../../skills/b24jssdk-recipes/examples/06-telegram-bot'
+
+describe('escape (recipe 06)', () => {
+  it('escapes the three characters Telegram HTML treats as markup', () => {
+    expect(escape('<')).toBe('&lt;')
+    expect(escape('>')).toBe('&gt;')
+    expect(escape('&')).toBe('&amp;')
+  })
+
+  it('neutralises a tag injected through a deal title', () => {
+    expect(escape('<b>URGENT</b>')).toBe('&lt;b&gt;URGENT&lt;/b&gt;')
+    expect(escape('</b><a href="http://evil">click</a>'))
+      .toBe('&lt;/b&gt;&lt;a href="http://evil"&gt;click&lt;/a&gt;')
+  })
+
+  it('does not double-escape an ampersand it just introduced', () => {
+    // Single-pass `replace` never re-scans its own output. If this were written
+    // as three chained replaces with `&` last, `<` would become `&amp;lt;`.
+    expect(escape('<&>')).toBe('&lt;&amp;&gt;')
+    expect(escape('&lt;')).toBe('&amp;lt;')
+  })
+
+  it('leaves text with no special characters untouched', () => {
+    expect(escape('Deal with ACME')).toBe('Deal with ACME')
+    expect(escape('')).toBe('')
+    expect(escape('цена 100 ₽')).toBe('цена 100 ₽')
+  })
+
+  it('leaves quotes alone — deliberately', () => {
+    // `escape` output is only ever placed in element TEXT, never inside an
+    // attribute value (see `format` below), so quotes need no escaping there.
+    // If a future edit interpolates it into an attribute, this must change.
+    expect(escape('say "hi"')).toBe('say "hi"')
+    expect(escape('it\'s')).toBe('it\'s')
+  })
+
+  it('handles a string that is only special characters', () => {
+    expect(escape('<<>>&&')).toBe('&lt;&lt;&gt;&gt;&amp;&amp;')
+  })
+})
+
+describe('format (recipe 06)', () => {
+  const deal = {
+    id: 42,
+    title: 'Deal',
+    opportunity: 1000,
+    currencyId: 'RUB',
+    contactId: 7,
+    createdTime: '2026-01-01T00:00:00Z',
+    stageId: 'NEW'
+  }
+
+  it('escapes the two portal-controlled fields it interpolates', () => {
+    const out = format({ ...deal, title: '<b>x</b>' }, '<i>y</i>')
+    expect(out).toContain('&lt;b&gt;x&lt;/b&gt;')
+    expect(out).toContain('&lt;i&gt;y&lt;/i&gt;')
+    // The raw forms must not survive anywhere in the message.
+    expect(out).not.toContain('<b>x')
+    expect(out).not.toContain('<i>y')
+  })
+
+  it('keeps its own markup tags intact', () => {
+    // The escaping must not neutralise the template's own <b> labels.
+    expect(format(deal, 'Ann')).toContain('<b>Title:</b>')
+  })
+
+  it('never places escaped text inside an attribute', () => {
+    // The assumption the quote decision above rests on. If this fails, `escape`
+    // needs to cover `"` and `'` as well.
+    expect(format({ ...deal, title: 'x' }, 'y')).not.toMatch(/<[a-z]+\s+[a-z-]+=/i)
+  })
+})

--- a/test/integration/skills-recipes/telegram-tick.unit.spec.ts
+++ b/test/integration/skills-recipes/telegram-tick.unit.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * #64 — `tick()` from recipe 06-telegram-bot.ts: the cursor logic.
+ *
+ * `tick` walks new deals in id-ascending order and advances `lastSeenDealId`
+ * per deal. On a send failure it `break`s rather than `continue`s, and that
+ * choice is the whole design: with `continue`, deals after the failed one would
+ * be delivered while the cursor stayed behind them, so the next tick would
+ * re-send them as duplicates. `break` keeps the cursor a *contiguous prefix* of
+ * what was delivered — at-least-once, never twice.
+ *
+ * A comment cannot enforce that. Someone "fixing" the loop to be more resilient
+ * by swapping `break` for `continue` would produce duplicate Telegram messages
+ * that only appear on the tick after a partial failure, which is exactly the
+ * bug nobody reproduces locally. These tests pin it.
+ *
+ * The recipe is driven through fakes for `$b24` and the grammy bot, so no
+ * portal and no network — jsSdk:unit.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+interface FakeDeal {
+  id: number
+  title: string
+  opportunity: number
+  currencyId: string
+  contactId?: number
+  createdTime: string
+  stageId: string
+}
+
+const deal = (id: number, stageId = 'NEW'): FakeDeal => ({
+  id,
+  title: `Deal ${id}`,
+  opportunity: 100 * id,
+  currencyId: 'RUB',
+  contactId: undefined,
+  createdTime: '2026-01-01T00:00:00Z',
+  stageId
+})
+
+/**
+ * Minimal stand-in for the SDK surface `tick` reaches through: one `call.make`
+ * that answers `crm.item.list` from a queue of batches and `crm.item.get` with a
+ * fixed contact. Records the `>id` filter of every list call so the cursor can
+ * be observed from outside without the recipe exporting it.
+ */
+function fakeB24(batches: FakeDeal[][], opts: { listFails?: boolean } = {}) {
+  const cursors: number[] = []
+  let batch = 0
+  const $b24 = {
+    actions: {
+      v2: {
+        call: {
+          make: async (options: { method: string, params?: Record<string, unknown> }) => {
+            if (options.method === 'crm.item.list') {
+              const filter = options.params?.filter as Record<string, number> | undefined
+              cursors.push(filter?.['>id'] ?? -1)
+              if (opts.listFails) {
+                return {
+                  isSuccess: false,
+                  getErrorMessages: () => ['portal said no'],
+                  getData: () => null
+                }
+              }
+              const items = batches[batch] ?? []
+              batch += 1
+              return { isSuccess: true, getErrorMessages: () => [], getData: () => ({ result: { items } }) }
+            }
+            // crm.item.get — contact lookup
+            return {
+              isSuccess: true,
+              getErrorMessages: () => [],
+              getData: () => ({ result: { item: { name: 'Ann', lastName: 'Lee' } } })
+            }
+          }
+        }
+      }
+    }
+  }
+  return { $b24, cursors }
+}
+
+/** Bot whose sendMessage throws for the deal ids named in `failOn`. */
+function fakeBot(failOn: number[] = []) {
+  const sent: string[] = []
+  const bot = {
+    api: {
+      sendMessage: async (_chatId: string, text: string) => {
+        const id = Number(/ID:<\/b> (\d+)/.exec(text)?.[1] ?? -1)
+        if (failOn.includes(id)) {
+          throw new Error(`telegram rejected ${id}`)
+        }
+        sent.push(text)
+      }
+    }
+  }
+  return { bot, sent }
+}
+
+const idsOf = (sent: string[]) => sent.map(t => Number(/ID:<\/b> (\d+)/.exec(t)?.[1]))
+
+/** Fresh module per test — `lastSeenDealId` is module state and must not leak. */
+async function loadRecipe() {
+  vi.resetModules()
+  return await import('../../../skills/b24jssdk-recipes/examples/06-telegram-bot')
+}
+
+describe('tick (recipe 06) — cursor advances as a contiguous prefix', () => {
+  it('sends nothing and leaves the cursor at 0 when there are no new deals', async () => {
+    const { tick } = await loadRecipe()
+    const { $b24, cursors } = fakeB24([[]])
+    const { bot, sent } = fakeBot()
+
+    await tick($b24 as never, bot as never, 'chat')
+
+    expect(sent).toEqual([])
+    expect(cursors).toEqual([0])
+  })
+
+  it('notifies every deal and advances the cursor to the highest id', async () => {
+    const { tick } = await loadRecipe()
+    const { $b24, cursors } = fakeB24([[deal(1), deal(2), deal(3)], []])
+    const { bot, sent } = fakeBot()
+
+    await tick($b24 as never, bot as never, 'chat')
+    expect(idsOf(sent)).toEqual([1, 2, 3])
+
+    // The next tick asks for deals after 3 — proof the cursor moved.
+    await tick($b24 as never, bot as never, 'chat')
+    expect(cursors).toEqual([0, 3])
+  })
+
+  it('stops at the first failure and does NOT deliver later deals', async () => {
+    const { tick } = await loadRecipe()
+    const { $b24, cursors } = fakeB24([[deal(1), deal(2), deal(3)], []])
+    const { bot, sent } = fakeBot([2])
+
+    await tick($b24 as never, bot as never, 'chat')
+
+    // 1 delivered; 2 failed; 3 must NOT have been sent even though it would
+    // have succeeded — that is `break`, not `continue`.
+    expect(idsOf(sent)).toEqual([1])
+    // Cursor sits at 1, so deals 2 and 3 are retried next tick.
+    await tick($b24 as never, bot as never, 'chat')
+    expect(cursors).toEqual([0, 1])
+  })
+
+  it('re-delivers nothing already delivered after a partial failure', async () => {
+    // The property `break` exists to protect: across two ticks spanning a
+    // failure, no deal is sent twice.
+    const { tick } = await loadRecipe()
+    const { $b24 } = fakeB24([[deal(1), deal(2), deal(3)], [deal(2), deal(3)], []])
+    const first = fakeBot([2])
+    await tick($b24 as never, first.bot as never, 'chat')
+
+    const second = fakeBot()
+    await tick($b24 as never, second.bot as never, 'chat')
+
+    const allSent = [...idsOf(first.sent), ...idsOf(second.sent)]
+    expect(allSent).toEqual([1, 2, 3])
+    expect(new Set(allSent).size).toBe(allSent.length)
+  })
+
+  it('leaves the cursor untouched when the deal fetch itself fails', async () => {
+    const { tick } = await loadRecipe()
+    const { $b24, cursors } = fakeB24([], { listFails: true })
+    const { bot, sent } = fakeBot()
+
+    await tick($b24 as never, bot as never, 'chat')
+    await tick($b24 as never, bot as never, 'chat')
+
+    expect(sent).toEqual([])
+    // Both ticks asked from 0 — a failed fetch must not look like "no deals".
+    expect(cursors).toEqual([0, 0])
+  })
+
+  it('ignores deals whose base stage is not NEW', async () => {
+    const { tick } = await loadRecipe()
+    // Multi-funnel prefixes are stripped by baseStage before the comparison.
+    const { $b24 } = fakeB24([[deal(1, 'C2:NEW'), deal(2, 'PREPARATION'), deal(3, 'NEW')], []])
+    const { bot, sent } = fakeBot()
+
+    await tick($b24 as never, bot as never, 'chat')
+
+    expect(idsOf(sent)).toEqual([1, 3])
+  })
+
+  it('advances past a filtered-out deal without re-fetching it', async () => {
+    // Deal 2 is skipped by the stage filter, so the cursor lands on 3 — the
+    // highest *delivered* id — and deal 2 is never reconsidered.
+    const { tick } = await loadRecipe()
+    const { $b24, cursors } = fakeB24([[deal(1), deal(2, 'LOSE'), deal(3)], []])
+    const { bot } = fakeBot()
+
+    await tick($b24 as never, bot as never, 'chat')
+    await tick($b24 as never, bot as never, 'chat')
+
+    expect(cursors).toEqual([0, 3])
+  })
+})

--- a/test/integration/skills-recipes/telegram-tick.unit.spec.ts
+++ b/test/integration/skills-recipes/telegram-tick.unit.spec.ts
@@ -44,7 +44,7 @@ const deal = (id: number, stageId = 'NEW'): FakeDeal => ({
  * fixed contact. Records the `>id` filter of every list call so the cursor can
  * be observed from outside without the recipe exporting it.
  */
-function fakeB24(batches: FakeDeal[][], opts: { listFails?: boolean } = {}) {
+function fakeB24(batches: FakeDeal[][], opts: { listFails?: boolean, contactFails?: boolean } = {}) {
   const cursors: number[] = []
   let batch = 0
   const $b24 = {
@@ -67,6 +67,9 @@ function fakeB24(batches: FakeDeal[][], opts: { listFails?: boolean } = {}) {
               return { isSuccess: true, getErrorMessages: () => [], getData: () => ({ result: { items } }) }
             }
             // crm.item.get — contact lookup
+            if (opts.contactFails) {
+              return { isSuccess: false, getErrorMessages: () => ['no such contact'], getData: () => null }
+            }
             return {
               isSuccess: true,
               getErrorMessages: () => [],
@@ -183,6 +186,37 @@ describe('tick (recipe 06) — cursor advances as a contiguous prefix', () => {
     await tick($b24 as never, bot as never, 'chat')
 
     expect(idsOf(sent)).toEqual([1, 3])
+  })
+
+  it('keeps the highest id when a batch is not ascending', async () => {
+    // The cursor is `Math.max(lastSeenDealId, d.id)`, not a plain assignment.
+    // The API is asked for `order: { id: 'asc' }`, so in practice ids arrive
+    // ascending and the two are indistinguishable — which is exactly why the
+    // guard would be droppable without a test that breaks the ordering.
+    const { tick } = await loadRecipe()
+    const { $b24, cursors } = fakeB24([[deal(3), deal(1)], []])
+    const { bot } = fakeBot()
+
+    await tick($b24 as never, bot as never, 'chat')
+    await tick($b24 as never, bot as never, 'chat')
+
+    // Plain assignment would leave the cursor at 1 and re-deliver deal 3.
+    expect(cursors).toEqual([0, 3])
+  })
+
+  it('still notifies when the contact lookup fails', async () => {
+    // A failed `crm.item.get` must degrade to a placeholder name, not abort the
+    // notification — the deal is the thing worth telling someone about.
+    const { tick } = await loadRecipe()
+    // contactId must be set, or fetchContactName short-circuits to 'Not set'
+    // and never reaches the failing lookup.
+    const { $b24 } = fakeB24([[{ ...deal(1), contactId: 55 }], []], { contactFails: true })
+    const { bot, sent } = fakeBot()
+
+    await tick($b24 as never, bot as never, 'chat')
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toContain('Failed to load')
   })
 
   it('advances past a filtered-out deal without re-fetching it', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,7 +23,24 @@ export default defineConfig({
           // flaky `window is not defined` failures. Serialise the files so the
           // global mutations can't interleave. (#222)
           fileParallelism: false,
-          include: ['./test/integration/**/*.unit.spec.ts']
+          include: ['./test/integration/**/*.unit.spec.ts'],
+          // The recipe specs live in their own project — see `skills:unit`.
+          exclude: ['./test/integration/skills-recipes/**']
+        }
+      },
+      {
+        extends: true,
+        test: {
+          // Unit tests for the skill recipes under `skills/b24jssdk-recipes/`
+          // (#64). Held apart from `jsSdk:unit` because these are the only
+          // specs that import the recipes' opt-in packages (grammy, express)
+          // and the recipe files themselves. Keeping the boundary explicit
+          // means moving those deps out of the workspace root (#65) has one
+          // project to gate rather than a subset of a larger one.
+          name: 'skills:unit',
+          environment: 'node',
+          testTimeout: 10_000,
+          include: ['./test/integration/skills-recipes/**/*.unit.spec.ts']
         }
       },
       {


### PR DESCRIPTION
Closes #64. The duplication half landed in #386; this is the coverage half, plus the `skills:unit` project and `skills:test` script the issue asks for.

## Making the recipes testable at all

The four functions were module-private, and the recipes call `main()` at the top level — importing one would have opened a Telegram connection or bound a port. Both recipes now export the functions under test and end with an entry-point guard:

```ts
if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
  main().catch(…)
}
```

`npx tsx 06-telegram-bot.ts` behaves exactly as before — the guard is false only on **import**. `export` is inert when a file runs directly, so copy-paste is unaffected. I verified both directions empirically (a probe run under `tsx` and under `vitest`) before changing any recipe.

Recipe 12's store path also became overridable via `B24_OAUTH_STORE`. Worth having regardless — a deployment should say where tokens land rather than inheriting the working directory — and it lets the tests use a temp file instead of writing credential-shaped JSON into the repo.

## What the tests actually pin

**`tick`** — the one #64 cared about. It walks deals in id order and `break`s on the first send failure rather than continuing. That is the whole design: with `continue`, deals after the failed one would be delivered while the cursor stayed behind them, so the next tick would re-send them as duplicates. The cursor has to stay a **contiguous prefix** of what was delivered.

Seven cases, driven through fakes for `$b24` and the grammy bot — no portal, no network. The cursor is observed from outside by recording the `>id` filter of each list call, so the recipe needed no test-only accessor. Two ticks spanning a failure assert nothing is sent twice.

> Swapping `break` → `continue` reddens exactly those two tests. Verified.

**`escape`** — recipe 06's injection boundary. Its output is interpolated into a message sent with `parse_mode: 'HTML'`, and its input is a CRM deal title: attacker-influenced anywhere a stranger can create a deal. Covered including the single-pass property (three chained replaces with `&` last would turn `<` into `&amp;lt;`) and the deliberate choice **not** to escape quotes — with a test asserting the assumption that choice rests on, that escaped text never lands inside an attribute. If a future edit breaks that assumption, the test says so.

**`handleUninstall`** — deletes stored portal credentials from a publicly reachable endpoint. Both guard branches pinned: unknown member is an idempotent no-op, token mismatch refuses to delete, plus a prefix token (which goes through `safeEqual`'s length early-return and must refuse rather than throw).

> Removing the token comparison reddens both refusal tests. Verified.

**`toOAuthParams`** — the string→number coercions and the status whitelist fallback, including that a missing numeric field yields `NaN` rather than `0`. Pinned deliberately: `NaN` is visibly broken downstream, whereas a silent `0` reads as "expired at the epoch" and is far harder to trace back here.

## `skills:unit` as its own project

These are the only specs importing the recipes' opt-in packages (`grammy`, `express`) and the recipe files themselves. Holding them apart from `jsSdk:unit` keeps that boundary explicit and gives **#65** — moving those deps out of the workspace root — one project to gate rather than a subset of a larger one.

119 tests across six files. `jsSdk:unit` no longer collects any of them (verified: 0 matches).

`skills:test` runs it, and CI runs `skills:test` in the `test` job on both Node lines.

## Note

`eslint . --fix` also cleaned a pre-existing **warning** in `docs/server/api/ai.post.ts` (a redundant `i` flag), unrelated to this work. I reverted it out rather than sweep it in silently — it is still there on `main`, still a warning, and CI stays green either way.

## Gates

`eslint`, `skills:typecheck`, `docs:typecheck-blocks`, `docs-lint --strict`, `docs-link-check`, `check-v3-method-refs`, `check-api-reference-index`, `lint:md`, `actionlint`, and both vitest projects — all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_