### PR TITLE
fix(docs): bundle prettier instead of executing six modules from a CDN

### DIFF
--- a/docs/app/plugins/prettier.ts
+++ b/docs/app/plugins/prettier.ts
@@ -1,8 +1,12 @@
 import { defu } from 'defu'
-import PrettierWorker from '@/workers/prettier.js?worker&inline'
+// Not `&inline`: the worker now bundles prettier instead of fetching it from a
+// CDN (#399), and inlining that as a base64 blob would put the parsers in the
+// entry bundle. As a separate chunk they are fetched when a page actually
+// formats something.
+import PrettierWorker from '@/workers/prettier.js?worker'
 // Message routing lives in a browser-free module so it can be tested without a
 // Worker (#139) — this file cannot be imported outside Vite, because of the
-// `?worker&inline` specifier above.
+// `?worker` specifier above.
 import { createPrettierWorkerApi } from '../utils/prettierWorkerApi'
 import type { SimplePrettier } from '../utils/prettierWorkerApi'
 
@@ -18,8 +22,20 @@ export default defineNuxtPlugin(async () => {
       }
     }
   } else {
-    const worker = new PrettierWorker()
-    prettier = createPrettierWorkerApi(worker)
+    // The worker is constructed on the FIRST format, not at plugin setup.
+    //
+    // Since #399 it bundles prettier rather than fetching it from a CDN, so the
+    // worker script is ~500 KB gzipped — building it eagerly would download the
+    // parsers on every page load, including the many pages that never format
+    // anything. Deferring it restores the old timing: nothing is fetched until a
+    // snippet actually needs formatting.
+    let api: SimplePrettier | undefined
+    prettier = {
+      format(source, options) {
+        api ??= createPrettierWorkerApi(new PrettierWorker())
+        return api.format(source, options)
+      }
+    }
   }
 
   return {

--- a/docs/app/plugins/prettier.ts
+++ b/docs/app/plugins/prettier.ts
@@ -29,6 +29,9 @@ export default defineNuxtPlugin(async () => {
     // parsers on every page load, including the many pages that never format
     // anything. Deferring it restores the old timing: nothing is fetched until a
     // snippet actually needs formatting.
+    // No race to guard: `??=` and the constructor are synchronous, with no
+    // await between the check and the assignment, so a second `format()` cannot
+    // interleave and build a second worker.
     let api: SimplePrettier | undefined
     prettier = {
       format(source, options) {

--- a/docs/app/workers/prettier.js
+++ b/docs/app/workers/prettier.js
@@ -1,5 +1,3 @@
-/* global __PRETTIER_VERSION__ */
-
 /**
  * Client-side formatting worker.
  *
@@ -24,19 +22,28 @@
  *    worker start and buffered messages behind a flag that was never reset on
  *    failure.
  *
- * The one deliberate divergence: upstream hard-codes the CDN version and has
- * the same drift this fork had. Here it was `3.7.4` in the worker against
- * `^3.9.6` in package.json; at `b751eae` upstream's own numbers are `3.8.2` and
- * `^3.9.6`. `__PRETTIER_VERSION__` is substituted at build time from the
- * resolved `prettier` package (see `nuxt.config.ts`), so the version the browser
- * loads is the version the server prerendered with, and `pnpm up` moves both
- * together.
+ * The deliberate divergence: upstream loads prettier from jsDelivr. This does
+ * not (#399).
  *
- * The CDN import is unpinned beyond its version — no SRI, and the site sets no
- * CSP. That is unchanged by this file's history and tracked separately.
+ * Fetching it meant the page executed six third-party modules that nothing
+ * verified. A dynamic `import()` cannot carry an `integrity` attribute, so SRI
+ * was not available even in principle, and the site sets no CSP — there was no
+ * second line of defence either. The version was at least pinned, after this
+ * fork and upstream both drifted (`3.7.4`, then `3.8.2` upstream, against
+ * `^3.9.6` in package.json), but a pinned version off a CDN is still a promise
+ * from the CDN.
+ *
+ * `prettier` is already a dependency of this package — the server imports it
+ * directly to prerender the same snippets — so the browser was fetching a copy
+ * of something already on disk. It is bundled now: no third-party origin, no
+ * integrity question, and the version cannot drift from the prerenderer's
+ * because it IS the prerenderer's.
+ *
+ * The imports stay dynamic so the parsers remain a lazy chunk, fetched on the
+ * first format rather than at page load. They are also why this worker is no
+ * longer `?worker&inline`: inlining a base64 copy of the parsers into the entry
+ * bundle would trade a supply-chain problem for a page-weight one.
  */
-
-const CDN = `https://cdn.jsdelivr.net/npm/prettier@${__PRETTIER_VERSION__}`
 
 let _prettier
 let _plugins
@@ -66,13 +73,15 @@ function handleMessage(message) {
 
 async function handleFormatMessage(message) {
   if (!_prettier) {
+    // `markdown` is the parser every callsite asks for; the other four are what
+    // it delegates to for a fenced code block inside the document.
     const [prettierModule, ...plugins] = await Promise.all([
-      import(`${CDN}/standalone.mjs`),
-      import(`${CDN}/plugins/babel.mjs`),
-      import(`${CDN}/plugins/estree.mjs`),
-      import(`${CDN}/plugins/html.mjs`),
-      import(`${CDN}/plugins/markdown.mjs`),
-      import(`${CDN}/plugins/typescript.mjs`)
+      import('prettier/standalone'),
+      import('prettier/plugins/babel'),
+      import('prettier/plugins/estree'),
+      import('prettier/plugins/html'),
+      import('prettier/plugins/markdown'),
+      import('prettier/plugins/typescript')
     ])
     _prettier = prettierModule
     _plugins = plugins

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -1,26 +1,10 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { readdirSync } from 'node:fs'
 import { join } from 'node:path'
-import { createRequire } from 'node:module'
 import { createResolver } from '@nuxt/kit'
 import pkg from '../package.json'
 import { withoutTrailingSlash } from 'ufo'
 
 const { resolve } = createResolver(import.meta.url)
-
-/**
- * The version of prettier actually installed here, injected into the client
- * worker so it loads the same one from the CDN.
- *
- * Server-side formatting imports `prettier` from node_modules; the worker used
- * to hard-code a CDN version, and the two had drifted (3.7.4 against 3.9.6).
- * That is a silent inconsistency of exactly the kind a docs site should not
- * have: the same snippet came out formatted one way during prerender and
- * another way after hydration. Reading the resolved version means a `pnpm up`
- * moves both sides together.
- */
-const prettierVersion: string = JSON.parse(
-  readFileSync(createRequire(import.meta.url).resolve('prettier/package.json'), 'utf8')
-).version
 
 // Prerender list is derived from the filesystem (#96) so a new page can't be
 // forgotten and silently 404 on the /raw/<page>.md path (crawlLinks only finds
@@ -226,9 +210,13 @@ export default defineNuxtConfig({
   },
 
   vite: {
-    define: {
-      // Consumed by app/workers/prettier.js — see `prettierVersion` above.
-      __PRETTIER_VERSION__: JSON.stringify(prettierVersion)
+    worker: {
+      // Vite builds a worker as an IIFE by default, and an IIFE cannot be code
+      // split — so every dynamic `import()` inside the worker is inlined into
+      // it. That put all of prettier into the worker script itself (#399).
+      // As an ES module the parsers stay a separate chunk, fetched on the first
+      // format rather than with the worker.
+      format: 'es'
     },
     server: {
       // Fix: "Blocked request. This host is not allowed" when using tunnels like ngrok

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -216,6 +216,15 @@ export default defineNuxtConfig({
       // it. That put all of prettier into the worker script itself (#399).
       // As an ES module the parsers stay a separate chunk, fetched on the first
       // format rather than with the worker.
+      //
+      // The cost, stated here because it is a trade and not a detail: this
+      // emits `new Worker(url, { type: 'module' })`, which needs Chrome/Edge
+      // 80+, Safari 15+ and Firefox 114+. The IIFE it replaces worked
+      // everywhere. The failure is contained — `app/plugins/prettier.ts` builds
+      // the worker lazily, so on an older browser in-page code formatting
+      // simply does not happen and nothing else is affected. The repository
+      // states no browserslist target, so this is the decision rather than a
+      // violation of one.
       format: 'es'
     },
     server: {

--- a/test/integration/docs/prettier-bundled.unit.spec.ts
+++ b/test/integration/docs/prettier-bundled.unit.spec.ts
@@ -90,7 +90,23 @@ describe('#399 the prettier worker uses the bundled dependency', () => {
     // Vite builds a worker as an IIFE by default, and an IIFE cannot be code
     // split — every dynamic import inside it is inlined. Measured: that put all
     // of prettier into the worker script, 1.9 MB, which the plugin constructs.
-    expect(read('docs/nuxt.config.ts')).toMatch(/worker:\s*\{[^}]*format:\s*'es'/)
+    //
+    // A source-text check, with the ceiling that implies: it cannot see that
+    // Vite really emitted a module worker, and it would not notice some other
+    // option disabling code splitting while this one still reads `'es'`. Only a
+    // real build shows that, which is why the measurement lives in the PR and
+    // the commit rather than here — a `docs:build` from a unit spec costs
+    // minutes. Comments are stripped first so the option cannot be matched
+    // inside the prose explaining it, and the search is anchored on the `worker`
+    // block rather than the whole file, so a stray `format: 'es'` elsewhere in
+    // the config does not satisfy it.
+    const config = read('docs/nuxt.config.ts')
+      .replaceAll(/\/\*[\s\S]*?\*\//g, ' ')
+      .replaceAll(/\/\/[^\n]*/g, ' ')
+
+    const workerBlock = /\bworker\s*:\s*\{([\s\S]*?)\n\s{4}\}/.exec(config)
+    expect(workerBlock, 'no `worker` block in the vite config').not.toBeNull()
+    expect(workerBlock![1]).toMatch(/format\s*:\s*'es'/)
   })
 
   it('constructs the worker lazily, not at plugin setup', () => {

--- a/test/integration/docs/prettier-bundled.unit.spec.ts
+++ b/test/integration/docs/prettier-bundled.unit.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * #399 — the docs site formats with the prettier it depends on, not a CDN copy.
+ *
+ * The worker used to `import()` six modules from jsDelivr. A dynamic import
+ * cannot carry an `integrity` attribute, so SRI was not available even in
+ * principle, and the site sets no CSP — the page executed third-party code with
+ * nothing verifying it. `prettier` was already a dependency of `docs/`, used by
+ * the server to prerender the same snippets, so the browser was fetching a copy
+ * of something already on disk.
+ *
+ * These pin the half a build cannot: that the six module specifiers resolve, and
+ * that they still format what the site asks them to. A green build proves the
+ * bundle was produced, not that the parsers work.
+ *
+ * Portal-free (jsSdk:unit).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const repoRoot = resolve(__dirname, '../../..')
+const read = (rel: string) => readFileSync(join(repoRoot, rel), 'utf8')
+const workerSource = read('docs/app/workers/prettier.js')
+
+describe('#399 the prettier worker uses the bundled dependency', () => {
+  it('imports no CDN URL', () => {
+    // The host that was there, and the general shape — so swapping jsDelivr for
+    // another CDN does not quietly pass.
+    expect(workerSource).not.toContain('cdn.jsdelivr.net')
+    expect(workerSource).not.toMatch(/import\(\s*[`'"]https?:/)
+  })
+
+  it('imports the six modules from the package', () => {
+    for (const specifier of [
+      'prettier/standalone',
+      'prettier/plugins/babel',
+      'prettier/plugins/estree',
+      'prettier/plugins/html',
+      'prettier/plugins/markdown',
+      'prettier/plugins/typescript'
+    ]) {
+      expect(workerSource).toContain(`import('${specifier}')`)
+    }
+  })
+
+  it('resolves and formats markdown with an embedded TypeScript block', async () => {
+    // Resolved FROM the docs package, which is where the worker lives and where
+    // `prettier` is declared — the root workspace does not depend on it, so a
+    // bare `import('prettier/standalone')` here would fail for a reason that
+    // says nothing about the site. This also makes the test check the thing
+    // that actually matters: that the specifiers resolve in the package that
+    // bundles them.
+    const requireFromDocs = createRequire(join(repoRoot, 'docs/nuxt.config.ts'))
+    const load = (specifier: string) =>
+      import(pathToFileURL(requireFromDocs.resolve(specifier)).href)
+
+    const [prettier, ...plugins] = await Promise.all([
+      load('prettier/standalone'),
+      load('prettier/plugins/babel'),
+      load('prettier/plugins/estree'),
+      load('prettier/plugins/html'),
+      load('prettier/plugins/markdown'),
+      load('prettier/plugins/typescript')
+    ])
+
+    const source = ['# t', '', '```ts', 'const a={b:1,c:[1,2]};function f(){return a}', '```', ''].join('\n')
+
+    const formatted = await prettier.format(source, {
+      parser: 'markdown',
+      plugins,
+      // The options CodeExample.vue passes.
+      trailingComma: 'none',
+      semi: false,
+      singleQuote: true,
+      printWidth: 100
+    })
+
+    // The embedded block is reformatted, which is what needs the
+    // babel/estree/typescript plugins — a markdown parser alone leaves it
+    // untouched, and this assertion is what would notice.
+    expect(formatted).toContain('const a = { b: 1, c: [1, 2] }')
+    expect(formatted).toContain('function f() {')
+    // The site's own style options reached the embedded code.
+    expect(formatted).not.toContain(';\n')
+  })
+
+  it('builds the worker as an ES module, so the parsers stay a separate chunk', () => {
+    // Vite builds a worker as an IIFE by default, and an IIFE cannot be code
+    // split — every dynamic import inside it is inlined. Measured: that put all
+    // of prettier into the worker script, 1.9 MB, which the plugin constructs.
+    expect(read('docs/nuxt.config.ts')).toMatch(/worker:\s*\{[^}]*format:\s*'es'/)
+  })
+
+  it('constructs the worker lazily, not at plugin setup', () => {
+    // The other half of the same measurement: an eagerly constructed worker
+    // downloads its own script immediately, on every page, including the many
+    // that never format anything.
+    const plugin = read('docs/app/plugins/prettier.ts')
+    expect(plugin).not.toMatch(/const worker = new PrettierWorker\(\)/)
+    expect(plugin).toMatch(/api \?\?= createPrettierWorkerApi\(new PrettierWorker\(\)\)/)
+  })
+})


### PR DESCRIPTION
The first half of #399. The second half — a CSP — is deliberately not here; see the end.

## ⚠️ This narrows browser support, slightly

`vite.worker.format: 'es'` produces a **module Worker**. Those need Chrome/Edge 80+, Safari 15+, **Firefox 114+** (2023). The previous IIFE worker had universal support.

Calling it out here rather than leaving it in a vite option, because it is a trade rather than a detail. The failure mode is contained: the worker is constructed lazily on first format, so on an unsupported browser in-page code formatting silently does not happen — navigation, content and everything else are unaffected. For a documentation site that is an acceptable price for removing third-party code execution; if it is not, say so and the alternative is keeping the IIFE worker and accepting a 1.9 MB eager chunk instead.

## The problem

The formatting worker loaded prettier and five parser plugins from jsDelivr with dynamic `import()`:

```js
await Promise.all([
  import(`${CDN}/standalone.mjs`),
  import(`${CDN}/plugins/babel.mjs`),
  // …four more
])
```

A dynamic import **cannot carry an `integrity` attribute**, so SRI was not available even in principle, and the site sets no CSP — there was no second line of defence either. The version was at least pinned, after this fork and upstream both drifted, but a pinned version off a CDN is still a promise from the CDN: nothing verified that jsDelivr served the pinned bytes on any given request.

## The fix, which turned out to be a deletion

`prettier` is **already a dependency of `docs/`** — the server imports it to prerender the same snippets. The browser was fetching a copy of something already on disk.

It is bundled now. No third-party origin, no integrity question, and the version cannot drift from the prerenderer's because it *is* the prerenderer's. The build-time `__PRETTIER_VERSION__` injection that existed only to keep the two in step goes with it.

The residual exposure collapses from two trust boundaries to one: npm's, which the rest of the application already depends on. The lockfile pins `prettier@3.9.6` exactly despite the `^3.9.6` range, and root `pnpm audit` plus Dependabot already covered it — the CDN copy was the part nothing covered.

## Measuring caught a regression I would otherwise have shipped

Vite builds a worker as an **IIFE** by default, and an IIFE cannot be code split — so every dynamic import inside it gets inlined. The whole of prettier landed in the worker script, **1.9 MB**, which the plugin constructed at setup. That would have downloaded the parsers on every page load, including the many pages that never format anything: trading a supply-chain problem for a page-weight one.

| | before this PR | naive bundling | after |
|---|---|---|---|
| worker script | small, + CDN fetch | **1.9 MB, eager** | **1 KB, lazy** |
| parsers | from jsDelivr, on first format | in the worker | separate chunks, on first format |

- `vite.worker.format: 'es'` — the parsers stay separate chunks.
- The worker is constructed on the **first format** rather than at plugin setup, restoring the timing the CDN version had.

**On hosting:** ~500 KB gzipped of parsers now come from GitHub Pages instead of jsDelivr. Pages is Fastly-backed, so latency is not a meaningful regression; the site loses jsDelivr's cross-site shared cache, which for a docs site is not worth a third-party origin.

## Verified, not assumed

- No `cdn.jsdelivr.net` anywhere in the built site.
- The parser chunks appear in no HTML preload — they really are lazy.
- The six modules resolve and reformat a markdown document **containing a TypeScript block**, which is what exercises the babel/estree/typescript plugins; a markdown parser alone would leave it untouched and prove nothing.
- The build emitting a single HTML file is normal here — checked by building `main` the same way rather than assuming it was my change.

The new spec resolves prettier **from the docs package**, since the root workspace does not depend on it; a bare specifier fails there for a reason that says nothing about the site. All three guards fail under mutation: restoring a CDN import (2 tests), switching the worker back to `iife` (1), constructing it eagerly (1).

## What this does not do

**No CSP.** The site is on GitHub Pages, so it cannot set response headers — a CSP has to be a `<meta http-equiv>` tag covering fonts, images and every other embed, and a wrong one breaks the page in ways only a browser shows.

It is a smaller job now: **the worker contacts zero external origins after this PR**, so the remaining CSP work no longer has to carve out an exception for jsDelivr. Worth recording on #399 so it is not re-litigated.

## Checks

- `pnpm run typecheck` — 0 errors · `pnpm run docs:build` — full site build, used for every measurement above
- `jsSdk:unit` + `jsSdk:types` + `skills:unit` — 734 tests
- `lint` (1 pre-existing unrelated warning in `docs/server/api/ai.post.ts`), `docs-lint --strict`, `md-internal-links`

Refs #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr