### PR TITLE
feat(scripts): type-check the JSDoc @example blocks in the SDK source

### DIFF
--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -207,6 +207,7 @@ reading a config.
 | `docs:typecheck-blocks` | `ts` fences in `docs/content/**/*.md` |
 | `skills:typecheck` | the recipe `.ts` files under `skills/b24jssdk-recipes/` |
 | `skills:typecheck-blocks` | `ts` fences in `skills/**/*.md` |
+| `jsdoc:typecheck-blocks` | JSDoc `@example` bodies in `packages/jssdk/src/**/*.ts` |
 
 Plus the `jsSdk:types` vitest project, which is where the `*.types.spec.ts` pins
 become real — `expectTypeOf` erases at runtime, so under a plain `vitest run` a
@@ -218,6 +219,13 @@ Two results from that measurement are worth carrying:
   smoke tests for the published package shape rather than typechecks of the
   playgrounds. An error inside either playground is caught by its own pass and by
   nothing else.
+- **JSDoc `@example` bodies used to be compiled by nothing** — 41 of them, the
+  ones an IDE shows on hover. `jsdoc:typecheck-blocks` closed that in #439; the
+  first run went red on every single block. An `@example` body is extracted from
+  the line after the tag to the next tag or the end of the comment, a Markdown
+  fence wrapping the whole body is unwrapped as presentation, and a
+  `// @check-ignore` first line skips the block. A same-line `@example 'value'`
+  is a value, not code, and is not compiled.
 - **`ts` fences in `.github/contributing/*.md` are compiled by nothing.**
   Docs fences and skill fences are covered; these are the gap (#435). There is a
   `test/some-code-from-docs/contributing/` directory of hand-written fixtures

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,11 @@ jobs:
           name: prepared-workspace
 
       - name: Typecheck
-        # Includes docs:typecheck-blocks — type-checks ```ts fences in docs/content/docs/**/*.md
-        # against @bitrix24/b24jssdk. Runs after dev:prepare so dist/ types are available.
+        # Includes docs:typecheck-blocks and jsdoc:typecheck-blocks — the first
+        # type-checks ```ts fences in docs/content/docs/**/*.md, the second the
+        # JSDoc @example bodies in packages/jssdk/src/**/*.ts (#439). Both compile
+        # against @bitrix24/b24jssdk, so they run after dev:prepare, when dist/
+        # types are available.
         run: pnpm run typecheck
 
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ coverage
 # docs-typecheck generated temp files (scripts/docs-typecheck.mjs)
 .docs-typecheck/tmp/
 .skills-typecheck/tmp/
+.jsdoc-typecheck/tmp/
 # Scratch file written by the docs-lint freshness test. It is removed in a
 # `finally`, but a killed runner would otherwise leave it as a stray untracked
 # file — ignoring it keeps `git status` honest either way.

--- a/.jsdoc-typecheck/globals.d.ts
+++ b/.jsdoc-typecheck/globals.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Ambient declarations for the `@example` bodies in `packages/jssdk/src/**`.
+ *
+ * Same rule as the docs equivalent: a name goes here only when the pattern
+ * appears across many examples. A one-off missing import is a defect in the
+ * example — a reader copying that block gets code that does not run — and is
+ * fixed there, not hidden here.
+ */
+
+// `Text` is the SDK's exported TextManager singleton. It needs an ambient
+// because `lib: ["DOM"]` also declares a global `Text` — the DOM node
+// constructor — so an example that calls `Text.numberFormat(...)` without
+// repeating the import silently resolves to the wrong one. 26 of the 28
+// property errors in the first run were this collision.
+declare const Text: import('@bitrix24/b24jssdk').TextManager
+
+// The live client. `B24Frame` rather than `B24Hook` so that frame-only members
+// (.placement, .slider, .dialog, .parent, .options) resolve in short snippets;
+// examples that construct their own client shadow this with a local const.
+declare const b24: import('@bitrix24/b24jssdk').B24Frame
+declare const $b24: import('@bitrix24/b24jssdk').B24Frame

--- a/.jsdoc-typecheck/tsconfig.json
+++ b/.jsdoc-typecheck/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ESNext"
+    ],
+    "strict": false,
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "moduleDetection": "force",
+    "allowJs": false,
+    "allowImportingTsExtensions": false,
+    "isolatedModules": false,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "globals.d.ts",
+    "tmp/**/*.ts"
+  ]
+}

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV2.make
 description: 'Method for executing batch requests with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-08-29
+audited: 2026-08-31
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3 with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-08-29
+audited: 2026-08-31
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/80.tools-object-helpers.md
+++ b/docs/content/docs/2.working-with-the-rest-api/80.tools-object-helpers.md
@@ -3,7 +3,7 @@ title: Object helpers
 description: 'Tiny, dependency-free object and enum helpers — `pick`, `omit`, `getEnumValue`, and the `isArrayOfArray` type guard.'
 category: 'tools'
 navigation.title: Object helpers
-audited: 2026-07-02
+audited: 2026-08-31
 links:
   - label: Object helpers
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/1.dashboard-deals-csv.md
+++ b/docs/content/docs/99.examples/1.dashboard-deals-csv.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Export deals to CSV'
 description: 'Stream every CRM deal that matches a date filter into a CSV file using a webhook and FetchListV2.'
-audited: 2026-08-29
+audited: 2026-08-31
 category: 'examples'
 featured: true
 cookbookOrder: 2

--- a/docs/content/docs/99.examples/3.webhook-cli-node.md
+++ b/docs/content/docs/99.examples/3.webhook-cli-node.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Webhook CLI smoke test'
 description: 'A 30-line Node script that authenticates against a Bitrix24 portal via inbound webhook and prints the calling user — useful as the first thing you run after creating a webhook.'
-audited: 2026-08-26
+audited: 2026-08-31
 category: 'examples'
 featured: true
 cookbookOrder: 1

--- a/docs/content/docs/99.examples/4.bulk-update-deals.md
+++ b/docs/content/docs/99.examples/4.bulk-update-deals.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Bulk update deals'
 description: 'Migrate thousands of CRM deals to a new stage using BatchByChunkV2 — automatic chunking, partial-error handling, and a single progress line.'
-audited: 2026-08-29
+audited: 2026-08-31
 category: 'examples'
 featured: true
 cookbookOrder: 3

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "docs:typecheck": "pnpm --filter ./docs typecheck",
     "skills:typecheck-blocks": "node scripts/skills-typecheck-blocks.mjs",
     "docs:typecheck-blocks": "node scripts/docs-typecheck.mjs",
+    "jsdoc:typecheck-blocks": "node scripts/jsdoc-typecheck-blocks.mjs",
     "skills:install": "pnpm --dir skills/b24jssdk-recipes install --frozen-lockfile",
     "skills:typecheck": "pnpm run skills:install && tsc -p skills/b24jssdk-recipes/tsconfig.json",
     "package-jssdk:test:run-unit": "vitest run --project jsSdk:unit",
@@ -76,7 +77,7 @@
     "docs:lint-links": "node scripts/docs-link-check.mjs",
     "docs:lint-api-index": "node scripts/check-api-reference-index.mjs",
     "docs:lint:test": "node --test \"scripts/__tests__/**/*.test.mjs\"",
-    "typecheck": "pnpm run package-jssdk:typecheck && pnpm run test:typecheck && pnpm run package-jssdk-nuxt:typecheck && pnpm run docs:typecheck && pnpm run playground-nuxt:typecheck && pnpm run playground-cli:typecheck && pnpm run docs:typecheck-blocks && pnpm run skills:typecheck && pnpm run skills:typecheck-blocks",
+    "typecheck": "pnpm run package-jssdk:typecheck && pnpm run test:typecheck && pnpm run package-jssdk-nuxt:typecheck && pnpm run docs:typecheck && pnpm run playground-nuxt:typecheck && pnpm run playground-cli:typecheck && pnpm run docs:typecheck-blocks && pnpm run skills:typecheck && pnpm run skills:typecheck-blocks && pnpm run jsdoc:typecheck-blocks",
     "release:bump": "node scripts/bump-version.mjs"
   },
   "devDependencies": {

--- a/packages/jssdk/src/core/actions/v2/batch-by-chunk.ts
+++ b/packages/jssdk/src/core/actions/v2/batch-by-chunk.ts
@@ -41,10 +41,10 @@ export class BatchByChunkV2 extends AbstractBatch {
    * @returns {Promise<Result<T[]>>} A promise that is resolved by the result of executing all commands.
    *
    * @example
-   * import { EnumCrmEntityTypeId, Text } from '@bitrix24/b24jssdk'
+   * import { EnumCrmEntityTypeId, Text, type CommandTuple } from '@bitrix24/b24jssdk'
    *
    * interface Contact { id: number, name: string }
-   * const commands = Array.from({ length: 150 }, (_, i) =>
+   * const commands = Array.from<unknown, CommandTuple>({ length: 150 }, (_, i) =>
    *   ['crm.item.get', { entityTypeId: EnumCrmEntityTypeId.contact, id: i + 1 }]
    * )
    *

--- a/packages/jssdk/src/core/actions/v3/aggregate.ts
+++ b/packages/jssdk/src/core/actions/v3/aggregate.ts
@@ -54,6 +54,8 @@ export class AggregateV3 extends AbstractAction {
    * @returns {Promise<Result<AggregateResultV3>>} buckets keyed by function then field name.
    *
    * @example
+   * import { FilterV3 } from '@bitrix24/b24jssdk'
+   *
    * const response = await b24.actions.v3.aggregate.make({
    *   method: 'some.entity.aggregate',
    *   select: { sum: { amount: 'totalAmount' }, count: ['id'] },

--- a/packages/jssdk/src/core/actions/v3/batch-by-chunk.ts
+++ b/packages/jssdk/src/core/actions/v3/batch-by-chunk.ts
@@ -41,6 +41,8 @@ export class BatchByChunkV3 extends AbstractBatch {
    * @returns {Promise<Result<T[]>>} A promise that is resolved by the result of executing all commands.
    *
    * @example
+   * import type { BatchCommandsArrayUniversal } from '@bitrix24/b24jssdk'
+   *
    * interface TaskItem { id: number, title: string }
    * const commands: BatchCommandsArrayUniversal = Array.from({ length: 150 }, (_, i) =>
    *   ['tasks.task.get', { id: i + 1, select: ['id', 'title'] }]

--- a/packages/jssdk/src/hook/b24.ts
+++ b/packages/jssdk/src/hook/b24.ts
@@ -18,6 +18,8 @@ import { versionManager } from '../core/version-manager'
  *
  * @example
  * ```ts
+ * import { B24Hook } from '@bitrix24/b24jssdk'
+ *
  * const b24 = B24Hook.fromWebhookUrl('https://your_domain.bitrix24.com/rest/1/abc123xyz/')
  * const result = await b24.actions.v2.call.make({ method: 'user.current' })
  * ```

--- a/packages/jssdk/src/oauth/b24.ts
+++ b/packages/jssdk/src/oauth/b24.ts
@@ -18,6 +18,10 @@ import { versionManager } from '../core/version-manager'
  *
  * @example
  * ```ts
+ * import { B24OAuth, type B24OAuthParams } from '@bitrix24/b24jssdk'
+ *
+ * declare const authOptions: B24OAuthParams
+ *
  * const b24 = new B24OAuth(authOptions, { clientId: '...', clientSecret: '...' })
  * const result = await b24.actions.v2.call.make({ method: 'crm.lead.list' })
  * ```

--- a/packages/jssdk/src/tools/formatters/numbers.ts
+++ b/packages/jssdk/src/tools/formatters/numbers.ts
@@ -55,6 +55,10 @@ export default class FormatterNumbers {
    *
    * @example
    * ```ts
+   * import { useFormatter } from '@bitrix24/b24jssdk'
+   *
+   * const { formatterNumber } = useFormatter()
+   *
    * formatterNumber.format(1234.5)        // '1,234.50'
    * formatterNumber.format(1234.5, 'de')  // '1.234,50'
    * ```

--- a/packages/jssdk/src/tools/index.ts
+++ b/packages/jssdk/src/tools/index.ts
@@ -36,6 +36,8 @@ export function isArrayOfArray<A>(item: A[] | A[][]): item is A[][] {
  * Returns the enum member whose value equals `value`, or `undefined` if no match is found.
  *
  * @example
+ * import { getEnumValue, EnumBizprocDocumentType } from '@bitrix24/b24jssdk'
+ *
  * const result = getEnumValue(EnumBizprocDocumentType, 'CCrmDocumentSmartOrder')
  */
 export function getEnumValue<T extends Record<string, string | number>>(

--- a/packages/jssdk/src/types/limiters.ts
+++ b/packages/jssdk/src/types/limiters.ts
@@ -129,6 +129,8 @@ export interface RestrictionParams {
    *
    * @example
    * ```ts
+   * import { ParamsFactory } from '@bitrix24/b24jssdk'
+   *
    * await $b24.setRestrictionManagerParams({
    *   ...ParamsFactory.getDefault(),
    *   hardErrorCodes: ['DOCUMENT_GENERATOR_ALREADY_IN_QUEUE', 'MY_APP_BAD_PAYLOAD']

--- a/scripts/__tests__/jsdoc-typecheck-blocks.test.mjs
+++ b/scripts/__tests__/jsdoc-typecheck-blocks.test.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Tests for scripts/_extract-jsdoc-examples.mjs and the gate that uses it (#439).
+//
+// Run with: node --test scripts/__tests__/jsdoc-typecheck-blocks.test.mjs
+//
+// The compile-and-report half is shared with the docs and skills gates and is
+// covered by docs-typecheck.test.mjs. What is specific here is the extractor:
+// where an example body starts and ends, which forms are deliberately not code,
+// and that a diagnostic still lands on the right source line after the
+// presentation fence is unwrapped.
+
+import { existsSync, readdirSync, writeFileSync, readFileSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { extractJsDocExamples } from '../_extract-jsdoc-examples.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const SCRIPT = resolve(__dirname, '..', 'jsdoc-typecheck-blocks.mjs')
+
+const TSC_BIN = join(REPO_ROOT, 'node_modules', 'typescript', 'bin', 'tsc')
+const SDK_TYPES = join(REPO_ROOT, 'packages', 'jssdk', 'dist', 'esm', 'index.d.ts')
+const SKIP = !existsSync(TSC_BIN) || !existsSync(SDK_TYPES)
+
+const extract = source => extractJsDocExamples(source, '/fake/file.ts')
+
+test('collects the body after @example and stops at the next tag', () => {
+  const blocks = extract([
+    '/**',
+    ' * Does a thing.',
+    ' *',
+    ' * @example',
+    ' * const a = 1',
+    ' * const b = 2',
+    ' *',
+    ' * @returns {number} the thing',
+    ' */',
+    'export const thing = 1'
+  ].join('\n'))
+
+  assert.equal(blocks.length, 1)
+  assert.deepEqual(blocks[0].lines, ['const a = 1', 'const b = 2'])
+  // Line 5 of the source, 1-indexed, is `const a = 1`.
+  assert.equal(blocks[0].startLine, 5)
+})
+
+test('a body that runs to the end of the comment is still collected', () => {
+  const blocks = extract([
+    '/**',
+    ' * @example',
+    ' * const a = 1',
+    ' */'
+  ].join('\n'))
+
+  assert.deepEqual(blocks.map(b => b.lines), [['const a = 1']])
+})
+
+test('a same-line @example is a value, not a block', () => {
+  // `types/auth.ts` uses this form twelve times to show what a field holds.
+  // Compiling `'1xxxxx1694'` on its own proves nothing.
+  const blocks = extract([
+    '/**',
+    ' * @example \'1xxxxx1694\'',
+    ' */',
+    'export interface X { applicationToken: string }'
+  ].join('\n'))
+
+  assert.deepEqual(blocks, [])
+})
+
+test('a Markdown fence around the whole body is presentation and is unwrapped', () => {
+  // Left in place, ```ts parses as a tagged template and every fenced example
+  // fails with the same TS2349 — which is what the first run of the gate saw.
+  const blocks = extract([
+    '/**',
+    ' * @example',
+    ' * ```ts',
+    ' * const a = 1',
+    ' * ```',
+    ' */'
+  ].join('\n'))
+
+  assert.equal(blocks.length, 1)
+  assert.deepEqual(blocks[0].lines, ['const a = 1'])
+  // The opening marker is on line 3, so the first code line is line 4.
+  assert.equal(blocks[0].startLine, 4)
+})
+
+test('// @check-ignore skips the block', () => {
+  const blocks = extract([
+    '/**',
+    ' * @example',
+    ' * // @check-ignore: pseudo-code for a portal-side handler',
+    ' * whatever this is',
+    ' */'
+  ].join('\n'))
+
+  assert.deepEqual(blocks, [])
+})
+
+test('two @example tags in one comment are two blocks', () => {
+  const blocks = extract([
+    '/**',
+    ' * @example',
+    ' * const a = 1',
+    ' * @example',
+    ' * const b = 2',
+    ' */'
+  ].join('\n'))
+
+  assert.deepEqual(blocks.map(b => b.lines), [['const a = 1'], ['const b = 2']])
+})
+
+test('a line comment outside a JSDoc block is not an example', () => {
+  const blocks = extract([
+    '// @example',
+    '// const a = 1',
+    'export const x = 1'
+  ].join('\n'))
+
+  assert.deepEqual(blocks, [])
+})
+
+test('the gate walks the SDK source, not a hand-written list', () => {
+  const source = readFileSync(SCRIPT, 'utf8')
+  assert.match(source, /walkFiles\(join\(REPO_ROOT, 'packages', 'jssdk', 'src'\)/)
+  assert.match(source, /extension: '\.ts'/)
+})
+
+test('the SDK source has examples for the gate to find', { skip: SKIP }, () => {
+  // An empty sweep is treated as failure by checkBlocks; this asserts the
+  // premise separately, so a broken path is distinguishable from a clean tree.
+  const files = readdirSync(join(REPO_ROOT, 'packages', 'jssdk', 'src'))
+  assert.ok(files.length > 0, 'packages/jssdk/src is empty — the layout changed')
+})
+
+test('a deliberate type error in an @example fails the gate', { skip: SKIP }, () => {
+  // Verified by injection rather than inspection: the acceptance criterion of
+  // #439 is that a broken example cannot reach main, and the only proof of that
+  // is watching a broken one fail.
+  const target = join(REPO_ROOT, 'packages', 'jssdk', 'src', 'tools', 'index.ts')
+  const original = readFileSync(target, 'utf8')
+  const marker = ' * const result = getEnumValue('
+  assert.ok(original.includes(marker), 'the example this test injects into moved')
+
+  try {
+    writeFileSync(
+      target,
+      original.replace(marker, ' * const injected: number = \'not a number\'\n' + marker),
+      'utf8'
+    )
+    const run = spawnSync(process.execPath, [SCRIPT], { cwd: REPO_ROOT, encoding: 'utf8' })
+    assert.equal(run.status, 1, 'the gate passed on an example that does not compile')
+    assert.match(run.stdout, /tools\/index\.ts:\d+:\d+ TS2322/)
+  } finally {
+    writeFileSync(target, original, 'utf8')
+  }
+})

--- a/scripts/__tests__/jsdoc-typecheck-blocks.test.mjs
+++ b/scripts/__tests__/jsdoc-typecheck-blocks.test.mjs
@@ -89,6 +89,43 @@ test('a Markdown fence around the whole body is presentation and is unwrapped', 
   assert.equal(blocks[0].startLine, 4)
 })
 
+test('an unterminated fence drops its opening marker too', () => {
+  // The comment can end before the closing marker does. Keeping the opening
+  // line would compile ```ts as a tagged template — the exact TS2349 the
+  // unwrap exists to prevent.
+  const blocks = extract([
+    '/**',
+    ' * @example',
+    ' * ```ts',
+    ' * const a = 1',
+    ' */'
+  ].join('\n'))
+
+  assert.equal(blocks.length, 1)
+  assert.deepEqual(blocks[0].lines, ['const a = 1'])
+  assert.equal(blocks[0].startLine, 4)
+})
+
+test('a single-line /** ... */ does not leave the scanner inside a comment', () => {
+  // It opens and closes on one line. Treated as an opening only, every later
+  // line in the file would be read as comment body.
+  const blocks = extract([
+    '/** One-liner. */',
+    'const template = `',
+    ' * @example',
+    ' * const a: number = \'not a number\'',
+    '`',
+    '/**',
+    ' * @example',
+    ' * const real = 1',
+    ' */'
+  ].join('\n'))
+
+  // Only the genuine example, and none of the template literal that a leaked
+  // comment state would have collected as one.
+  assert.deepEqual(blocks.map(b => b.lines), [['const real = 1']])
+})
+
 test('// @check-ignore skips the block', () => {
   const blocks = extract([
     '/**',

--- a/scripts/_extract-jsdoc-examples.mjs
+++ b/scripts/_extract-jsdoc-examples.mjs
@@ -48,10 +48,12 @@ export function extractJsDocExamples(content, filePath) {
     if (opening) {
       const marker = opening[0]
       const closeAt = body.findIndex((l, i) => i > 0 && l.trim() === marker)
-      if (closeAt > 0) {
-        body = body.slice(1, closeAt)
-        startLine++
-      }
+      // An unterminated fence is the same presentation marker with its closing
+      // half missing — usually because the comment ended first. Dropping only
+      // the opening line still leaves compilable code; keeping it guarantees
+      // the TS2349 this unwrap exists to prevent.
+      body = body.slice(1, closeAt > 0 ? closeAt : undefined)
+      startLine++
     }
     const firstCode = body.find(l => l.trim() !== '')
     const ignored = firstCode !== undefined && firstCode.trim().startsWith('// @check-ignore')
@@ -67,7 +69,10 @@ export function extractJsDocExamples(content, filePath) {
     const trimmed = raw.trim()
 
     if (!inComment) {
-      if (trimmed.startsWith('/**')) inComment = true
+      // A single-line `/** ... */` opens and closes on one line. Without this
+      // guard it would set `inComment` and never clear it, and every later line
+      // in the file would be read as comment body.
+      if (trimmed.startsWith('/**') && !trimmed.slice(3).includes('*/')) inComment = true
       continue
     }
 

--- a/scripts/_extract-jsdoc-examples.mjs
+++ b/scripts/_extract-jsdoc-examples.mjs
@@ -1,0 +1,99 @@
+/**
+ * Pull the `@example` bodies out of a TypeScript source file.
+ *
+ * Companion to `extractTsBlocks` in `_typecheck-blocks.mjs`, which does the same
+ * job for Markdown fences. Both feed `checkBlocks`, so the two kinds of example
+ * are compiled by one engine and report diagnostics the same way (#439).
+ *
+ * A block runs from the line after `@example` to the next JSDoc tag or the end
+ * of the comment, with the ` * ` gutter stripped. Skips a block whose first
+ * non-empty line is `// @check-ignore` (optionally `: reason`) — the same escape
+ * hatch the Markdown extractor honours, spelled as a comment because that is
+ * what is legal inside an example body.
+ *
+ * **A same-line `@example 'value'` is not a block.** `types/auth.ts` uses that
+ * form twelve times to show what a field looks like — `@example '1xxxxx1694'` —
+ * and those are values, not code. They are skipped deliberately: feeding them to
+ * `tsc` produces twelve meaningless fragments, and the emptiness of the body is
+ * what distinguishes them rather than anything about where they appear.
+ *
+ * @param {string} content File contents.
+ * @param {string} filePath Absolute path, for the returned records.
+ * @returns {{ lines: string[], startLine: number, filePath: string }[]}
+ *   `startLine` is the 1-indexed line of the first code line in the source file.
+ */
+export function extractJsDocExamples(content, filePath) {
+  const lines = content.replace(/\r\n/g, '\n').split('\n')
+  const blocks = []
+  let inComment = false
+  let collecting = false
+  let body = []
+  let startLine = 0
+
+  const flush = () => {
+    // Trailing blank lines are an artefact of the gutter, not of the example.
+    while (body.length > 0 && body[body.length - 1].trim() === '') body.pop()
+
+    // Many examples wrap their code in a Markdown fence so it renders as a
+    // block in an IDE tooltip. The fence is presentation; passing it to `tsc`
+    // makes ```` ```ts ```` a tagged template and every such example fails with
+    // the same TS2349. Unwrap a fence that encloses the whole body, and shift
+    // `startLine` past the opening marker so a diagnostic still points at the
+    // right source line.
+    while (body.length > 0 && body[0].trim() === '') {
+      body.shift()
+      startLine++
+    }
+    const opening = body.length >= 2 ? body[0].trim().match(/^(?:`{3,}|~{3,})/) : null
+    if (opening) {
+      const marker = opening[0]
+      const closeAt = body.findIndex((l, i) => i > 0 && l.trim() === marker)
+      if (closeAt > 0) {
+        body = body.slice(1, closeAt)
+        startLine++
+      }
+    }
+    const firstCode = body.find(l => l.trim() !== '')
+    const ignored = firstCode !== undefined && firstCode.trim().startsWith('// @check-ignore')
+    if (body.length > 0 && !ignored) {
+      blocks.push({ lines: [...body], startLine, filePath })
+    }
+    body = []
+    collecting = false
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]
+    const trimmed = raw.trim()
+
+    if (!inComment) {
+      if (trimmed.startsWith('/**')) inComment = true
+      continue
+    }
+
+    if (trimmed.startsWith('*/')) {
+      if (collecting) flush()
+      inComment = false
+      continue
+    }
+
+    // Strip the ` * ` gutter. A line that is only ` *` becomes empty.
+    const stripped = raw.replace(/^\s*\* ?/, '')
+    const tag = stripped.trim().match(/^@(\w+)/)
+
+    if (tag) {
+      if (collecting) flush()
+      if (tag[1] === 'example') {
+        // Anything on the tag's own line is a value example (see the note
+        // above), and leaving the body empty is what drops it in `flush`.
+        collecting = true
+        startLine = i + 2 // the line after `@example`, 1-indexed
+      }
+      continue
+    }
+
+    if (collecting) body.push(stripped)
+  }
+
+  return blocks
+}

--- a/scripts/_typecheck-blocks.mjs
+++ b/scripts/_typecheck-blocks.mjs
@@ -8,8 +8,14 @@
  * might misread — it is a template that gets reproduced. The first run of this
  * gate found a documented class that is not exported from the package at all.
  *
- * The two differ only in which files they walk, which ambient declarations the
- * fragments may rely on, and where the scratch directory lives. Everything else
+ * `jsdoc-typecheck-blocks.mjs` joined them in #439 for the `@example` bodies in
+ * `packages/jssdk/src/**` — the examples an IDE shows on hover, and the only kind
+ * of example in this repository that nothing compiled. It passes its own
+ * `extract`; everything downstream is shared.
+ *
+ * The three differ only in which files they walk, how a block is recognised
+ * inside one, which ambient declarations the fragments may rely on, and where
+ * the scratch directory lives. Everything else
  * — fence extraction, the `// @check-ignore` marker, mapping a `tsc` diagnostic
  * back to `file:line:col` in the Markdown, the GitHub annotation escaping — is
  * identical, and lived in one copy before this split. It stays in one copy.
@@ -102,7 +108,7 @@ export function extractTsBlocks(content, filePath) {
  * @param {string[]} options.files     absolute paths of the Markdown files to walk
  * @returns {number} process exit code — 0 clean, 1 on any error
  */
-export function checkBlocks({ label, repoRoot, checkDir, files }) {
+export function checkBlocks({ label, repoRoot, checkDir, files, extract = extractTsBlocks }) {
   const tmpDir = join(checkDir, 'tmp')
   const tsconfigPath = join(checkDir, 'tsconfig.json')
   const tscBin = join(repoRoot, 'node_modules', 'typescript', 'bin', 'tsc')
@@ -134,7 +140,7 @@ export function checkBlocks({ label, repoRoot, checkDir, files }) {
 
   for (const file of files) {
     const content = readFileSync(file, 'utf8')
-    for (const block of extractTsBlocks(content, file)) {
+    for (const block of extract(content, file)) {
       const name = `block-${String(blockIndex).padStart(4, '0')}.ts`
       writeFileSync(join(tmpDir, name), block.lines.join('\n') + '\n', 'utf8')
       blockMap.set(name, { filePath: file, startLine: block.startLine })

--- a/scripts/jsdoc-typecheck-blocks.mjs
+++ b/scripts/jsdoc-typecheck-blocks.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { resolve, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { checkBlocks } from './_typecheck-blocks.mjs'
+import { extractJsDocExamples } from './_extract-jsdoc-examples.mjs'
+import { walkFiles } from './_docs-utils.mjs'
+import { requireSdkTypes } from './_require-sdk-types.mjs'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+requireSdkTypes('jsdoc:typecheck-blocks')
+
+process.exit(checkBlocks({
+  label: 'jsdoc-typecheck',
+  repoRoot: REPO_ROOT,
+  checkDir: join(REPO_ROOT, '.jsdoc-typecheck'),
+  files: walkFiles(join(REPO_ROOT, 'packages', 'jssdk', 'src'), { extension: '.ts' }),
+  extract: extractJsDocExamples
+}))


### PR DESCRIPTION
Closes #439.

## What

The `@example` bodies in `packages/jssdk/src/` are what an IDE shows on hover, and they were the only kind of example in this repository that no pass compiled — docs fences have been checked since #109, skill fences since #402, JSDoc examples by nothing.

The first run of the new gate went red on **all 41 blocks**.

## How

`jsdoc:typecheck-blocks` reuses the `checkBlocks` engine behind the docs and skills gates. That engine gained one option — `extract` — so a caller can supply its own block recogniser; everything downstream (compiling, mapping a `tsc` diagnostic back to `file:line:col` in the source, the GitHub annotation escaping) stays in one copy.

`scripts/_extract-jsdoc-examples.mjs` is the recogniser:

- a body runs from the line after `@example` to the next JSDoc tag or the end of the comment, with the ` * ` gutter stripped;
- a Markdown fence wrapping the whole body is unwrapped as presentation, and `startLine` advances past it so diagnostics still land on the right line;
- a `// @check-ignore` first line skips the block — the same escape hatch the Markdown extractor honours, spelled as a comment because that is what is legal inside an example body;
- a same-line `` @example '1xxxxx1694' `` is a value, not code (`types/auth.ts` uses that form twelve times) and is not compiled.

`.jsdoc-typecheck/` holds the scratch tsconfig and two ambients — `Text` (the SDK's `TextManager`, which needed rescuing from the DOM global of the same name) and `b24` / `$b24`. `lib` deliberately omits `DOM`: with it, 26 of the first run's property errors were the DOM `Text` shadowing the SDK export.

## Why the examples were failing

Once the fence wrapper and the `Text` collision were out of the way, what remained were real defects — examples a reader could not copy and run:

- missing imports in `hook/b24.ts`, `oauth/b24.ts`, `tools/index.ts`, `types/limiters.ts`, `core/actions/v3/aggregate.ts`;
- `tools/formatters/numbers.ts` used `formatterNumber` without showing where it comes from (`useFormatter()`);
- `core/actions/v2/batch-by-chunk.ts` built its command list with `Array.from`, which infers an array rather than the tuple `BatchCommandsArrayUniversal` requires.

All fixed in place. Nothing was excluded, and no `// @check-ignore` was needed.

## Verification

- A deliberate type error injected into a real `@example` fails the gate, and the reported line is the injected one — asserted as a test, not just run by hand.
- 12 extractor tests cover the block boundaries, the value form, the fence unwrap, the ignore marker, and two holes `/code-review` found on this branch: a single-line `/** ... */` left the scanner inside a comment, and an unterminated fence left its opening marker in the compiled body. Both new tests were checked by mutation — each goes red against the code as it was.
- `pnpm run typecheck` chains the new pass; `docs-lint --strict` and `md-internal-links` are clean, and the `audited:` stamps on the six pages citing the touched sources are refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_