### PR TITLE
fix(scripts): anchor the fence pattern, which was miscounting an inline marker

### DIFF
--- a/scripts/__tests__/md-internal-links.test.mjs
+++ b/scripts/__tests__/md-internal-links.test.mjs
@@ -318,6 +318,87 @@ test('SECURITY.md is checked, not just AGENTS.md', () => {
   })
 })
 
+test('md-internal-links: a fence marker inside an inline span does not unmask a fenced link', () => {
+  // #441. `stripCode` removed fenced blocks with an unanchored pattern, so three
+  // backticks written inside an inline-code span — the natural way to name a
+  // fence in prose — read as a fence opening. The parity of everything after it
+  // flips: the real fence below is taken for a *closing* marker, its block is
+  // left unstripped, and the illustrative link inside it gets checked.
+  //
+  // This is how it was found (#440): a false alarm on an ellipsis inside a
+  // deliberately abbreviated code sample.
+  withFixture((root) => {
+    mkDir(root, '.github/contributing')
+    writeFile(root, '.github/contributing/guide.md', [
+      '# Guide',
+      '',
+      'Prose naming a `' + '```ts' + '` fence, the way a guide does.',
+      '',
+      '```ts',
+      '/**',
+      ' * See [the batch page](…) for the full reference.',
+      ' */',
+      '```'
+    ])
+
+    const result = runCheck(root)
+
+    assert.equal(result.status, 0, `a link inside a fenced block must not be checked:\n${result.stdout}`)
+  })
+})
+
+test('md-internal-links: the same parity flip does not hide a real broken link', () => {
+  // The failure direction that matters, and the reason this is a fix rather
+  // than a tidy-up. #440 hit the harmless one — a false alarm, loud and
+  // immediate. Put the broken link *between* the inline fence marker and the
+  // real fence and the flip swallows it instead: the old strip left
+  // `Prose naming a \` ts\ncode\n\`` with the link gone, so the checker passed
+  // while the link rotted, and nothing said so.
+  withFixture((root) => {
+    mkDir(root, '.github/contributing')
+    writeFile(root, '.github/contributing/guide.md', [
+      '# Guide',
+      '',
+      'Prose naming a `' + '```ts' + '` fence.',
+      '',
+      'A [link to a file that is not there](../../packages/jssdk/src/gone.ts).',
+      '',
+      '```ts',
+      'const x = 1',
+      '```'
+    ])
+
+    const result = runCheck(root)
+
+    assert.equal(result.status, 1, 'the broken link must not be swallowed by the strip')
+    assert.match(result.stdout, /gone\.ts/)
+  })
+})
+
+test('md-internal-links: fences indented inside a list item are still stripped', () => {
+  // The fix anchors the fence to a line start, and a naive anchor at column 0
+  // would stop stripping fences nested in list items. This repository has them
+  // at two, three and six columns.
+  withFixture((root) => {
+    mkDir(root, '.github/contributing')
+    writeFile(root, '.github/contributing/guide.md', [
+      '# Guide',
+      '',
+      '1. A step:',
+      '',
+      '      ```ts',
+      '      // [illustrative](does/not/exist.ts)',
+      '      ```',
+      '',
+      '2. Another step.'
+    ])
+
+    const result = runCheck(root)
+
+    assert.equal(result.status, 0, `an indented fenced block must still be stripped:\n${result.stdout}`)
+  })
+})
+
 test('SECURITY.md exists in the repository', () => {
   // Deliberately not a fixture test: this asserts the real file is there.
   //

--- a/scripts/md-internal-links.mjs
+++ b/scripts/md-internal-links.mjs
@@ -53,8 +53,37 @@ function targetFiles() {
 // Strip fenced code (a run of ≥3 backticks closed by the same length, so a
 // ```` ```` ```` block can wrap nested ``` fences) and inline code, so
 // illustrative snippets don't produce false positives.
+//
+// The fence pattern is **anchored to the start of a line**, which is where
+// Markdown defines a fence. Unanchored it also matched a fence marker written
+// inside an inline-code span — the natural way to name a fence in prose — and
+// that flips the parity of everything after it: the next real fence is read as
+// a *closing* marker, so the block it opened is left unstripped and its
+// contents get link-checked. Found in #440 as a false alarm; the same flip the
+// other way round swallows a genuinely broken link and the check passes (#441).
+//
+// Leading whitespace is allowed because fences inside list items are indented —
+// this repository has them at two, three and six columns. A fence marker in an
+// inline span that begins a line is still miscounted; that is rare enough to
+// leave, and it fails towards a false alarm.
+//
+// The opening marker is followed by its info string and the line break rather
+// than letting the body quantifier start straight after it, and that info string
+// excludes both fence characters. Neither is cosmetic: adjacent, `` `{3,} `` and
+// a quantifier that can also match a backtick trade characters, which
+// `regexp/no-super-linear-backtracking` flags as polynomial backtracking on a
+// crafted input. Excluding them is also what CommonMark says — the info string
+// of a backtick fence may not contain a backtick.
+//
+// An unclosed fence is not stripped, as before — `String.replace` finds no
+// match and the block's contents stay in the text. That fails towards a false
+// alarm, which is the right direction for a gate. Shared between the two
+// callers below and safe to share because both use it with `replace`, which
+// resets `lastIndex`; do not reach for `test` or `matchAll` on it.
+const FENCE = /^[ \t]*(`{3,}|~{3,})[^`~\n]*\n[\s\S]*?^[ \t]*\1[ \t]*$/gm
+
 function stripCode(md) {
-  return md.replace(/(`{3,})[\s\S]*?\1/g, '').replace(/`[^`\n]*`/g, '')
+  return md.replace(FENCE, '').replace(/`[^`\n]*`/g, '')
 }
 
 // [text](target) and ![alt](target); capture up to ) or whitespace (drops a "title")
@@ -94,7 +123,7 @@ function headingAnchors(markdown) {
   // helpers`, dropping the first word of the slug. Both fence markers count;
   // stripping only backticks would let a `#` line inside a `~~~` block pass as
   // a heading.
-  const withoutFences = markdown.replace(/(`{3,}|~{3,})[\s\S]*?\1/g, '')
+  const withoutFences = markdown.replace(FENCE, '')
   const anchors = new Set()
 
   // ATX. Up to three leading spaces still parse as a heading (four make it an


### PR DESCRIPTION
Closes #441.

## The bug

`stripCode` removed fenced blocks with an unanchored `` /(`{3,})[\s\S]*?\1/g ``. Three backticks written inside an inline-code span — the natural way to name a fence in prose — read as a fence opening, and the parity of everything after it flips: the next real fence is taken for a *closing* marker, so the block it opened is left unstripped and the links inside it get checked.

## Both directions, demonstrated rather than asserted

It surfaced in #440 as a **false alarm** — a broken link reported against an ellipsis inside a deliberately abbreviated code sample. That is the harmless direction.

Put the broken link *between* the inline marker and the real fence and the flip swallows it instead:

```
Prose naming a ` ```ts ` fence.

A [link to a file that is not there](…/gone.ts).

```ts
const x = 1
```
```

The old strip left `` Prose naming a ` ts\ncode\n` `` — the link gone. The checker passes while the link rots, and nothing says so.

The issue claimed this direction existed; the first test I wrote for it passed against the old pattern, which meant it proved nothing. Rewriting it to the layout above makes both new cases go red without the fix, which is what I verified before committing.

## The fix

Anchor to the start of a line, which is where Markdown defines a fence.

Two copies had the pattern — `stripCode` and the fence strip in `headingAnchors` — now one `FENCE` constant. `docs-link-check.mjs` deliberately does not strip fences and `docs-lint.mjs` has no copy, so this is contained to one file.

**Leading whitespace is allowed.** Fences inside list items are indented, and this repository has them at two, three and six columns — a naive anchor at column zero would silently stop stripping them. Measured before choosing, and covered by a third test.

**The info string excludes both fence characters** and the body quantifier starts after the line break. Adjacent quantifiers that can trade characters are polynomial backtracking; `regexp/no-super-linear-backtracking` caught that twice while this was being written. Excluding backticks there is also what CommonMark specifies for a backtick fence.

## Edge cases checked

| | |
| --- | --- |
| ```` ```` ```` wrapping ``` ``` ``` | stripped — the documented nesting still works |
| `~~~` fences | stripped |
| six-space indent inside a list | stripped |
| unclosed fence | **not** stripped, as before — fails towards a false alarm |

## Checks

16 tests in this file (13 → 16), 99 across `scripts/__tests__`, all six checks green against the real tree, lint clean. `/code-review` per the scoping rule — a script, no runtime behaviour; no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_