### PR TITLE
test(skills): read the shapes batch and callList actually return

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
@@ -100,6 +100,11 @@ calls: {
 | **`returnAjaxResult`** | `boolean`{lang="ts-type"} | `false` | Whether to return an `AjaxResult` object instead of data. |
 | **`requestId`** | `string`{lang="ts-type"} | — | Unique request identifier for tracking. Used for request deduplication and debugging. |
 
+
+::warning
+These belong **inside** `options`. Passed as top-level properties of the argument they are **silently ignored** — no error, no warning, and the call behaves as though you never set them. `returnAjaxResult` dropped this way is the one that bites: `isSuccess` on a plain payload is `undefined`, so a batch where every command succeeded reads as a batch where every command failed (#426).
+::
+
 ### Return Value
 
 `Promise<CallBatchResult<T>>`{lang="ts-type"} — a promise that resolves to a `CallBatchResult<T>` object.

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
@@ -100,6 +100,11 @@ calls: {
 | **`returnAjaxResult`** | `boolean`{lang="ts-type"} | `false` | Whether to return an `AjaxResult` object instead of data. |
 | **`requestId`** | `string`{lang="ts-type"} | — | Unique request identifier for tracking. Used for request deduplication and debugging. |
 
+
+::warning
+These belong **inside** `options`. Passed as top-level properties of the argument they are **silently ignored** — no error, no warning, and the call behaves as though you never set them. `returnAjaxResult` dropped this way is the one that bites: `isSuccess` on a plain payload is `undefined`, so a batch where every command succeeded reads as a batch where every command failed (#426).
+::
+
 ### Return Value
 
 `Promise<CallBatchResult<T>>`{lang="ts-type"} — a promise that resolves to a `CallBatchResult<T>` object.

--- a/skills/b24jssdk-rest/SKILL.md
+++ b/skills/b24jssdk-rest/SKILL.md
@@ -277,6 +277,20 @@ res.getQuery()              // { method, params, requestId }
 
 > `getData()` returns `undefined` when the call did not succeed — the new typing forces you to either check `isSuccess` first, or assert with `!`. Both patterns appear in the canonical SDK tests (`test/integration/js-docs/actions-v{2,3}.spec.ts`).
 
+### What `getData()` returns, per action
+
+Only `call.make` has a `result` property. Reading `.result` off the others gives `undefined` — no error, no warning, just a value that reads as an empty response (#425).
+
+| Action | `getData()` | Reach a row with |
+| --- | --- | --- |
+| `call.make` | `{ result, time }` | `getData()!.result` |
+| `batch.make` | the keyed map, or an array for the array form | `getData()!.myKey` |
+| `callList.make` | a flat array | `getData()![0]` |
+| `batchByChunk.make` | a flat array | `getData()![0]` |
+| `fetchList.make` | *(async generator)* — yields arrays | `for await (const chunk of …)` |
+
+With `options.returnAjaxResult: true`, each entry of a batch result is an `AjaxResult` rather than the raw payload, so you reach a row with `getData()!.myKey.getData()!.result`.
+
 ### `restApi:v2` paging members — kept, but v2-only
 
 `isMore()` / `hasMore()` / `getTotal()` / `getNext()` / `fetchNext()` are **not** deprecated and are **not** going away in `3.0.0`. They work with the v2 envelope fields `next` / `total` directly.
@@ -397,6 +411,8 @@ const hasNotes = Boolean(doc?.paths?.['/note.collection.list'])
 - ❌ `idKey: 'ID'` alone for `tasks.task.list` — the response id is lowercase `id`, so the cursor can't read it and paging silently stops after 50. Use `idKey: 'id', cursorIdKey: 'ID'`.
 - ❌ `Promise.all` over `callList.make` for parallel paging — internal cursor pagination is sequential by design; you'll get duplicates or skipped rows.
 - ❌ Hand-paging a v3 list method by the `nextCursor` it returns (e.g. `note.*`) — `callList` / `fetchList` page via their own `idKey` cursor and walk every page; `nextCursor` is informational and the SDK ignores it. Just use the list helpers with `idKey` + `customKeyForResult`.
+- ❌ `batch.make({ calls, isHaltOnError: false })` — batch flags at the top level are **silently ignored**: no error, no warning, and the call behaves as if you never set them. `returnAjaxResult` dropped this way is the nastier one, because `entry.isSuccess` is then `undefined` on a plain object, so a batch where everything succeeded reads as a batch where everything failed. They belong under `options: { isHaltOnError, returnAjaxResult, requestId }` (#426).
+- ❌ Reading `getData()!.result` off `batch.make` / `callList.make` / `batchByChunk.make` — only `call.make` returns that envelope. See the table above.
 - ❌ `B24Hook` in a browser bundle — leaks the webhook secret. Use `B24Frame` there.
 
 ## Cross-reference

--- a/test/integration/skills/skills-live.spec.ts
+++ b/test/integration/skills/skills-live.spec.ts
@@ -218,15 +218,34 @@ describe('skills-live @skills', () => {
   })
 
   // ── b24jssdk-rest ──────────────────────────────────────────────────────
+  /**
+   * What `getData()` returns, per action — measured against a live portal, and
+   * the thing this block used to get wrong (#425):
+   *
+   * | action            | `getData()`                                  |
+   * | ----------------- | -------------------------------------------- |
+   * | `call.make`       | the envelope: `{ result, time }`             |
+   * | `batch.make`      | the keyed map directly: `{ now: …, me: … }`  |
+   * | `callList.make`   | a flat array                                 |
+   * | `batchByChunk`    | a flat array                                 |
+   *
+   * Only `call` has a `result` property. Reading `getData()!.result` off the
+   * others yields `undefined`, which reads as an SDK or skill defect and is
+   * neither — the skill files document these shapes correctly.
+   *
+   * Batch flags (`isHaltOnError`, `returnAjaxResult`) go under `options`. At the
+   * top level they are silently ignored (#426), so a case written that way
+   * verifies something other than what its title claims.
+   */
   describe('b24jssdk-rest/SKILL.md', () => {
     portalIt('actions.v2.batch.make returns one result per command', async () => {
       const response = await getB24Client().actions.v2.batch.make({
         calls: { now: ['server.time', {}], me: ['profile', {}] },
-        isHaltOnError: false,
-        requestId: 'skills-live/rest-v2-batch'
+        options: { isHaltOnError: false, requestId: 'skills-live/rest-v2-batch' }
       })
       expect(response.isSuccess).toBe(true)
-      const data = response.getData()!.result as Record<string, unknown>
+      // The keyed map itself — batch has no `result` envelope.
+      const data = response.getData() as Record<string, unknown>
       expect(Object.keys(data)).toEqual(expect.arrayContaining(['now', 'me']))
     })
 
@@ -238,10 +257,19 @@ describe('skills-live @skills', () => {
         requestId: 'skills-live/rest-v2-callList'
       })
       expect(response.isSuccess).toBe(true)
-      expect(Array.isArray(response.getData()!.result)).toBe(true)
+      expect(Array.isArray(response.getData())).toBe(true)
     })
 
-    portalIt('actions.v2.fetchList.make yields chunks', async () => {
+    portalIt('actions.v2.fetchList.make yields chunks', async (ctx) => {
+      // A generator over an empty method yields nothing at all — correctly. That
+      // is a portal with no contacts, not a skill defect, so it skips rather
+      // than failing; asserting "at least one chunk" made an empty portal look
+      // like a broken generator (#425).
+      if (found.contactId === null) {
+        console.warn('[skills-live] SKIP — no contact on this portal to page over')
+        ctx.skip()
+        return
+      }
       const generator = getB24Client().actions.v2.fetchList.make<{ ID: string }>({
         method: 'crm.contact.list',
         params: { select: ['ID'] },
@@ -284,7 +312,7 @@ describe('skills-live @skills', () => {
         requestId: 'skills-live/rest-v3-callList'
       })
       expect(response.isSuccess).toBe(true)
-      expect(Array.isArray(response.getData()!.result)).toBe(true)
+      expect(Array.isArray(response.getData())).toBe(true)
     })
 
     it('a method that is not on v3 fails softly, not by throwing', async () => {
@@ -309,12 +337,11 @@ describe('skills-live @skills', () => {
       // not sink the good ones, and the failures are reachable by key.
       const response = await getB24Client().actions.v2.batch.make({
         calls: { good: ['server.time', {}], bad: ['this.method.does.not.exist', {}] },
-        isHaltOnError: false,
-        requestId: 'skills-live/rest-v2-batch-partial'
+        options: { isHaltOnError: false, requestId: 'skills-live/rest-v2-batch-partial' }
       })
       const errorsByKey = response.getErrorsByKey?.() ?? {}
       expect(Object.keys(errorsByKey)).toContain('bad')
-      const data = response.getData()!.result as Record<string, unknown>
+      const data = response.getData() as Record<string, unknown>
       expect(data.good).toBeDefined()
     })
 
@@ -354,7 +381,7 @@ describe('skills-live @skills', () => {
         requestId: 'skills-live/rest-v2-tasks-cursor'
       })
       expect(response.isSuccess).toBe(true)
-      expect(Array.isArray(response.getData()!.result)).toBe(true)
+      expect(Array.isArray(response.getData())).toBe(true)
     })
 
     portalIt('crm.item.list needs lowercase idKey and customKeyForResult items', async () => {
@@ -368,7 +395,7 @@ describe('skills-live @skills', () => {
         requestId: 'skills-live/rest-crm-item-list'
       })
       expect(response.isSuccess).toBe(true)
-      expect(Array.isArray(response.getData()!.result)).toBe(true)
+      expect(Array.isArray(response.getData())).toBe(true)
     })
 
     portalIt('actions.v3.fetchTail.make drives the native cursor', async () => {
@@ -469,7 +496,7 @@ describe('skills-live @skills', () => {
         requestId: 'skills-live/filtering-v2-prefix'
       })
       expect(response.isSuccess).toBe(true)
-      for (const row of response.getData()!.result) {
+      for (const row of response.getData()!) {
         expect(Number(row.ID)).toBeGreaterThan(found.contactId!)
       }
     })
@@ -512,7 +539,7 @@ describe('skills-live @skills', () => {
         requestId: 'skills-live/filtering-order-stripped'
       })
       expect(response.isSuccess).toBe(true)
-      const ids = response.getData()!.result.map(r => Number(r.ID))
+      const ids = response.getData()!.map(r => Number(r.ID))
       const ascending = [...ids].sort((a, b) => a - b)
       expect(ids).toEqual(ascending)
     })

--- a/test/integration/skills/skills-live.spec.ts
+++ b/test/integration/skills/skills-live.spec.ts
@@ -219,23 +219,18 @@ describe('skills-live @skills', () => {
 
   // ── b24jssdk-rest ──────────────────────────────────────────────────────
   /**
-   * What `getData()` returns, per action — measured against a live portal, and
-   * the thing this block used to get wrong (#425):
+   * Two traps this block fell into, both now written up where a reader will
+   * actually meet them — `skills/b24jssdk-rest/SKILL.md`, section
+   * "What `getData()` returns, per action" and the Anti-patterns list:
    *
-   * | action            | `getData()`                                  |
-   * | ----------------- | -------------------------------------------- |
-   * | `call.make`       | the envelope: `{ result, time }`             |
-   * | `batch.make`      | the keyed map directly: `{ now: …, me: … }`  |
-   * | `callList.make`   | a flat array                                 |
-   * | `batchByChunk`    | a flat array                                 |
+   *   - only `call.make` returns a `{ result, time }` envelope; `batch` and
+   *     `callList` do not, so `getData()!.result` there is `undefined` (#425);
+   *   - batch flags belong under `options` — at the top level they are silently
+   *     ignored, so a case written that way verifies something other than what
+   *     its title claims (#426).
    *
-   * Only `call` has a `result` property. Reading `getData()!.result` off the
-   * others yields `undefined`, which reads as an SDK or skill defect and is
-   * neither — the skill files document these shapes correctly.
-   *
-   * Batch flags (`isHaltOnError`, `returnAjaxResult`) go under `options`. At the
-   * top level they are silently ignored (#426), so a case written that way
-   * verifies something other than what its title claims.
+   * Six cases here asserted the first and two relied on the second, which is
+   * why this suite was red against a working portal.
    */
   describe('b24jssdk-rest/SKILL.md', () => {
     portalIt('actions.v2.batch.make returns one result per command', async () => {


### PR DESCRIPTION
Closes #425.

## What this fixes

`pnpm run skills:verify` against a working portal came back **7 failed, 12 passed, 4 skipped**. Every failure was in the spec, not in the SDK and not in the skill files.

The spec read `response.getData()!.result` for `batch.make` and `callList.make`. Only `call.make` returns that envelope:

| action | `getData()` returns |
| --- | --- |
| `call.make` | `{ result, time }` |
| `batch.make` | the keyed map directly |
| `callList.make` | a flat array |
| `batchByChunk.make` | a flat array |

So `.result` was `undefined`, and six cases failed in a way that read as "the skill documents something that does not work" — which is exactly the signal this suite exists to give, spent on a false alarm. `skills/b24jssdk-rest/SKILL.md` had it right all along.

## Changes

- Six assertions now read the real shape.
- Two batch calls pass `isHaltOnError` under `options`. At the top level it is silently ignored (#426), so those two cases were verifying something other than what their titles said — including the one whose title is *"batch reports per-command failures when `isHaltOnError` is false"*.
- `fetchList yields chunks` skips when the portal has no contacts. A generator over an empty method yields nothing, correctly; asserting at least one chunk turned an empty portal into a red line. `portalIt`'s own docblock says a green line has to mean something was checked — this keeps that true without producing a false red.
- A table in the file recording what each action returns, so the next author does not have to measure it.

## Result

Against a live portal: **0 failed, 18 passed, 5 skipped** (was 7 / 12 / 4). The extra skip is the `fetchList` case, which the portal genuinely cannot exercise.

## Not in scope

The silent option drop itself is SDK behaviour and is tracked in #426. This PR only stops the spec from relying on the broken form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_