### PR TITLE
test(skills): a live-portal verification pass for the skill files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "skills:typecheck": "pnpm run skills:install && tsc -p skills/b24jssdk-recipes/tsconfig.json",
     "package-jssdk:test:run-unit": "vitest run --project jsSdk:unit",
     "skills:test": "pnpm run skills:install && vitest run --project skills:unit",
-    "skills:verify": "vitest run --project jsSdk:integration -t \"skills-live\"",
+    "skills:verify": "vitest run --project skills:live",
     "package-jssdk:test": "vitest --project jsSdk:integration",
     "package-jssdk:test:run": "vitest run --project jsSdk:integration --project jsSdk:contributing-snippets",
     "package-jssdk:test-contributing-snippets": "vitest run --project jsSdk:contributing-snippets",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "skills:typecheck": "pnpm run skills:install && tsc -p skills/b24jssdk-recipes/tsconfig.json",
     "package-jssdk:test:run-unit": "vitest run --project jsSdk:unit",
     "skills:test": "pnpm run skills:install && vitest run --project skills:unit",
+    "skills:verify": "vitest run --project jsSdk:integration -t \"skills-live\"",
     "package-jssdk:test": "vitest --project jsSdk:integration",
     "package-jssdk:test:run": "vitest run --project jsSdk:integration --project jsSdk:contributing-snippets",
     "package-jssdk:test-contributing-snippets": "vitest run --project jsSdk:contributing-snippets",

--- a/skills/README.md
+++ b/skills/README.md
@@ -17,6 +17,14 @@ Project skills for the `@bitrix24/b24jssdk` workspace. Source of truth:
 | **b24jssdk-recipes** | Twelve end-to-end mini-apps (CRM analytics, ERP sync, Telegram bot, mass mailing, task automation, AI assistant, web search + LLM, Disk files, webhook handler, error-handling, event registration, OAuth install) — built on `actions.v{2,3}.*`. |
 | **b24jssdk-vibecode** | How to use the SDK alongside the VibeCode HTTP API. Mostly: don't — keep them apart. The "AI add-on" pattern is the only sane mix. |
 
+## Verification status
+
+The snippets in every skill are compile-checked in CI (`pnpm run skills:typecheck`).
+They have **not** yet been verified against a live portal — that is #113, and
+[`VERIFICATION.md`](VERIFICATION.md) is the pass: `pnpm run skills:verify` covers
+everything a webhook can reach, and a manual checklist covers the frame-only
+managers, which need an app open inside a real placement.
+
 ## Top-level docs
 
 - `.github/contributing/maintenance.md` — rules for the weekly `docs/llms-full.txt` review.

--- a/skills/VERIFICATION.md
+++ b/skills/VERIFICATION.md
@@ -1,0 +1,139 @@
+# Verifying the skills against a real portal (#113)
+
+CI already compiles every snippet in every skill (`pnpm run skills:typecheck`).
+That proves they type-check against the built SDK types. It does not prove the
+portal answers the way the skill says it does — which is what #113 asks for.
+
+This splits in two, because half of it cannot be scripted.
+
+| | How | Who |
+| --- | --- | --- |
+| **Part A** — everything a webhook can reach | `pnpm run skills:verify` | anyone with `.env.test` |
+| **Part B** — everything that needs a live placement iframe | by hand, in a browser | someone with an installed app |
+
+---
+
+## Part A — scripted
+
+### Setup for the scripted pass
+
+```bash
+cp .env.test-example .env.test
+# set B24_HOOK to a real webhook URL
+pnpm run skills:verify
+```
+
+The webhook needs the scopes the skills document — at minimum `crm`, `task`,
+`user`. A narrower webhook still works; cases it cannot reach report as skips,
+not failures (see *Reading the output*).
+
+### What it covers
+
+Everything is discovered at run time — the suite finds a task, a deal and a
+contact on your portal rather than assuming fixed ids, so it runs anywhere.
+It is read-only.
+
+| Skill | Verified |
+| --- | --- |
+| `b24jssdk-core` | boot snippet reaches the portal; an unknown method is a **soft** error on the `Result`, not a throw; the operating-budget fields the skill documents are present |
+| `b24jssdk-rest` | `actions.v2.batch` (one result per command), `v2.callList`, `v2.fetchList` (chunked), `v3.call`, `v3.callList` on `tasks.task.list` **without** a `cursorIdKey` override — the claim in the skill's table; a non-v3 method fails softly rather than throwing; `v3.aggregate` reported (it is `@experimental` and does not gate the run) |
+| `b24jssdk-filtering` | a v2 prefix-keyed filter actually narrows rows; a v3 array-of-triples filter is accepted; `callList` **strips a caller-supplied `order`** — asks for `DESC`, asserts the rows come back ascending |
+| `b24jssdk-helpers` | `initB24Helper` over a webhook loads Profile + Currency; `currency.format` uses the portal's own rules (the formatted value is printed) |
+| `b24jssdk-vibecode` | the SDK-side calls the skill documents succeed |
+
+### Reading the output
+
+Three outcomes, and the distinction is the point:
+
+- **pass** — the skill is right about this portal.
+- **`SKIP — … portal limitation [CODE]`** — your webhook or plan cannot do this.
+  Says nothing about the skill. Common on trial portals and narrow webhooks.
+- **`FAIL — … error [CODE]`** — the skill documents something that does not
+  work. **This is the finding #113 is after.** Copy the line into the issue.
+
+A failure whose code looks like a limitation the suite does not yet recognise is
+still a failure by design — the pattern list in the spec is deliberately narrow,
+because erring towards "skip" would hide exactly what this is for. If you hit
+one, paste the code and it gets added rather than guessed at.
+
+> Portals answer in the portal's language. The classifier matches both English
+> and Russian; a portal in a third language will surface unfamiliar text as a
+> failure with the code attached.
+
+### Recording the result
+
+```text
+Portal:            (domain, plan)
+Webhook scopes:
+Date:
+skills:verify →    N passed, N skipped, N failed
+Failures:          (paste the FAIL lines)
+```
+
+---
+
+## Part B — manual, needs a live placement
+
+None of this can run from a webhook: it needs the app open **inside** a Bitrix24
+placement iframe, because the SDK talks to the parent window over `postMessage`.
+
+### Setup for the placement pass
+
+1. A local application on the portal, with a placement handler pointing at a
+   page you control (a tunnel to localhost is fine).
+2. That page boots with `initializeB24Frame()`.
+3. Open the placement in the portal and work through the list below.
+
+Each row names the skill file and the section, so a mismatch has a place to be
+fixed. Record **observed**, not "looks fine".
+
+### `b24jssdk-frame-ui/SKILL.md`
+
+| # | What to do | Expected | OK? | Observed |
+| --- | --- | --- | --- | --- |
+| 1 | `$b24.slider.openPath(path)` | the slider opens on that path | ☐ | |
+| 2 | `$b24.slider.openSliderAppPage(params)` | the app page opens in a slider | ☐ | |
+| 3 | close the slider from inside | the promise the skill documents settles, with the documented shape | ☐ | |
+| 4 | `$b24.dialog.selectUser()` | user picker opens; the resolved value matches the skill's shape | ☐ | |
+| 5 | `$b24.dialog.selectCRM()` | CRM picker opens; resolved shape matches | ☐ | |
+| 6 | `$b24.parent.fitWindow()` | the iframe resizes to content | ☐ | |
+| 7 | `$b24.parent.setTitle(...)` | the portal's title area changes | ☐ | |
+| 8 | `$b24.placement.getInfo()` | returns the placement code the app was opened from | ☐ | |
+| 9 | `$b24.placement.setValue(...)` | value persists; re-open the placement to confirm | ☐ | |
+| 10 | `$b24.options` round-trip (app and user) | written value reads back after a reload | ☐ | |
+
+### `b24jssdk-helpers/SKILL.md` — the frame half
+
+| # | What to do | Expected | OK? | Observed |
+| --- | --- | --- | --- | --- |
+| 11 | `initB24Helper` with `LoadDataType.App` | `helper.appInfo.data` populated; `statusCode` is an `EnumAppStatus` value | ☐ | |
+| 12 | `LoadDataType.AppOptions` / `UserOptions` | both load; `helper.appOptions.encode` round-trips | ☐ | |
+| 13 | `usePullClient()` + `useSubscribePullClient(...)` then `startPullClient()` | subscription receives a message (trigger one via `helper.appOptions.save` with the `command` option, per the skill) | ☐ | |
+| 14 | `helper.appOptions.save({...}, { moduleId, command })` | saves **and** broadcasts the Pull event the skill describes | ☐ | |
+| 15 | read `helper.profileInfo` **before** `initB24Helper` resolves | throws `B24HelperManager.profileInfo not initialized` — the skill's stated guard | ☐ | |
+
+### `b24jssdk-core/SKILL.md` — the frame boot
+
+| # | What to do | Expected | OK? | Observed |
+| --- | --- | --- | --- | --- |
+| 16 | `initializeB24Frame()` | resolves inside the placement | ☐ | |
+| 17 | the same page opened **outside** a placement | fails the way the skill says it does, not by hanging | ☐ | |
+
+---
+
+## Closing #113
+
+The issue's acceptance criteria, and where each is answered:
+
+- [x] every snippet compiles — `skills:typecheck`, already in CI
+- [ ] every REST-calling snippet verified live — Part A, plus rows 1–17 for the
+      frame-only ones
+- [x] the v3 whitelist table matches `version-manager.ts` — **already true**:
+      the SDK dropped the allowlist (`automaticallyObtainApiVersion` ignores the
+      method and returns v2, `isSupport` returns `true` unconditionally), and
+      `b24jssdk-rest/SKILL.md` says so and lists known families as
+      non-exhaustive. Nothing to reconcile.
+- [ ] patterns that changed since the 2026-05 migration updated — whatever Parts
+      A and B turn up
+- [ ] `skills/REPORT.md` open questions resolved or deferred with a reason
+- [ ] `skills/README.md` migration note updated once the pass is done

--- a/skills/VERIFICATION.md
+++ b/skills/VERIFICATION.md
@@ -62,8 +62,11 @@ one, paste the code and it gets added rather than guessed at.
 
 ### Recording the result
 
+If you paste this into a public issue, replace the domain with a placeholder —
+the plan and the scopes are what matter, and the domain identifies the portal.
+
 ```text
-Portal:            (domain, plan)
+Portal:            (domain or placeholder, plan)
 Webhook scopes:
 Date:
 skills:verify →    N passed, N skipped, N failed
@@ -79,10 +82,21 @@ placement iframe, because the SDK talks to the parent window over `postMessage`.
 
 ### Setup for the placement pass
 
-1. A local application on the portal, with a placement handler pointing at a
-   page you control (a tunnel to localhost is fine).
-2. That page boots with `initializeB24Frame()`.
-3. Open the placement in the portal and work through the list below.
+[`reproducing-user-reports.md`](../.github/contributing/reproducing-user-reports.md#running-it-locally)
+already describes this setup end to end — building the SDK, running the Nuxt
+playground, exposing it with a tunnel via `NUXT_ALLOWED_HOSTS`, and registering
+a local application **with UI** under *Applications → Developer resources →
+Local application*. Follow it; there is no second way to do this.
+
+Two things that pass differs in:
+
+- **Bind a placement**, not just install the app. Rows 8–9 need the app opened
+  *from* a placement, so the handler has to be registered against one — an app
+  that only opens from the left menu has no placement context and
+  `$b24.placement.title` comes back empty.
+- **Scopes.** Grant `crm` (row 5), `user` (row 4), `task` if you want the
+  helper rows to have data, and `placement` (rows 8–9). Missing a scope shows
+  up as the manager rejecting, not as a blank screen.
 
 Each row names the skill file and the section, so a mismatch has a place to be
 fixed. Record **observed**, not "looks fine".
@@ -98,7 +112,7 @@ fixed. Record **observed**, not "looks fine".
 | 5 | `$b24.dialog.selectCRM()` | CRM picker opens; resolved shape matches | ☐ | |
 | 6 | `$b24.parent.fitWindow()` | the iframe resizes to content | ☐ | |
 | 7 | `$b24.parent.setTitle(...)` | the portal's title area changes | ☐ | |
-| 8 | `$b24.placement.getInfo()` | returns the placement code the app was opened from | ☐ | |
+| 8 | `$b24.placement.title` / `.options` / `.isSliderMode` | identify the placement the app was opened from, and the params it was given | ☐ | |
 | 9 | `$b24.placement.setValue(...)` | value persists; re-open the placement to confirm | ☐ | |
 | 10 | `$b24.options` round-trip (app and user) | written value reads back after a reload | ☐ | |
 
@@ -135,5 +149,9 @@ The issue's acceptance criteria, and where each is answered:
       non-exhaustive. Nothing to reconcile.
 - [ ] patterns that changed since the 2026-05 migration updated — whatever Parts
       A and B turn up
-- [ ] `skills/REPORT.md` open questions resolved or deferred with a reason
+- [ ] open questions resolved or deferred with a reason — the issue says
+      `skills/REPORT.md`, which does not exist; the file is
+      [`.github/contributing/report.md`](../.github/contributing/report.md)
+      (same for `skills/SUGGESTED-EXAMPLES.md` →
+      [`suggested-examples.md`](../.github/contributing/suggested-examples.md))
 - [ ] `skills/README.md` migration note updated once the pass is done

--- a/test/integration/skills/skills-live.spec.ts
+++ b/test/integration/skills/skills-live.spec.ts
@@ -1,0 +1,401 @@
+/**
+ * #113a — live-portal verification of the skill files that a webhook can reach.
+ *
+ * The skills under `skills/` are the SDK's agent-facing interface. CI already
+ * compiles every snippet (`skills:typecheck`), which proves they type-check
+ * against the built types — not that the portal answers the way the skill says
+ * it does. This suite exercises each documented pattern against a real portal
+ * and names the skill file in the test title, so a failure points straight at
+ * the sentence to fix.
+ *
+ * Deliberately portal-agnostic. The rest of `test/integration/` uses the fixed
+ * ids in `hooks-integration-jssdk.ts`, which are tuned to one portal; a skill
+ * verification that fails on someone else's portal for lack of task #2 says
+ * nothing about the skill. Entities are discovered at run time and a case skips
+ * itself, loudly, when the portal has nothing to work with.
+ *
+ * Read-only by default. The two round-trip cases that write app options run
+ * only with `B24_SKILLS_ALLOW_WRITE=1`, and restore what they found.
+ *
+ * Run: `pnpm run skills:verify` (needs `.env.test` with `B24_HOOK`).
+ *
+ * NOT covered here — everything that needs a live placement iframe: the whole
+ * of `b24jssdk-frame-ui`, and the frame half of `b24jssdk-helpers` (Pull
+ * subscription, `initializeB24Frame`). Those are a manual pass; see
+ * `skills/VERIFICATION.md`.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { setupB24Tests } from '../../0_setup/hooks-integration-jssdk'
+import { LoadDataType, useB24Helper } from '../../../packages/jssdk/src/'
+
+/** Ids discovered from the portal, or null when it has no such entity. */
+const found: { taskId: number | null, dealId: number | null, contactId: number | null } = {
+  taskId: null,
+  dealId: null,
+  contactId: null
+}
+
+/**
+ * Failures that say something about the portal or the webhook, not about the
+ * skill. A restricted webhook, a plan without CRM, a missing scope — all arrive
+ * as a thrown AjaxError and would otherwise look exactly like "the skill
+ * documents something that does not work". They are reported as skips with the
+ * portal's own words, so a red line in this suite always means a skill to fix.
+ */
+const ENVIRONMENT_LIMIT_CODE = /ACCESS_DENIED|INSUFFICIENT_SCOPE|PAYMENT_REQUIRED|NOT_FOUND_MODULE|METHOD_NOT_FOUND|INVALID_CREDENTIALS|ALLOWED_ONLY_INTRANET_USER/i
+
+/**
+ * The portal answers in the portal's language, so matching English alone is not
+ * enough — a restricted plan says "Функция недоступна на текущем тарифе" on a
+ * Russian portal and this suite reported it as a skill defect until both were
+ * listed. Codes are matched first because they do not translate.
+ *
+ * Kept deliberately narrow: an unrecognised failure must go red. Erring towards
+ * "skip" would hide the defects this suite exists to find, so an unfamiliar
+ * limitation shows up as a failure whose message names the code — add it here
+ * once, rather than widening the pattern on a guess.
+ */
+const ENVIRONMENT_LIMIT_MESSAGE = new RegExp([
+  'not available on the current plan',
+  'higher privileges',
+  'insufficient scope',
+  'method not found',
+  'недоступна на текущем тарифе',
+  'требует более высоких прав',
+  'недостаточно прав',
+  'метод не найден'
+].join('|'), 'i')
+
+function isEnvironmentLimit(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  const code = String((error as { code?: unknown }).code ?? '')
+  return ENVIRONMENT_LIMIT_CODE.test(code) || ENVIRONMENT_LIMIT_MESSAGE.test(error.message)
+}
+
+/** `it`, but a portal/webhook limitation skips instead of failing. */
+function portalIt(name: string, run: () => Promise<void>) {
+  it(name, async (ctx) => {
+    try {
+      await run()
+    } catch (error) {
+      const code = String((error as { code?: unknown }).code ?? '—')
+      if (isEnvironmentLimit(error)) {
+        console.warn(
+          `[skills-live] SKIP — ${name}\n`
+          + `    portal limitation [${code}]: ${(error as Error).message}`
+        )
+        ctx.skip()
+        return
+      }
+      // Not a limitation this suite recognises. Naming the code here is what
+      // lets an unfamiliar one be added to the list above rather than guessed at.
+      console.error(`[skills-live] FAIL — ${name}\n    error [${code}]: ${(error as Error).message}`)
+      throw error
+    }
+  })
+}
+
+describe('skills-live @skills', () => {
+  const { getB24Client } = setupB24Tests()
+
+  /**
+   * Discovery must never fail the suite. A hard error — a webhook without the
+   * `crm` scope, say — arrives as a thrown AjaxError rather than a soft Result,
+   * and an unguarded `beforeAll` would take every case down with it and report
+   * nothing. A portal that cannot show us a deal should skip the deal cases and
+   * still verify everything else.
+   */
+  async function discover<T>(
+    label: string,
+    run: () => Promise<T | null>
+  ): Promise<T | null> {
+    try {
+      return await run()
+    } catch (error) {
+      console.warn(`[skills-live] discovery for ${label} failed: ${(error as Error).message}`)
+      return null
+    }
+  }
+
+  beforeAll(async () => {
+    const b24 = getB24Client()
+
+    found.taskId = await discover('task', async () => {
+      const response = await b24.actions.v2.call.make<{ tasks: Array<{ id: string }> }>({
+        method: 'tasks.task.list',
+        params: { select: ['ID'], start: 0 },
+        requestId: 'skills-live/discover-task'
+      })
+      return response.isSuccess
+        ? Number(response.getData()!.result.tasks?.[0]?.id ?? NaN) || null
+        : null
+    })
+
+    found.dealId = await discover('deal', async () => {
+      const response = await b24.actions.v2.call.make<Array<{ ID: string }>>({
+        method: 'crm.deal.list',
+        params: { select: ['ID'], start: 0 },
+        requestId: 'skills-live/discover-deal'
+      })
+      return response.isSuccess ? Number(response.getData()!.result?.[0]?.ID ?? NaN) || null : null
+    })
+
+    found.contactId = await discover('contact', async () => {
+      const response = await b24.actions.v2.call.make<Array<{ ID: string }>>({
+        method: 'crm.contact.list',
+        params: { select: ['ID'], start: 0 },
+        requestId: 'skills-live/discover-contact'
+      })
+      return response.isSuccess ? Number(response.getData()!.result?.[0]?.ID ?? NaN) || null : null
+    })
+
+    console.log(
+      `[skills-live] discovered — task:${found.taskId ?? 'none'} `
+      + `deal:${found.dealId ?? 'none'} contact:${found.contactId ?? 'none'}`
+    )
+  })
+
+  // ── b24jssdk-core ──────────────────────────────────────────────────────
+  describe('b24jssdk-core/SKILL.md', () => {
+    portalIt('the boot snippet reaches the portal (actions.v2.call.make)', async () => {
+      const response = await getB24Client().actions.v2.call.make({
+        method: 'server.time',
+        requestId: 'skills-live/core-boot'
+      })
+      expect(response.isSuccess).toBe(true)
+      expect(response.getData()!.result).toBeDefined()
+    })
+
+    portalIt('a soft error is returned on the Result, not thrown', async () => {
+      // The skill's central claim about error handling: an unknown method is a
+      // soft error the caller inspects, not an exception.
+      const response = await getB24Client().actions.v2.call.make({
+        method: 'this.method.does.not.exist',
+        requestId: 'skills-live/core-soft-error'
+      })
+      expect(response.isSuccess).toBe(false)
+      expect(response.getErrorMessages().join(' ')).not.toBe('')
+    })
+
+    portalIt('the response carries the operating-budget fields the skill documents', async () => {
+      const response = await getB24Client().actions.v2.call.make({
+        method: 'server.time',
+        requestId: 'skills-live/core-operating'
+      })
+      const time = response.getData()!.time
+      expect(time).toHaveProperty('operating')
+      expect(time).toHaveProperty('operating_reset_at')
+    })
+  })
+
+  // ── b24jssdk-rest ──────────────────────────────────────────────────────
+  describe('b24jssdk-rest/SKILL.md', () => {
+    portalIt('actions.v2.batch.make returns one result per command', async () => {
+      const response = await getB24Client().actions.v2.batch.make({
+        calls: { now: ['server.time', {}], me: ['profile', {}] },
+        isHaltOnError: false,
+        requestId: 'skills-live/rest-v2-batch'
+      })
+      expect(response.isSuccess).toBe(true)
+      const data = response.getData()!.result as Record<string, unknown>
+      expect(Object.keys(data)).toEqual(expect.arrayContaining(['now', 'me']))
+    })
+
+    portalIt('actions.v2.callList.make pages a *.list method', async () => {
+      const response = await getB24Client().actions.v2.callList.make<{ ID: string }>({
+        method: 'crm.contact.list',
+        params: { select: ['ID'] },
+        idKey: 'ID',
+        requestId: 'skills-live/rest-v2-callList'
+      })
+      expect(response.isSuccess).toBe(true)
+      expect(Array.isArray(response.getData()!.result)).toBe(true)
+    })
+
+    portalIt('actions.v2.fetchList.make yields chunks', async () => {
+      const generator = getB24Client().actions.v2.fetchList.make<{ ID: string }>({
+        method: 'crm.contact.list',
+        params: { select: ['ID'] },
+        idKey: 'ID',
+        requestId: 'skills-live/rest-v2-fetchList'
+      })
+      let chunks = 0
+      for await (const chunk of generator) {
+        expect(Array.isArray(chunk)).toBe(true)
+        chunks++
+        if (chunks >= 2) break
+      }
+      expect(chunks).toBeGreaterThanOrEqual(1)
+    })
+
+    portalIt('actions.v3.call.make reaches the v3 endpoint', async () => {
+      if (found.taskId === null) {
+        console.warn('[skills-live] SKIPPED: portal has no task to read')
+        return
+      }
+      const response = await getB24Client().actions.v3.call.make<{ task: { id: number } }>({
+        method: 'tasks.task.get',
+        params: { id: found.taskId },
+        requestId: 'skills-live/rest-v3-call'
+      })
+      expect(response.isSuccess).toBe(true)
+      // The skill says v3 returns camelCase fields under a unified `result`.
+      expect(response.getData()!.result.task).toHaveProperty('id')
+    })
+
+    portalIt('v3 tasks.task.list needs no cursorIdKey override (the skill\'s table)', async () => {
+      // The skill states that on v3 `tasks.task.list` is all-lowercase — `id`
+      // for both request and response, rows under `result.items` — unlike v2.
+      const response = await getB24Client().actions.v3.callList.make<{ id: number }>({
+        method: 'tasks.task.list',
+        params: { select: ['id'] },
+        idKey: 'id',
+        customKeyForResult: 'items',
+        requestId: 'skills-live/rest-v3-callList'
+      })
+      expect(response.isSuccess).toBe(true)
+      expect(Array.isArray(response.getData()!.result)).toBe(true)
+    })
+
+    it('a method that is not on v3 fails softly, not by throwing', async () => {
+      // The skill's claim after the allowlist removal: any method is sent, and
+      // a non-v3 method comes back as a soft error.
+      const response = await getB24Client().actions.v3.call.make({
+        method: 'crm.deal.get',
+        params: { id: found.dealId ?? 1 },
+        requestId: 'skills-live/rest-v3-not-a-v3-method'
+      })
+      // Either the portal really does expose it on v3, or it is a soft error —
+      // both are consistent with the skill. What must NOT happen is a throw,
+      // and that is what reaching this line proves.
+      expect(typeof response.isSuccess).toBe('boolean')
+      if (!response.isSuccess) {
+        console.log(`[skills-live] crm.deal.get on v3: ${response.getErrorMessages().join('; ')}`)
+      }
+    })
+
+    it('actions.v3.aggregate.make — @experimental, records the outcome', async () => {
+      // The skill marks this "unverified live; fall back to callList + reduce".
+      // This case exists to answer that question on a real portal rather than
+      // to gate the suite, so it reports and does not fail.
+      try {
+        const response = await getB24Client().actions.v3.aggregate.make({
+          method: 'tasks.task.aggregate',
+          params: { select: [{ field: 'id', type: 'count' }] },
+          requestId: 'skills-live/rest-v3-aggregate'
+        } as never)
+        console.log(
+          `[skills-live] v3 aggregate: isSuccess=${response.isSuccess} `
+          + `${response.isSuccess ? JSON.stringify(response.getData()!.result) : response.getErrorMessages().join('; ')}`
+        )
+      } catch (error) {
+        console.log(`[skills-live] v3 aggregate threw: ${(error as Error).message}`)
+      }
+      expect(true).toBe(true)
+    })
+  })
+
+  // ── b24jssdk-filtering ─────────────────────────────────────────────────
+  describe('b24jssdk-filtering/SKILL.md', () => {
+    portalIt('a v2 prefix-keyed filter narrows the result set', async () => {
+      if (found.contactId === null) {
+        console.warn('[skills-live] SKIPPED: portal has no contact to filter on')
+        return
+      }
+      const response = await getB24Client().actions.v2.callList.make<{ ID: string }>({
+        method: 'crm.contact.list',
+        params: { select: ['ID'], filter: { '>ID': found.contactId } },
+        idKey: 'ID',
+        requestId: 'skills-live/filtering-v2-prefix'
+      })
+      expect(response.isSuccess).toBe(true)
+      for (const row of response.getData()!.result) {
+        expect(Number(row.ID)).toBeGreaterThan(found.contactId!)
+      }
+    })
+
+    portalIt('a v3 array-of-triples filter is accepted', async () => {
+      const response = await getB24Client().actions.v3.callList.make<{ id: number }>({
+        method: 'tasks.task.list',
+        params: { select: ['id'], filter: [['id', '>', 0]] },
+        idKey: 'id',
+        customKeyForResult: 'items',
+        requestId: 'skills-live/filtering-v3-triples'
+      })
+      expect(response.isSuccess).toBe(true)
+    })
+
+    portalIt('callList strips a caller-supplied order (the skill\'s warning)', async () => {
+      // The skill says keyset pagination requires idKey ASC, so callList
+      // discards any `order` the caller passes. Ask for DESC and confirm the
+      // rows still come back ascending.
+      const response = await getB24Client().actions.v2.callList.make<{ ID: string }>({
+        method: 'crm.contact.list',
+        params: { select: ['ID'], order: { ID: 'DESC' } },
+        idKey: 'ID',
+        requestId: 'skills-live/filtering-order-stripped'
+      })
+      expect(response.isSuccess).toBe(true)
+      const ids = response.getData()!.result.map(r => Number(r.ID))
+      const ascending = [...ids].sort((a, b) => a - b)
+      expect(ids).toEqual(ascending)
+    })
+  })
+
+  // ── b24jssdk-helpers (the half a webhook can reach) ─────────────────────
+  describe('b24jssdk-helpers/SKILL.md', () => {
+    portalIt('initB24Helper loads Profile and Currency over a webhook', async () => {
+      // The skill's frontmatter says the helpers also work with B24Hook for
+      // read-only data. `App` / `AppOptions` are deliberately not requested:
+      // a webhook has no application context.
+      const { initB24Helper, isInitB24Helper, getB24Helper, destroyB24Helper } = useB24Helper()
+      try {
+        await initB24Helper(
+          getB24Client(),
+          [LoadDataType.Profile, LoadDataType.Currency],
+          'skills-live/helper-init'
+        )
+        expect(isInitB24Helper()).toBe(true)
+
+        const helper = getB24Helper()
+        expect(helper.profileInfo.data).toHaveProperty('id')
+        expect(typeof helper.currency.baseCurrency).toBe('string')
+        console.log(`[skills-live] base currency: ${helper.currency.baseCurrency}`)
+      } finally {
+        destroyB24Helper()
+      }
+    })
+
+    portalIt('currency formatting uses the portal\'s own rules', async () => {
+      const { initB24Helper, getB24Helper, destroyB24Helper } = useB24Helper()
+      try {
+        await initB24Helper(getB24Client(), [LoadDataType.Currency], 'skills-live/helper-currency')
+        const helper = getB24Helper()
+        const base = helper.currency.baseCurrency
+
+        const literal = helper.currency.getCurrencyLiteral(base, 'en')
+        const formatted = helper.currency.format(1234.56, base, 'en')
+        console.log(`[skills-live] format(1234.56, '${base}', 'en') = ${formatted} (literal ${literal})`)
+
+        expect(typeof formatted).toBe('string')
+        expect(formatted.length).toBeGreaterThan(0)
+      } finally {
+        destroyB24Helper()
+      }
+    })
+  })
+
+  // ── b24jssdk-vibecode ──────────────────────────────────────────────────
+  describe('b24jssdk-vibecode/SKILL.md', () => {
+    portalIt('the SDK-side calls the skill documents succeed', async () => {
+      const response = await getB24Client().actions.v2.call.make({
+        method: 'profile',
+        requestId: 'skills-live/vibecode-profile'
+      })
+      expect(response.isSuccess).toBe(true)
+      expect(response.getData()!.result).toHaveProperty('ID')
+    })
+  })
+})

--- a/test/integration/skills/skills-live.spec.ts
+++ b/test/integration/skills/skills-live.spec.ts
@@ -14,8 +14,9 @@
  * nothing about the skill. Entities are discovered at run time and a case skips
  * itself, loudly, when the portal has nothing to work with.
  *
- * Read-only by default. The two round-trip cases that write app options run
- * only with `B24_SKILLS_ALLOW_WRITE=1`, and restore what they found.
+ * Read-only. Every call is a `get` or a `list`; nothing here mutates a portal.
+ * Keep it that way — if a write case is ever added it needs an explicit opt-in
+ * flag, not a promise in this comment.
  *
  * Run: `pnpm run skills:verify` (needs `.env.test` with `B24_HOOK`).
  *
@@ -26,7 +27,7 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest'
 import { setupB24Tests } from '../../0_setup/hooks-integration-jssdk'
-import { LoadDataType, useB24Helper } from '../../../packages/jssdk/src/'
+import { FilterV3, LoadDataType, useB24Helper } from '../../../packages/jssdk/src/'
 
 /** Ids discovered from the portal, or null when it has no such entity. */
 const found: { taskId: number | null, dealId: number | null, contactId: number | null } = {
@@ -42,7 +43,7 @@ const found: { taskId: number | null, dealId: number | null, contactId: number |
  * documents something that does not work". They are reported as skips with the
  * portal's own words, so a red line in this suite always means a skill to fix.
  */
-const ENVIRONMENT_LIMIT_CODE = /ACCESS_DENIED|INSUFFICIENT_SCOPE|PAYMENT_REQUIRED|NOT_FOUND_MODULE|METHOD_NOT_FOUND|INVALID_CREDENTIALS|ALLOWED_ONLY_INTRANET_USER/i
+const ENVIRONMENT_LIMIT_CODE = /ACCESS_DENIED|INSUFFICIENT_SCOPE|PAYMENT_REQUIRED|NOT_FOUND_MODULE|INVALID_CREDENTIALS|ALLOWED_ONLY_INTRANET_USER/i
 
 /**
  * The portal answers in the portal's language, so matching English alone is not
@@ -59,12 +60,16 @@ const ENVIRONMENT_LIMIT_MESSAGE = new RegExp([
   'not available on the current plan',
   'higher privileges',
   'insufficient scope',
-  'method not found',
   'недоступна на текущем тарифе',
   'требует более высоких прав',
-  'недостаточно прав',
-  'метод не найден'
+  'недостаточно прав'
 ].join('|'), 'i')
+
+// Deliberately NOT in the lists above: "method not found". A skill that
+// documents a method the portal does not have is precisely the defect #113
+// exists to catch, and classifying it as a portal limitation would skip the
+// finding. The two cases that probe an unsupported method on purpose handle
+// their own outcome with a plain `it`.
 
 function isEnvironmentLimit(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -74,11 +79,18 @@ function isEnvironmentLimit(error: unknown): boolean {
   return ENVIRONMENT_LIMIT_CODE.test(code) || ENVIRONMENT_LIMIT_MESSAGE.test(error.message)
 }
 
-/** `it`, but a portal/webhook limitation skips instead of failing. */
-function portalIt(name: string, run: () => Promise<void>) {
+/**
+ * `it`, but a portal/webhook limitation skips instead of failing.
+ *
+ * The body receives the test context so a case with no fixture to work on can
+ * `ctx.skip()`. Returning early instead registers as a **pass** — two of the
+ * four green results on a restricted portal had verified nothing, which breaks
+ * the one property this suite needs: a green line means something was checked.
+ */
+function portalIt(name: string, run: (ctx: { skip: () => void }) => Promise<void>) {
   it(name, async (ctx) => {
     try {
-      await run()
+      await run(ctx)
     } catch (error) {
       const code = String((error as { code?: unknown }).code ?? '—')
       if (isEnvironmentLimit(error)) {
@@ -168,15 +180,30 @@ describe('skills-live @skills', () => {
       expect(response.getData()!.result).toBeDefined()
     })
 
-    portalIt('a soft error is returned on the Result, not thrown', async () => {
-      // The skill's central claim about error handling: an unknown method is a
-      // soft error the caller inspects, not an exception.
-      const response = await getB24Client().actions.v2.call.make({
+    portalIt('an unknown v3 method is a soft error on the Result, not a throw', async () => {
+      // The claim is specific to v3 (b24jssdk-core/SKILL.md, "Common SdkError
+      // codes"): since the allowlist was dropped, an unknown v3 method comes
+      // back as a METHODNOTFOUNDEXCEPTION *on the result*.
+      //
+      // It does NOT hold on v2, where the same call throws
+      // ERROR_METHOD_NOT_FOUND — an earlier version of this case asserted the
+      // soft behaviour against v2 and reported the core skill as wrong. It is
+      // not; the test was.
+      const response = await getB24Client().actions.v3.call.make({
         method: 'this.method.does.not.exist',
-        requestId: 'skills-live/core-soft-error'
+        requestId: 'skills-live/core-v3-soft-error'
       })
       expect(response.isSuccess).toBe(false)
       expect(response.getErrorMessages().join(' ')).not.toBe('')
+    })
+
+    portalIt('the same unknown method throws on v2', async () => {
+      // The other half of the same sentence, pinned so the asymmetry is
+      // recorded rather than rediscovered.
+      await expect(getB24Client().actions.v2.call.make({
+        method: 'this.method.does.not.exist',
+        requestId: 'skills-live/core-v2-throws'
+      })).rejects.toThrow()
     })
 
     portalIt('the response carries the operating-budget fields the skill documents', async () => {
@@ -230,9 +257,10 @@ describe('skills-live @skills', () => {
       expect(chunks).toBeGreaterThanOrEqual(1)
     })
 
-    portalIt('actions.v3.call.make reaches the v3 endpoint', async () => {
+    portalIt('actions.v3.call.make reaches the v3 endpoint', async (ctx) => {
       if (found.taskId === null) {
-        console.warn('[skills-live] SKIPPED: portal has no task to read')
+        console.warn('[skills-live] SKIP — no task on this portal to read')
+        ctx.skip()
         return
       }
       const response = await getB24Client().actions.v3.call.make<{ task: { id: number } }>({
@@ -276,16 +304,107 @@ describe('skills-live @skills', () => {
       }
     })
 
+    portalIt('batch reports per-command failures when isHaltOnError is false', async () => {
+      // The skill's batch semantics: with halt-on-error off, a bad command does
+      // not sink the good ones, and the failures are reachable by key.
+      const response = await getB24Client().actions.v2.batch.make({
+        calls: { good: ['server.time', {}], bad: ['this.method.does.not.exist', {}] },
+        isHaltOnError: false,
+        requestId: 'skills-live/rest-v2-batch-partial'
+      })
+      const errorsByKey = response.getErrorsByKey?.() ?? {}
+      expect(Object.keys(errorsByKey)).toContain('bad')
+      const data = response.getData()!.result as Record<string, unknown>
+      expect(data.good).toBeDefined()
+    })
+
+    portalIt('actions.v2.batchByChunk.make takes a command list, not a method', async () => {
+      // One of the five primitives in the skill's decision table, and the only
+      // one with no other coverage here. Note the shape: `calls` + `options`,
+      // and `getData()` is a FLAT array — not the `{ result }` envelope the
+      // other actions return. Writing it like `callList` is the obvious
+      // mistake, and it fails with a TypeError rather than a portal error.
+      const calls: Array<[string, Record<string, unknown>]> = [
+        ['server.time', {}],
+        ['profile', {}]
+      ]
+      const response = await getB24Client().actions.v2.batchByChunk.make({
+        calls,
+        options: { isHaltOnError: false, requestId: 'skills-live/rest-v2-batchByChunk' }
+      })
+      expect(response.isSuccess).toBe(true)
+      expect(Array.isArray(response.getData())).toBe(true)
+    })
+
+    portalIt('v2 tasks.task.list needs idKey id with cursorIdKey ID', async (ctx) => {
+      // The asymmetry the skill calls out as "most notably": on v2 the method
+      // sorts and filters by `ID` but returns lowercase `id`, so the cursor
+      // needs both keys. Getting this wrong pages forever or not at all.
+      if (found.taskId === null) {
+        console.warn('[skills-live] SKIP — no task on this portal to page')
+        ctx.skip()
+        return
+      }
+      const response = await getB24Client().actions.v2.callList.make<{ id: string }>({
+        method: 'tasks.task.list',
+        params: { select: ['ID'] },
+        idKey: 'id',
+        cursorIdKey: 'ID',
+        customKeyForResult: 'tasks',
+        requestId: 'skills-live/rest-v2-tasks-cursor'
+      })
+      expect(response.isSuccess).toBe(true)
+      expect(Array.isArray(response.getData()!.result)).toBe(true)
+    })
+
+    portalIt('crm.item.list needs lowercase idKey and customKeyForResult items', async () => {
+      // The skill's primary CRM pattern: v3 entities called on v2 still return
+      // rows under `items` with a lowercase id.
+      const response = await getB24Client().actions.v2.callList.make<{ id: number }>({
+        method: 'crm.item.list',
+        params: { entityTypeId: 3, select: ['id'] },
+        idKey: 'id',
+        customKeyForResult: 'items',
+        requestId: 'skills-live/rest-crm-item-list'
+      })
+      expect(response.isSuccess).toBe(true)
+      expect(Array.isArray(response.getData()!.result)).toBe(true)
+    })
+
+    portalIt('actions.v3.fetchTail.make drives the native cursor', async () => {
+      // v3-only, and distinct from fetchList: it uses the server's own `tail`
+      // action rather than an emulated keyset.
+      const generator = getB24Client().actions.v3.fetchTail.make<{ id: number }>({
+        method: 'main.eventlog.tail',
+        params: { select: ['id'] },
+        cursorField: 'id',
+        requestId: 'skills-live/rest-v3-fetchTail'
+      })
+      let chunks = 0
+      for await (const chunk of generator) {
+        expect(Array.isArray(chunk)).toBe(true)
+        chunks++
+        break
+      }
+      expect(chunks).toBeGreaterThanOrEqual(0)
+    })
+
     it('actions.v3.aggregate.make — @experimental, records the outcome', async () => {
       // The skill marks this "unverified live; fall back to callList + reduce".
       // This case exists to answer that question on a real portal rather than
       // to gate the suite, so it reports and does not fail.
       try {
+        // Real `ActionAggregateV3` shape: `select` is top level and is keyed by
+        // aggregate function. An earlier version nested it under `params` with a
+        // `{ field, type }[]` that does not exist in the type, hidden behind an
+        // `as never` — `options.select` came out undefined, the shape validation
+        // iterated zero times, and the call went out empty. It answered nothing
+        // while looking like it did.
         const response = await getB24Client().actions.v3.aggregate.make({
           method: 'tasks.task.aggregate',
-          params: { select: [{ field: 'id', type: 'count' }] },
+          select: { count: ['id'] },
           requestId: 'skills-live/rest-v3-aggregate'
-        } as never)
+        })
         console.log(
           `[skills-live] v3 aggregate: isSuccess=${response.isSuccess} `
           + `${response.isSuccess ? JSON.stringify(response.getData()!.result) : response.getErrorMessages().join('; ')}`
@@ -299,9 +418,10 @@ describe('skills-live @skills', () => {
 
   // ── b24jssdk-filtering ─────────────────────────────────────────────────
   describe('b24jssdk-filtering/SKILL.md', () => {
-    portalIt('a v2 prefix-keyed filter narrows the result set', async () => {
+    portalIt('a v2 prefix-keyed filter narrows the result set', async (ctx) => {
       if (found.contactId === null) {
-        console.warn('[skills-live] SKIPPED: portal has no contact to filter on')
+        console.warn('[skills-live] SKIP — no contact on this portal to filter on')
+        ctx.skip()
         return
       }
       const response = await getB24Client().actions.v2.callList.make<{ ID: string }>({
@@ -323,6 +443,22 @@ describe('skills-live @skills', () => {
         idKey: 'id',
         customKeyForResult: 'items',
         requestId: 'skills-live/filtering-v3-triples'
+      })
+      expect(response.isSuccess).toBe(true)
+    })
+
+    portalIt('the FilterV3 builder produces a filter the server accepts', async () => {
+      // The skill tells readers to build nested v3 groups with FilterV3 rather
+      // than by hand; this checks the built shape is actually accepted.
+      const filter = FilterV3.and(
+        FilterV3.gt('id', 0)
+      )
+      const response = await getB24Client().actions.v3.callList.make<{ id: number }>({
+        method: 'tasks.task.list',
+        params: { select: ['id'], filter: FilterV3.build(filter) },
+        idKey: 'id',
+        customKeyForResult: 'items',
+        requestId: 'skills-live/filtering-v3-builder'
       })
       expect(response.isSuccess).toBe(true)
     })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,7 +51,28 @@ export default defineConfig({
           testTimeout: 30_000,
           hookTimeout: 30_000,
           include: ['./test/integration/**/*.spec.ts'],
-          exclude: ['./test/integration/**/*.unit.spec.ts'],
+          exclude: [
+            './test/integration/**/*.unit.spec.ts',
+            // Own project — see `skills:live`.
+            './test/integration/skills/**'
+          ],
+          setupFiles: ['./test/0_setup/setup-integration-jssdk.ts']
+        }
+      },
+      {
+        extends: true,
+        test: {
+          // Live-portal verification of the skill files (#113). Its own project
+          // rather than a `-t` title filter over jsSdk:integration: the repo
+          // already scopes by `include` for `skills:unit`, and a substring match
+          // is one copied describe title away from silently running the wrong
+          // set — or nothing at all, which in a verification suite reads as
+          // "everything passed".
+          name: 'skills:live',
+          environment: 'node',
+          testTimeout: 30_000,
+          hookTimeout: 30_000,
+          include: ['./test/integration/skills/**/*.spec.ts'],
           setupFiles: ['./test/0_setup/setup-integration-jssdk.ts']
         }
       },


### PR DESCRIPTION
Refs #113. Does not close it — this is the apparatus; the pass itself needs a portal and, for half of it, a human in an iframe.

## The split

| | How | Needs |
| --- | --- | --- |
| **Part A** — everything a webhook can reach | `pnpm run skills:verify` | `.env.test` with `B24_HOOK` |
| **Part B** — everything needing a live placement | 17-step checklist in [`skills/VERIFICATION.md`](https://github.com/bitrix24/b24jssdk/blob/claude/113-skill-verification/skills/VERIFICATION.md) | an installed app, open in a placement |

## Part A — what it actually checks

Each test names the skill file, so a red line points at the sentence to fix rather than at the SDK.

- **core** — the boot snippet reaches the portal; an unknown method is a **soft** error on the `Result`, not a throw; the operating-budget fields are present.
- **rest** — `v2.batch` returns one result per command, `v2.callList`, `v2.fetchList` chunks, `v3.call`, and `v3.callList` on `tasks.task.list` **without** a `cursorIdKey` override, which is a specific claim in the skill's table. A non-v3 method must fail *softly*. `v3.aggregate` is reported rather than gated — the skill marks it `@experimental`, "unverified live", and this answers that question without holding the suite hostage to it.
- **filtering** — a v2 prefix-keyed filter really narrows rows; a v3 array-of-triples filter is accepted; `callList` **strips a caller-supplied `order`** — it asks for `DESC` and asserts the rows come back ascending, which is the skill's stated keyset-pagination rule.
- **helpers** — `initB24Helper` over a webhook loads Profile + Currency; `currency.format` uses the portal's own rules, printing the value.
- **vibecode** — the SDK-side calls succeed.

**Portal-agnostic by design.** The rest of `test/integration/` uses the fixed ids in `hooks-integration-jssdk.ts`, tuned to one portal. A skill verification that fails on someone else's portal for lack of task #2 says nothing about the skill, so entities are discovered at run time and a case skips itself, loudly, when the portal has nothing to work with. Read-only.

## Two things the restricted webhook in this environment taught me

Both would have cost the maintainer a debugging session.

**Discovery has to be fault-tolerant.** A hard error — a webhook without the `crm` scope — arrives as a *thrown* `AjaxError`, not a soft `Result`. My first version let it escape `beforeAll`, which took all 83 cases down and reported nothing at all.

**Portal limitations must not look like skill defects.** Every case failed with *"Feature is not available on the current plan"* — which reads exactly like the skills documenting things that don't work. They are now classified and reported as skips carrying the portal's own error code:

```
SKIP — actions.v2.batch.make returns one result per command
    portal limitation [PAYMENT_REQUIRED]: Feature is not available on the current plan.
```

The classifier matches **codes first, then text in both English and Russian** — the portal answers in the portal's language, and two cases stayed red purely because I'd only listed the English form of the same message. It is kept deliberately narrow: an unrecognised failure still goes **red**, because erring towards "skip" would hide precisely what this suite exists to find. Unfamiliar codes are printed so they get added rather than guessed at.

On this environment's locked-down portal the suite now correctly reports *nothing verifiable here* rather than *the skills are broken*.

## One criterion already met, no portal needed

> the v3 whitelist table in `b24jssdk-rest` matches the current `version-manager.ts` source

It does. The SDK dropped the allowlist — `automaticallyObtainApiVersion` ignores its method argument and returns v2, `isSupport` returns `true` unconditionally — and `b24jssdk-rest/SKILL.md` already says exactly that, listing known v3 families as explicitly non-exhaustive. Nothing to reconcile.

## Not covered, and why

`b24jssdk-frame-ui` in full, and the frame half of `b24jssdk-helpers` — slider, dialog, `parent.fitWindow`, `placement.setValue`, the options round-trip, the Pull subscription. The SDK talks to the parent window over `postMessage`; there is no parent window to talk to from a test runner. Those are Part B.

## Gates

`eslint`, `lint:md`, `md-internal-links`, `check-v3-method-refs`, `jsSdk:unit` (496), `skills:unit` (136) — all clean. `skills:verify` is a local command and is deliberately **not** wired into CI: it needs a portal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_