### PR TITLE
docs(releasing): decide the release body does not mirror the changelog

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -65,8 +65,28 @@ the reader has the same defect) all read as helpful while writing.
 The GitHub Release body is rendered by release-please from its own changeset, not
 read from `CHANGELOG.md`. An edit made to `CHANGELOG.md` on the release branch
 therefore lands in the repository but **not** in the release notes — the two
-diverge silently. If the release page should match the file, paste the section in
-by hand after publishing.
+diverge.
+
+**Decided: do not mirror them.** Pasting the changelog section into the release
+body was considered and rejected. It is a manual step with no gate, so it would
+be skipped and the divergence would become unpredictable instead of merely known;
+and it creates a second copy of an argument that will drift, which is the failure
+this repository has already documented elsewhere (#420).
+
+What follows from that decision is a discipline, not a chore:
+
+> **Anything a reader must act on has to be legible from the commit subject
+> alone.** The subject is the only text that reaches the release page.
+
+`feat(core): an unknown option on any action is now a compile error` passes — an
+upgrader reading nothing else knows their build may complain. `fix(core): tidy up
+action options` would not have. Check this when writing the squash message, where
+it is free; the release page cannot be fixed afterwards without the manual step
+this section just rejected.
+
+The long form — the paragraph explaining what to do about it — belongs in
+`CHANGELOG.md`, which is where a reader who needs the detail is sent by the
+subject line.
 
 What this changes for everyday work:
 


### PR DESCRIPTION
`RELEASING.md` described the divergence between the GitHub Release body and `CHANGELOG.md` and then left the question open: *"If the release page should match the file, paste the section in by hand after publishing."* This closes it.

## Decision: do not mirror

Two reasons, both structural rather than aesthetic:

- **A manual step with no gate gets skipped.** Today the divergence is consistent and known — the body is always the generated subjects. Pasting sometimes turns that into a divergence nobody can predict, which is worse than the one it replaces.
- **It creates a second copy of an argument.** That is the failure #420 already documents for JSDoc essays duplicating the contributing guides: two copies drift, and the drift is silent.

## What replaces it

> Anything a reader must act on has to be legible from the commit subject alone.

The subject is the only text that reaches the release page. Checked while writing the squash message, this costs nothing; afterwards the release page cannot be fixed without the manual step just rejected.

The 2.2.0 release is the worked example. Its body carries `feat(core): an unknown option on any action is now a compile error` — an upgrader reading nothing else knows their build may complain. `fix(core): tidy up action options` would have hidden it.

The long form stays in `CHANGELOG.md`, which is where the subject line sends a reader who needs the detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_