### PR TITLE
docs: ask whether to deprecate, in the places that describe how

### DIFF
--- a/.github/contributing/deprecations.md
+++ b/.github/contributing/deprecations.md
@@ -135,15 +135,32 @@ Keeping a member is not the same as saying nothing about it. Record:
   is a contract — including whatever it does in the situation that motivated the
   deprecation in the first place.
 
-## This page is not a control
+## Where this is asked, and what still is not enforced
 
-Nothing makes anyone read it at the moment a tag is written. That is the honest
-limit of a contributing document, and it is worth saying here rather than
-discovering it the next time a batch goes through unexamined — the failure this
-page describes was not someone believing the wrong thing, it was a question
-nobody asked. #414 tracks putting the test somewhere it interrupts: the PR
-checklist, the `/code-review` prompt, or a CI nudge on a diff that tags more than
-one export at once.
+The failure this page describes was not someone believing the wrong thing. It was
+a question nobody asked. So the question is now asked in the three places
+someone passes on the way to writing a tag (#414):
+
+- the **PR Review Checklist** in `AGENTS.md` — the entry immediately after the
+  deprecation-cycle line, which asks for the replacement line of code **per
+  member**;
+- the **Code Conventions** row for Deprecation, which puts the decision ahead of
+  the `@deprecated` / `@removed` / `forcedLog` mechanics it used to describe on
+  its own;
+- the **public-contract bullet** under SDK Source, where "needs a deprecation
+  cycle" now carries "and a deprecation needs a replacement".
+
+All three previously described **how** to deprecate and never asked **whether**.
+That was the gap: the mechanics assume a decision that nothing prompted anyone to
+make.
+
+**None of it is enforced.** Nothing fails when a pull request adds `@deprecated`
+and skips the question — these are prompts in a document, read by whoever reads
+documents. A CI nudge on a diff that tags more than one export at once was
+considered and not built: it is the only option that targets the actual failure
+(batching), and also the only one that produces false alarms, since a genuine
+batch of one-for-one replacements is legitimate and would trip it every time. For
+a failure that has happened once, prompts first; revisit if it happens again.
 
 ## Related
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ Cutting a release (bump → changelog → tag → publish) is documented in **[R
 - **Conventional Commits**: the commit subject IS the changelog entry — release-please assembles `CHANGELOG.md` from the subjects merged since the last tag (#347). Use a type mapped in `changelog-sections` ([release-please-config.json](release-please-config.json)): `feat`, `fix`, `perf`, `revert`, `security`, `deps`, `refactor`, `build`, `docs`, `test`, `ci`, `chore`, `style`. That list **replaces** the preset's rather than extending it, so an unmapped type is invisible in the changelog — the ad-hoc `platform:` / `dx:` / `http:` subjects this repo has used are not mapped. Only `feat` and a breaking marker raise the version above a patch; force one with a `Release-As: 2.1.0` footer. Write the subject so a reader of the release notes understands the change without opening the diff. The hand-written `## [Unreleased]` block in [CHANGELOG.md](CHANGELOG.md) is being retired on the first release PR — see the handover note in [RELEASING.md](RELEASING.md); do not add to it.
 - **No default exports**: every export is named so consumers stay tree-shakeable (`sideEffects: false`).
 - **TypeScript strict**: `tsc` for the core SDK; `vue-tsc` for the Nuxt / docs / playground projects.
-- **Public contract**: exports from [packages/jssdk/src/index.ts](packages/jssdk/src/index.ts) are a public API. Any breaking change needs a deprecation cycle, not a silent rename.
+- **Public contract**: exports from [packages/jssdk/src/index.ts](packages/jssdk/src/index.ts) are a public API. Any breaking change needs a deprecation cycle, not a silent rename — and a deprecation needs a replacement that costs the caller nothing, or it is a breaking change with a friendlier tag on it ([`deprecations.md`](.github/contributing/deprecations.md)).
 - **Cross-package awareness**: when you change the core SDK API, check whether [packages/jssdk-nuxt/src/runtime/plugin.ts](packages/jssdk-nuxt/src/runtime/plugin.ts) needs an update.
 - **Code formatting**: `@nuxt/eslint-config` (flat) with stylistic overrides — 2-space indent, no trailing commas, 1tbs braces. `.editorconfig` enforces LF + 2 spaces. The protobuf JS files in `packages/jssdk/src/pullClient` are eslint-ignored intentionally.
 - **Build tokens**: `__SDK_VERSION__` and `__SDK_USER_AGENT__` are replaced at build time by [packages/jssdk/build.config.ts](packages/jssdk/build.config.ts); the Nuxt module's `meta.version` uses the same `__SDK_VERSION__` token via [packages/jssdk-nuxt/build.config.ts](packages/jssdk-nuxt/build.config.ts). Do not hard-code versions.
@@ -220,7 +220,7 @@ Load these based on your task. **Do not load all files at once** — only load w
 | Limiters | New transport code paths must respect the limiter stack (`RateLimiter`, `OperatingLimiter`, `AdaptiveDelayer`) — do not bypass it. HTTP 4xx is automatically classified as non-retryable; `hardErrorCodes` is for HTTP 2xx domain-level error codes the SDK doesn't recognise as terminal |
 | Enterprise | Treat the enterprise restriction params from `LicenseManager` as load-time switches; do not duplicate them |
 | Build tokens | Use `__SDK_VERSION__` / `__SDK_USER_AGENT__` placeholders, never literal version strings |
-| Deprecation | Mark with JSDoc `@deprecated`, add `@removed X.Y.Z` and (if useful) `@memo` tags, and emit a runtime warning with `LoggerFactory.forcedLog(this._logger, 'warning', { … })`. See `abstract-b24.ts` for the canonical pattern |
+| Deprecation | **First decide whether to deprecate at all** — does a replacement exist that costs the caller nothing? See [`deprecations.md`](.github/contributing/deprecations.md). Then: JSDoc `@deprecated`, `@removed X.Y.Z` and (if useful) `@memo` tags, and a runtime warning via `LoggerFactory.forcedLog(this._logger, 'warning', { … })`. See `abstract-b24.ts` for the canonical pattern |
 | Pull protobuf | The auto-generated protobuf JS is intentionally eslint-ignored — do not "clean it up" |
 
 ## Workflows
@@ -274,6 +274,7 @@ PR Review:
 - [ ] Errors use SdkError ({ code, description, status }) / AjaxError — no bare throws or string-form SdkError
 - [ ] Public API changes are re-exported from src/index.ts
 - [ ] Public API changes have a deprecation cycle (no silent renames): JSDoc @deprecated + @removed tag + LoggerFactory.forcedLog warning
+- [ ] **Adding `@deprecated`? Name the replacement for each member, one at a time.** Write the line of code the caller replaces it with. Cannot write that line, or it only works under one protocol version, or it is `@experimental`? Then this is a breaking change wearing a deprecation tag — see [`deprecations.md`](.github/contributing/deprecations.md). Judge per member: a shared trait is a reason to review a group together, never to decide it together
 - [ ] Frame changes bootstrap only through initializeB24Frame() (no alternative constructor paths)
 - [ ] Helper sub-managers extend AbstractHelper and follow the constructor(b24: TypeB24) + setLogger() shape
 - [ ] B24Hook usage is server-side only; no logs of raw request URLs (which contain webhook secrets in the path)


### PR DESCRIPTION
Closes #414.

## The gap

`deprecations.md` (from #409) records the test a deprecation has to pass, and said of itself:

> Nothing makes anyone read it at the moment a tag is written.

That was accurate, and it is the whole problem. The failure in #277 was **not** that anyone believed `getTotal()` had a replacement and was mistaken. **Nobody asked about `getTotal()` specifically at all** — five members moved as one batch on a shared trait.

Meanwhile `AGENTS.md` mentioned deprecation in three places, and all three described the **mechanics** — `@deprecated`, `@removed`, the `forcedLog` warning — while assuming a decision that nothing prompted anyone to make. The instructions were complete about *how* and silent about *whether*.

## What changed

| Where | Before | Now |
|---|---|---|
| **PR Review Checklist** | "Public API changes have a deprecation cycle: JSDoc + @removed + forcedLog" | plus a new entry: name the replacement **for each member, one at a time**, by writing the line of code the caller replaces it with |
| **Code Conventions**, Deprecation row | the three tags and the warning | the decision first, then the tags |
| **Public-contract bullet** | "needs a deprecation cycle, not a silent rename" | "…and a deprecation needs a replacement that costs the caller nothing, or it is a breaking change with a friendlier tag on it" |

The checklist entry carries the three ways to fail, in the form that is actually usable at that moment:

> Cannot write that line, or it only works under one protocol version, or it is `@experimental`? Then this is a breaking change wearing a deprecation tag. Judge per member: a shared trait is a reason to review a group together, never to decide it together.

That last clause is the one that would have caught #277.

## What is still not enforced — all of it

`deprecations.md`'s "this page is not a control" section is replaced by where the question now gets asked, and by an equally plain statement that **nothing fails** when a PR adds `@deprecated` and skips it. These are prompts in a document, read by whoever reads documents.

The issue listed three options. Two are not taken, and the reasons are recorded rather than left as silence:

- **The `/code-review` prompt** — not editable from this repository. The skill lives outside it.
- **A CI nudge on a diff tagging more than one export at once** — the only option that targets the actual failure, batching, and also the only one that produces false alarms: a genuine batch of one-for-one replacements is legitimate and would trip it every time. For a failure that has happened once, prompts first; revisit if it happens again.

There is no PR template in this repository, so the checklist in `AGENTS.md` is the artifact the actor doing the work actually reads.

## Checks

Documentation only, so `/code-review` alone under the rule introduced in #421.

- `lint:md` · `lint:md-links` 131 links · `docs-lint --strict` 0/0
- `scripts/__tests__` 95 passed · `lint` 0 errors (1 pre-existing unrelated warning)

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_