### PR TITLE
docs(core): agree where a JSDoc block ends, and cut the two longest

### DIFF
--- a/.github/contributing/package-structure.md
+++ b/.github/contributing/package-structure.md
@@ -1,6 +1,6 @@
 # Package Structure
 
-<sub>Last reviewed: 2026-06-17.</sub>
+<sub>Last reviewed: 2026-08-31.</sub>
 
 > **Agent-facing mirror:** the published surface from the angle of agents writing usage code lives in [`b24jssdk-core/`](../../skills/b24jssdk-core/SKILL.md), [`b24jssdk-frame-ui/`](../../skills/b24jssdk-frame-ui/SKILL.md), and [`b24jssdk-helpers/`](../../skills/b24jssdk-helpers/SKILL.md). Keep this guide and those skills in sync when the underlying API changes.
 
@@ -139,6 +139,72 @@ export type { TypeMyPayload } from './types/payloads'
 
       The context key is `removalVersion`, not `removeInVersion`. The canonical pattern lives in [packages/jssdk/src/core/abstract-b24.ts](../../packages/jssdk/src/core/abstract-b24.ts) (search for `@deprecated` + `forcedLog`).
   3. **Both symbols ship together** for at least one minor release.
+
+## How much of a JSDoc block belongs in the code
+
+The longest block in `packages/jssdk/src/` was 97 lines. Eighteen are over
+thirty. Long comments are not the problem — the ones explaining *why* are the
+most valuable thing in this codebase. **Placement** is (#420).
+
+### The threshold
+
+> A JSDoc block longer than the function it documents is a prompt to ask where
+> the text belongs.
+
+Not a lint rule and not a limit. Plenty of short functions deserve a long
+explanation; the question is whether *this* reader, opening *this* file, needs
+all of it in front of them.
+
+### What always stays in the code
+
+The signature contract: parameter meanings, `@returns`, `@throws`,
+`@deprecated` / `@removed`, and **any invariant a reader could break while
+editing that exact file**. If getting it wrong here breaks something, it stays
+here.
+
+### What is better off in a guide
+
+Reasoning, alternatives considered, history, and worked examples. Two reasons,
+one of them measurable:
+
+- **Examples in JSDoc are compiled by nothing.** There are 57 `@example` blocks
+  in `packages/jssdk/src/`, about 460 lines, and no pass type-checks them —
+  while ` ```ts ` fences in `docs/content/**` and `skills/**` are compiled on
+  every CI run (#439). That is not theoretical: three of those examples did not
+  compile, all dereferencing `getData()` without the `!` its
+  `T | null | undefined` return has required since #395. An example in a guide is
+  checked; the same example above the function is not.
+- **A stale claim in the code rots silently.** `docs-lint`, `md-internal-links`
+  and the fence typecheck keep the Markdown guides honest. Nothing watches a
+  comment.
+
+### The shape that works
+
+Worked out in #417 and generalised here. Point at the canonical text, then list
+only what matters while editing:
+
+```ts
+/**
+ * Executes a batch request … (one or two lines)
+ *
+ * **The full argument reference, the three `calls` formats and worked examples
+ * live in [the batch page](…) — that copy is compiled in CI, this one would
+ * not be.**
+ *
+ * What matters while editing this file:
+ *   - at most 50 commands …
+ *   - flags belong in `options` …
+ */
+```
+
+Twelve lines instead of ninety, the argument in one place under lint, and a
+pointer that survives.
+
+### Do this opportunistically
+
+When a file is next touched for another reason. A mass move would be a large
+diff with no behavioural change and a high chance of losing something in
+transit.
 
 ## Class Hierarchies
 

--- a/.github/contributing/package-structure.md
+++ b/.github/contributing/package-structure.md
@@ -169,7 +169,7 @@ one of them measurable:
 
 - **Examples in JSDoc are compiled by nothing.** There are 57 `@example` blocks
   in `packages/jssdk/src/`, about 460 lines, and no pass type-checks them —
-  while ` ```ts ` fences in `docs/content/**` and `skills/**` are compiled on
+  while `ts` fences in `docs/content/**` and `skills/**` are compiled on
   every CI run (#439). That is not theoretical: three of those examples did not
   compile, all dereferencing `getData()` without the `!` its
   `T | null | undefined` return has required since #395. An example in a guide is

--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -204,9 +204,9 @@ reading a config.
 | `docs:typecheck` | the docs Nuxt app |
 | `playground-nuxt:typecheck` | `playgrounds/nuxt/` |
 | `playground-cli:typecheck` | `playgrounds/cli/` |
-| `docs:typecheck-blocks` | ` ```ts ` fences in `docs/content/**/*.md` |
+| `docs:typecheck-blocks` | `ts` fences in `docs/content/**/*.md` |
 | `skills:typecheck` | the recipe `.ts` files under `skills/b24jssdk-recipes/` |
-| `skills:typecheck-blocks` | ` ```ts ` fences in `skills/**/*.md` |
+| `skills:typecheck-blocks` | `ts` fences in `skills/**/*.md` |
 
 Plus the `jsSdk:types` vitest project, which is where the `*.types.spec.ts` pins
 become real — `expectTypeOf` erases at runtime, so under a plain `vitest run` a
@@ -218,7 +218,7 @@ Two results from that measurement are worth carrying:
   smoke tests for the published package shape rather than typechecks of the
   playgrounds. An error inside either playground is caught by its own pass and by
   nothing else.
-- **` ```ts ` fences in `.github/contributing/*.md` are compiled by nothing.**
+- **`ts` fences in `.github/contributing/*.md` are compiled by nothing.**
   Docs fences and skill fences are covered; these are the gap (#435). There is a
   `test/some-code-from-docs/contributing/` directory of hand-written fixtures
   whose names mirror the guides, and nothing checks that a fixture still matches

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: CallV2.make
 description: 'A method for making Bitrix24 REST API version 2 calls.'
 category: 'actions'
-audited: 2026-08-29
+audited: 2026-08-31
 restApiVersion: 'rest-api-ver2'
 navigation.title: Call
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallV3.make
 description: 'Method for making Bitrix24 REST API version 3 calls.'
 category: 'actions'
-audited: 2026-08-29
+audited: 2026-08-31
 restApiVersion: 'rest-api-ver3'
 navigation.title: Call
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: BatchV2.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 2. Allows executing up to 50 commands in a single API call.'
 category: 'actions'
-audited: 2026-08-29
+audited: 2026-08-31
 restApiVersion: 'rest-api-ver2'
 navigation.title: Batch
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3. Allows executing up to 50 commands in a single API call.'
 category: 'actions'
-audited: 2026-08-29
+audited: 2026-08-31
 restApiVersion: 'rest-api-ver3'
 navigation.title: Batch
 links:

--- a/packages/jssdk/src/core/actions/v2/batch.ts
+++ b/packages/jssdk/src/core/actions/v2/batch.ts
@@ -23,96 +23,45 @@ export type ActionBatchV2 = {
  */
 export class BatchV2 extends AbstractBatch {
   /**
-   * Executes a batch request to the Bitrix24 REST API with a maximum number of commands of no more than 50.
-   * Allows you to execute multiple requests in a single API call, significantly improving performance.
+   * Executes a batch request to the Bitrix24 REST API: up to 50 commands in one
+   * HTTP call, in array, object or named-command form. `restApi:v2`
    *
-   * @template T - The data type returned by batch query commands (default is `unknown`)
+   * **The argument reference, the three `calls` formats, the options table and
+   * worked examples live on the [batch page](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/batch-rest-api-ver2/).**
+   * Deliberately not repeated here: that copy is compiled on every CI run and
+   * this one would not be — no pass type-checks a JSDoc `@example` (#420).
    *
-   * @param {ActionBatchV2} options - parameters for executing the request.
-   *     - `calls: BatchCommandsArrayUniversal | BatchCommandsObjectUniversal | BatchNamedCommandsUniversal` - Commands to execute in a batch.
-   *        Supports several formats:
-   *        1. Array of tuples: `[['method1', params1], ['method2', params2], ...]`
-   *        2. Array of objects: `[{ method: 'method1', params: params1 }, { method: 'method2', params: params2 }, ...]`
-   *        3. An object with named commands: `{ cmd1: { method: 'method1', params: params1 }, cmd2: ['method2', params2], ...}`
-   *     - `options?: IB24BatchOptions` - Additional options for executing a batch request.
-   *        - `isHaltOnError?: boolean` - Whether to stop execution on the first error (default: true)
-   *        - `requestId?: string` - Unique request identifier for tracking. Used for query deduplication and debugging (default: undefined)
-   *        - `returnAjaxResult?: boolean` - Whether to return an AjaxResult object instead of data (default: false)
+   * What matters while editing this file:
+   *   - **50 commands maximum.** This action does not split; `BatchByChunkV2`
+   *     is the one that does.
+   *   - **`getData()` has no `result` envelope here.** It returns the keyed map
+   *     or array directly — only `call.make` returns `{ result, time }` (#425).
+   *   - **Flags live in `options`.** At the top level they are dropped, which is
+   *     why `_warnMisplacedOptions` runs first (#426).
    *
-   * @returns {Promise<CallBatchResult<T>>} A promise that is resolved by the result of executing a batch request:
-   *     - On success: a `Result` object with the command execution results
-   *     - The structure of the results depends on the format of the `calls` input data:
-   *          - For an array of commands, an array of results in the same order
-   *          - For named commands, an object with keys corresponding to the command names
+   * @template T - The data type returned by batch query commands (default `unknown`)
+   * @param {ActionBatchV2} options - `calls` plus an optional `options` bag; see
+   *   {@link ActionBatchV2} and {@link IB24BatchOptions} for the members.
+   * @returns {Promise<CallBatchResult<T>>} results in the shape of the input:
+   *   an array for array input, an object keyed by command name for named input.
+   *   With `options.returnAjaxResult` each entry is an `AjaxResult` rather than
+   *   the raw payload.
    *
    * @example
-   * import { EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
+   * import type { AjaxResult } from '@bitrix24/b24jssdk'
    *
-   * interface Contact { id: number, name: string }
    * const response = await b24.actions.v2.batch.make<{ item: Contact }>({
-   *   calls: [
-   *     ['crm.item.get', { entityTypeId: EnumCrmEntityTypeId.contact, id: 1 }],
-   *     ['crm.item.get', { entityTypeId: EnumCrmEntityTypeId.contact, id: 2 }],
-   *     ['crm.item.get', { entityTypeId: EnumCrmEntityTypeId.contact, id: 3 }]
-   *   ],
-   *   options: {
-   *     isHaltOnError: true,
-   *     returnAjaxResult: true,
-   *     requestId: 'batch-123'
-   *   }
-   * })
-   * if (!response.isSuccess) {
-   *   throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
-   * }
-   *
-   * const resultData = (response as Result<AjaxResult<{ item: Contact }>[]>).getData()
-   * resultData.forEach((resultRow, index) => {
-   *   if (resultRow.isSuccess) {
-   *    console.log(`Item ${index + 1}:`, resultRow.getData()!.result.item)
-   *   }
-   * })
-   *
-   * @example
-   * import { EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
-   *
-   * const response = await b24.actions.v2.batch.make({
-   *   calls: [
-   *     { method: 'crm.item.get', params: { entityTypeId: EnumCrmEntityTypeId.contact, id: 1 } },
-   *     { method: 'crm.item.get', params: { entityTypeId: EnumCrmEntityTypeId.contact, id: 2 } }
-   *   ],
-   *   options: {
-   *     isHaltOnError: true,
-   *     returnAjaxResult: true,
-   *     requestId: 'batch-123'
-   *   }
-   * })
-   * if (!response.isSuccess) {
-   *   throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
-   * }
-   *
-   * @example
-   * import { EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
-   *
-   * interface Contact { id: number, name: string }
-   * interface Deal { id: number, title: string }
-   * const response = await b24.actions.v2.batch.make<{ item: Contact } | { item: Deal }>({
    *   calls: {
-   *     Contact: { method: 'crm.item.get', params: { entityTypeId: EnumCrmEntityTypeId.contact, id: 1 } },
-   *     Deal: ['crm.item.get', { entityTypeId: EnumCrmEntityTypeId.deal, id: 2 }]
+   *     first: ['crm.item.get', { entityTypeId: 3, id: 1 }],
+   *     second: ['crm.item.get', { entityTypeId: 3, id: 2 }]
    *   },
-   *   options: {
-   *     isHaltOnError: true,
-   *     returnAjaxResult: true,
-   *     requestId: 'batch-123'
-   *   }
+   *   options: { isHaltOnError: false, returnAjaxResult: true, requestId: 'batch-123' }
    * })
    * if (!response.isSuccess) {
    *   throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
    * }
-   *
-   * const results = response.getData() as Record<string, AjaxResult<{ item: Contact } | { item: Deal }>>
-   * console.log('Contact:', results.Contact.getData()?.result.item as Contact)
-   * console.log('Deal:', results.Deal.getData()?.result.item as Deal)
+   * const data = response.getData()! as Record<string, AjaxResult<{ item: Contact }>>
+   * console.log(data['first']!.getData()!.result.item)
    *
    * @warning The maximum number of commands in one batch request is 50.
    * @note A batch request executes faster than sequential single calls,

--- a/packages/jssdk/src/core/actions/v2/batch.ts
+++ b/packages/jssdk/src/core/actions/v2/batch.ts
@@ -50,6 +50,7 @@ export class BatchV2 extends AbstractBatch {
    * @example
    * import type { AjaxResult } from '@bitrix24/b24jssdk'
    *
+   * interface Contact { id: number, name: string }
    * const response = await b24.actions.v2.batch.make<{ item: Contact }>({
    *   calls: {
    *     first: ['crm.item.get', { entityTypeId: 3, id: 1 }],

--- a/packages/jssdk/src/core/actions/v2/call.ts
+++ b/packages/jssdk/src/core/actions/v2/call.ts
@@ -44,7 +44,7 @@ export class CallV2 extends AbstractAction {
    * if (!response.isSuccess) {
    *   throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
    * }
-   * console.log(response.getData().result.item.name)
+   * console.log(response.getData()!.result.item.name)
    */
   public override async make<T = unknown>(options: ActionCallV2): Promise<AjaxResult<T>> {
     const params = options.params || {}

--- a/packages/jssdk/src/core/actions/v3/batch.ts
+++ b/packages/jssdk/src/core/actions/v3/batch.ts
@@ -53,6 +53,7 @@ export class BatchV3 extends AbstractBatch {
    * @example
    * import type { AjaxResult } from '@bitrix24/b24jssdk'
    *
+   * interface Contact { id: number, name: string }
    * const response = await b24.actions.v3.batch.make<{ item: Contact }>({
    *   calls: {
    *     first: ['crm.item.get', { entityTypeId: 3, id: 1 }],

--- a/packages/jssdk/src/core/actions/v3/batch.ts
+++ b/packages/jssdk/src/core/actions/v3/batch.ts
@@ -24,90 +24,47 @@ export type ActionBatchV3 = {
  */
 export class BatchV3 extends AbstractBatch {
   /**
-   * Executes a batch request to the Bitrix24 REST API with a maximum number of commands of no more than 50.
-   * Allows you to execute multiple requests in a single API call, significantly improving performance.
+   * Executes a batch request to the Bitrix24 REST API: up to 50 commands in one
+   * HTTP call, in array, object or named-command form. `restApi:v3`
    *
-   * @template T - The data type returned by batch query commands (default is `unknown`)
+   * **The argument reference, the three `calls` formats, the options table and
+   * worked examples live on the [batch page](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/batch-rest-api-ver3/).**
+   * Deliberately not repeated here: that copy is compiled on every CI run and
+   * this one would not be — no pass type-checks a JSDoc `@example` (#420).
    *
-   * @param {ActionBatchV3} options - parameters for executing the request.
-   *     - `calls: BatchCommandsArrayUniversal | BatchCommandsObjectUniversal | BatchNamedCommandsUniversal` - Commands to execute in a batch.
-   *        Supports several formats:
-   *        1. Array of tuples: `[['method1', params1], ['method2', params2], ...]`
-   *        2. Array of objects: `[{ method: 'method1', params: params1 }, { method: 'method2', params: params2 }, ...]`
-   *        3. An object with named commands: `{ cmd1: { method: 'method1', params: params1 }, cmd2: ['method2', params2], ...}`
-   *     - `options?: IB24BatchOptions` - Additional options for executing a batch request.
-   *        - `isHaltOnError?: boolean` - Whether to stop execution on the first error (default: true)
-   *        - `requestId?: string` - Unique request identifier for tracking. Used for query deduplication and debugging (default: undefined)
-   *        - `returnAjaxResult?: boolean` - Whether to return an AjaxResult object instead of data (default: false)
+   * What matters while editing this file:
+   *   - **50 commands maximum.** This action does not split; `BatchByChunkV3`
+   *     is the one that does.
+   *   - **`getData()` has no `result` envelope here.** It returns the keyed map
+   *     or array directly — only `call.make` returns `{ result, time }` (#425).
+   *   - **Flags live in `options`.** At the top level they are dropped, which is
+   *     why `_warnMisplacedOptions` runs first (#426).
+   *   - **v3 batch is all-or-nothing.** Per-command errors do not surface; one
+   *     failing command fails the envelope.
    *
-   * @returns {Promise<CallBatchResult<T>>} A promise that is resolved by the result of executing a batch request:
-   *     - On success: a `Result` object with the command execution results
-   *     - The structure of the results depends on the format of the `calls` input data:
-   *          - For an array of commands, an array of results in the same order
-   *          - For named commands, an object with keys corresponding to the command names
-   *
-   * @example
-   * interface TaskItem { id: number, title: string }
-   * const response = await b24.actions.v3.batch.make<{ item: TaskItem }>({
-   *   calls: [
-   *     ['tasks.task.get', { id: 1, select: ['id', 'title'] }],
-   *     ['tasks.task.get', { id: 2, select: ['id', 'title'] }],
-   *     ['tasks.task.get', { id: 3, select: ['id', 'title'] }]
-   *   ],
-   *   options: {
-   *     isHaltOnError: true,
-   *     returnAjaxResult: true,
-   *     requestId: 'batch-123'
-   *   }
-   * })
-   * if (!response.isSuccess) {
-   *   throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
-   * }
-   *
-   * const resultData = (response as Result<AjaxResult<{ item: TaskItem }>[]>).getData()
-   * resultData.forEach((resultRow, index) => {
-   *   if (resultRow.isSuccess) {
-   *    console.log(`Item ${index + 1}:`, resultRow.getData()!.result.item)
-   *   }
-   * })
+   * @template T - The data type returned by batch query commands (default `unknown`)
+   * @param {ActionBatchV3} options - `calls` plus an optional `options` bag; see
+   *   {@link ActionBatchV3} and {@link IB24BatchOptions} for the members.
+   * @returns {Promise<CallBatchResult<T>>} results in the shape of the input:
+   *   an array for array input, an object keyed by command name for named input.
+   *   With `options.returnAjaxResult` each entry is an `AjaxResult` rather than
+   *   the raw payload.
    *
    * @example
-   * const response = await b24.actions.v3.batch.make({
-   *   calls: [
-   *     { method: 'tasks.task.get', params: { id: 1, select: ['id', 'title'] } },
-   *     { method: 'tasks.task.get', params: { id: 2, select: ['id', 'title'] } }
-   *   ],
-   *   options: {
-   *     isHaltOnError: true,
-   *     returnAjaxResult: true,
-   *     requestId: 'batch-123'
-   *   }
-   * })
-   * if (!response.isSuccess) {
-   *   throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
-   * }
+   * import type { AjaxResult } from '@bitrix24/b24jssdk'
    *
-   * @example
-   * interface TaskItem { id: number, title: string }
-   * interface MainEventLogItem { id: number, userId: number }
-   * const response = await b24.actions.v3.batch.make<{ item: TaskItem } | { items: MainEventLogItem[] }>({
+   * const response = await b24.actions.v3.batch.make<{ item: Contact }>({
    *   calls: {
-   *     Task: { method: 'tasks.task.get', params: { id: 1, select: ['id', 'title'] } },
-   *     MainEventLog: ['main.eventlog.list', { select: ['id', 'userId'], pagination: { limit: 5 } }]
+   *     first: ['crm.item.get', { entityTypeId: 3, id: 1 }],
+   *     second: ['crm.item.get', { entityTypeId: 3, id: 2 }]
    *   },
-   *   options: {
-   *     isHaltOnError: true,
-   *     returnAjaxResult: true,
-   *     requestId: 'batch-123'
-   *   }
+   *   options: { isHaltOnError: false, returnAjaxResult: true, requestId: 'batch-123' }
    * })
    * if (!response.isSuccess) {
    *   throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
    * }
-   *
-   * const results = response.getData() as Record<string, AjaxResult<{ item: TaskItem } | { items: MainEventLogItem[] }>>
-   * console.log('Task:', results.Task.getData()?.result.item as TaskItem)
-   * console.log('MainEventLog:', results.MainEventLog.getData()?.result.items as MainEventLogItem[])
+   * const data = response.getData()! as Record<string, AjaxResult<{ item: Contact }>>
+   * console.log(data['first']!.getData()!.result.item)
    *
    * @warning The maximum number of commands in one batch request is 50.
    * @note A batch request executes faster than sequential single calls,

--- a/packages/jssdk/src/core/actions/v3/call.ts
+++ b/packages/jssdk/src/core/actions/v3/call.ts
@@ -40,7 +40,7 @@ export class CallV3 extends AbstractAction {
    * if (!response.isSuccess) {
    *   throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
    * }
-   * console.log(response.getData().result.item.title)
+   * console.log(response.getData()!.result.item.title)
    */
   public override async make<T = unknown>(options: ActionCallV3): Promise<AjaxResult<T>> {
     // No client-side allowlist: the method is sent straight to the v3 endpoint


### PR DESCRIPTION
Refs #420, which asked for a threshold to be agreed before anything moves.

## The threshold

Written into `package-structure.md`:

> A JSDoc block longer than the function it documents is a prompt to ask where the text belongs.

Not a lint rule and not a limit — plenty of short functions deserve a long explanation. **What always stays** is the signature contract and any invariant a reader could break while editing that exact file. **What is better off in a guide** is reasoning, history and worked examples.

## The reason turns out to be measurable

#420 argues placement on readability grounds. There is a sharper one:

| Examples in | Compiled by |
| --- | --- |
| `docs/content/**/*.md` fences | `docs:typecheck-blocks` — 157 blocks |
| `skills/**/*.md` fences | `skills:typecheck-blocks` — 69 blocks |
| **JSDoc `@example` in `packages/jssdk/src/`** | **nothing — 57 blocks, ~460 lines** |

Three of those examples did not compile, all dereferencing `getData()` without the `!` its `T | null | undefined` return has required since #395. Fixed here. The other 54 are unverified — the scan looked for one specific mistake — and are tracked in #439.

## The two longest blocks

97 and 91 lines on `batch.make`, cut to 44 and 46. Both were a second, unverified copy of a documentation page that *is* verified: argument reference, the three `calls` formats, the options table and four examples — all already on the batch pages.

What replaces them is the shape from #417 — a pointer to the compiled copy, then the three things that matter while editing the file:

- the 50-command ceiling, and that `BatchByChunkV2` is the one that splits;
- that `getData()` has no `result` envelope here (#425);
- that flags outside `options` are dropped, which is why `_warnMisplacedOptions` runs first (#426).

## Verification, and where it caught me

The premise of cutting the JSDoc is that the pages carry what it said. I re-read all four before refreshing their `audited:` stamps rather than stamping them — the batch pages do document all three `calls` formats, the options table and the return shape per input form.

The kept examples were compiled before committing. `/code-review` then found both used `Contact` without declaring it: I had compiled them with the interface supplied separately by my probe, which is not what a reader copying the block gets. Extracted verbatim and recompiled.

That the argument-for-checking-examples PR shipped two unchecked examples is the argument, made at my expense.

## Scope

Two files of eighteen. #420 says opportunistically, and it is right: a mass move is a large diff with no behavioural change and a high chance of losing something. #420 stays open.

## Checks

591 unit tests, typecheck 0, `docs-lint --strict` 0/0, links 0 broken, api-reference 97 exports, lint clean. `/code-review` per the scoping rule — comments and Markdown only, no runtime behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_