### PR TITLE
fix(docs): stop README-AI.md teaching the removed LoggerBrowser, and gate it

### DIFF
--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -206,7 +206,7 @@ reading a config.
 | `playground-cli:typecheck` | `playgrounds/cli/` |
 | `docs:typecheck-blocks` | `ts` fences in `docs/content/**/*.md` |
 | `skills:typecheck` | the recipe `.ts` files under `skills/b24jssdk-recipes/` |
-| `skills:typecheck-blocks` | `ts` fences in `skills/**/*.md` |
+| `skills:typecheck-blocks` | `ts` fences in `skills/**/*.md` and in `packages/jssdk/README-AI.md` |
 | `jsdoc:typecheck-blocks` | JSDoc `@example` bodies in `packages/jssdk/src/**/*.ts` |
 
 Plus the `jsSdk:types` vitest project, which is where the `*.types.spec.ts` pins

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV2.make
 description: 'Method for executing batch requests with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-08-31
+audited: 2026-09-01
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3 with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-08-31
+audited: 2026-09-01
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/80.tools-object-helpers.md
+++ b/docs/content/docs/2.working-with-the-rest-api/80.tools-object-helpers.md
@@ -3,7 +3,7 @@ title: Object helpers
 description: 'Tiny, dependency-free object and enum helpers — `pick`, `omit`, `getEnumValue`, and the `isArrayOfArray` type guard.'
 category: 'tools'
 navigation.title: Object helpers
-audited: 2026-08-31
+audited: 2026-09-01
 links:
   - label: Object helpers
     iconName: GitHubIcon

--- a/docs/content/docs/99.examples/1.dashboard-deals-csv.md
+++ b/docs/content/docs/99.examples/1.dashboard-deals-csv.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Export deals to CSV'
 description: 'Stream every CRM deal that matches a date filter into a CSV file using a webhook and FetchListV2.'
-audited: 2026-08-31
+audited: 2026-09-01
 category: 'examples'
 featured: true
 cookbookOrder: 2

--- a/docs/content/docs/99.examples/3.webhook-cli-node.md
+++ b/docs/content/docs/99.examples/3.webhook-cli-node.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Webhook CLI smoke test'
 description: 'A 30-line Node script that authenticates against a Bitrix24 portal via inbound webhook and prints the calling user — useful as the first thing you run after creating a webhook.'
-audited: 2026-08-31
+audited: 2026-09-01
 category: 'examples'
 featured: true
 cookbookOrder: 1

--- a/docs/content/docs/99.examples/4.bulk-update-deals.md
+++ b/docs/content/docs/99.examples/4.bulk-update-deals.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Bulk update deals'
 description: 'Migrate thousands of CRM deals to a new stage using BatchByChunkV2 — automatic chunking, partial-error handling, and a single progress line.'
-audited: 2026-08-31
+audited: 2026-09-01
 category: 'examples'
 featured: true
 cookbookOrder: 3

--- a/packages/jssdk/README-AI.md
+++ b/packages/jssdk/README-AI.md
@@ -86,12 +86,12 @@ import {
   B24Frame,
   EnumCrmEntityTypeId,
   Text,
-  LoggerBrowser,
+  LoggerFactory,
   Result,
   type ISODate
 } from '@bitrix24/b24jssdk'
 
-const logger = LoggerBrowser.build('MyApp', import.meta.env?.DEV === true)
+const logger = LoggerFactory.createForBrowser('MyApp', import.meta.env?.DEV === true)
 let $b24: B24Frame
 
 async function boot() {
@@ -103,7 +103,7 @@ async function boot() {
     order: { id: 'desc' },
     select: ['id', 'title', 'createdTime']
   })
-  logger.info('items:', companies.getData().result)
+  logger.info('items', { items: companies.getData().result })
 
   // Batch (object syntax, with keys)
   const batch: Result = await $b24.callBatch({
@@ -122,7 +122,7 @@ async function boot() {
     title: it.title,
     createdTime: Text.toDateTime(it.createdTime as ISODate)
   }))
-  logger.info('batch list:', list)
+  logger.info('batch list', { list })
 }
 
 function teardown() {
@@ -159,7 +159,7 @@ When you can’t bundle ESM, load the global B24Js from a CDN inside your iframe
 <script>
   document.addEventListener('DOMContentLoaded', async () => {
     try {
-      const logger = B24Js.LoggerBrowser.build('MyApp', true)
+      const logger = B24Js.LoggerFactory.createForBrowser('MyApp', true)
       const $b24 = await B24Js.initializeB24Frame()
 
       const res = await $b24.callBatch({
@@ -173,7 +173,7 @@ When you can’t bundle ESM, load the global B24Js from a CDN inside your iframe
         }
       }, true)
 
-      logger.info('data:', res.getData())
+      logger.info('data', { data: res.getData() })
     } catch (e) {
       console.error(e)
     }
@@ -185,7 +185,7 @@ Globals exposed by UMD
 
 - B24Js.initializeB24Frame
 - B24Js.B24Frame and managers via properties (auth, parent, slider, dialog, placement, options)
-- Utilities: LoggerBrowser, Text, Type, enums (e.g., EnumCrmEntityTypeId), Result, AjaxError/AjaxResult, etc.
+- Utilities: LoggerFactory, Text, Type, enums (e.g., EnumCrmEntityTypeId), Result, AjaxError/AjaxResult, etc.
 
 
 ## Backend/Services (Node.js, ESM) with B24Hook
@@ -203,11 +203,11 @@ Example: construct from webhook URL and call API
 import {
   B24Hook,
   EnumCrmEntityTypeId,
-  LoggerBrowser,
+  LoggerFactory,
   Result
 } from '@bitrix24/b24jssdk'
 
-const logger = LoggerBrowser.build('Srv', true)
+const logger = LoggerFactory.createForBrowser('Srv', true)
 
 const $b24 = B24Hook.fromWebhookUrl(
   'https://your_domain.bitrix24.com/rest/1/k32t88gf3azpmwv3'
@@ -219,19 +219,21 @@ const res = await $b24.callMethod('crm.item.list', {
   entityTypeId: EnumCrmEntityTypeId.company,
   order: { id: 'desc' },
 })
-logger.info('companies:', res.getData().result)
+logger.info('companies', { companies: res.getData().result })
 
 // Batch (array syntax)
 const batch: Result = await $b24.callBatch([
   ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.company, select: ['id'] }],
   ['crm.item.list', { entityTypeId: EnumCrmEntityTypeId.contact, select: ['id'] }]
 ], true)
-logger.info('batch:', batch.getData())
+logger.info('batch', { batch: batch.getData() })
 ```
 
 Listing helpers
 
 ```ts
+import { EnumCrmEntityTypeId } from '@bitrix24/b24jssdk'
+
 // Pull a full list with automatic paging
 const list = await $b24.callListMethod('crm.item.list', {
   entityTypeId: EnumCrmEntityTypeId.deal,
@@ -334,7 +336,7 @@ The SDK ships a high-level helper to preload portal and app data and to work wit
 Initialization pattern (after B24Frame is initialized)
 
 ```ts
-import { useB24Helper, LoadDataType, type TypePullMessage } from '@bitrix24/b24jssdk'
+import { initializeB24Frame, useB24Helper, LoadDataType, type TypePullMessage } from '@bitrix24/b24jssdk'
 
 const {
   initB24Helper,
@@ -355,7 +357,7 @@ await initB24Helper($b24, [
 ])
 
 // Enable Pull
-usePullClient('prefix')      // optionally pass userId
+usePullClient()              // takes no arguments
 useSubscribePullClient((m: TypePullMessage) => {
   // handle Pull messages
 }, 'application')
@@ -507,7 +509,7 @@ try {
   // const total = res.getTotal()                // restApi:v2 only — returns 0 on v3, which sends no `total`
 } catch (e) {
   if (e instanceof AjaxError) {
-    console.error(e.code, e.description, e.status, e.requestInfo)
+    console.error(e.code, e.message, e.status, e.requestInfo)
     // restApi:v3 validation failures also name the field that failed:
     // e.validation?.forEach(d => markInvalid(d.field, d.message))
     // `field` and `message` are both optional; absent under restApi:v2.
@@ -531,7 +533,8 @@ try {
   - Use callListMethod/fetchListMethod for large lists
   - Batch related calls with callBatch; chunk big arrays with callBatchByChunk
 - Logging
-  - Build once via LoggerBrowser.build(appName, isDev) and set to instances if needed
+  - Build once via LoggerFactory.createForBrowser(appName, isDev) and set to instances if needed
+  - Pass context as an object: `logger.info('message', { key: value })`, not as extra arguments
 - Types and enums
   - Prefer exported enums (e.g., EnumCrmEntityTypeId) and types (ISODate, payload types)
 
@@ -557,7 +560,7 @@ try {
 - B24Hook (+ B24Hook.fromWebhookUrl)
 - AbstractB24 helpers: callMethod, callBatch, callListMethod, fetchListMethod, callBatchByChunk, chunkArray
 - HTTP types and classes: AjaxResult, AjaxError, Result
-- LoggerBrowser, Text, Type, Browser, tools/use-formatters
+- LoggerFactory, Logger, Text, Type, Browser, tools/use-formatters
 - Types/enums: http, b24, auth, payloads, user, slider, handler, placement, crm, catalog, bizproc, event, pull, b24-helper
 
 
@@ -618,7 +621,7 @@ This document is based on the SDK source in packages/jssdk/src and the docs unde
  
 - Unique ID Generator: request IDs are appended automatically via Http
 - Result / AjaxResult: uniform result objects, error aggregation. (The paging members `isMore`/`hasMore`/`getTotal`/`getNext`/`fetchNext` are not deprecated, but are `restApi:v2`-only — see Deprecation notice.)
-- Language List and LoggerBrowser
+- Language List and LoggerFactory / Logger
 
 ### Tools
 

--- a/scripts/__tests__/skills-typecheck-blocks.test.mjs
+++ b/scripts/__tests__/skills-typecheck-blocks.test.mjs
@@ -8,7 +8,7 @@
 // tests pin — is the wiring: which files the gate discovers, and that it treats
 // an empty sweep as a failure rather than a pass.
 
-import { existsSync, readdirSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
@@ -57,6 +57,20 @@ test('every skill directory is covered, not a hand-written list', () => {
   const match = output.match(/skills-typecheck: (\d+) block\(s\) checked/)
   assert.ok(match, `expected a block count in:\n${output}`)
   assert.ok(Number(match[1]) > 0, 'zero blocks checked — the sweep found nothing')
+})
+
+test('README-AI.md is in the sweep', () => {
+  // It is shipped in the npm package and written for an agent to read before
+  // writing code — the same category as a SKILL.md, under a different name. It
+  // sat outside every gate until #277, and the first run over it found three
+  // defects. A file added by name rather than discovered can silently drop out,
+  // so pin it.
+  const source = readFileSync(SCRIPT, 'utf8')
+  assert.match(source, /'packages', 'jssdk', 'README-AI\.md'/)
+  assert.ok(
+    existsSync(join(REPO_ROOT, 'packages', 'jssdk', 'README-AI.md')),
+    'README-AI.md is gone — the gate would now be checking a path that does not exist'
+  )
 })
 
 test('the skills tree currently type-checks clean', { skip: SKIP }, () => {

--- a/scripts/skills-typecheck-blocks.mjs
+++ b/scripts/skills-typecheck-blocks.mjs
@@ -22,6 +22,10 @@
  * list and `.skills-typecheck/globals.d.ts`, whose header explains what may and
  * may not be declared there.
  *
+ * The file list is every `skills/*\/SKILL.md` plus `packages/jssdk/README-AI.md`,
+ * which is the same kind of file under a different name — shipped in the npm
+ * package, written for an agent to read before it writes code.
+ *
  * Prerequisites: pnpm install && pnpm run dev:prepare (creates dist/ for jssdk types).
  */
 
@@ -46,6 +50,13 @@ const files = readdirSync(SKILLS_DIR, { withFileTypes: true })
   .filter(entry => entry.isDirectory() || entry.isSymbolicLink())
   .map(entry => join(SKILLS_DIR, entry.name, 'SKILL.md'))
   .filter(existsSync)
+
+// `README-AI.md` is the same category of file wearing a different name: it is
+// shipped inside the npm package and is written to be read by an agent before
+// it writes code. It sat outside every gate, and the first run over it found
+// three defects — a missing import, a helper called with an argument it does
+// not take, and `AjaxError.description`, which does not exist.
+files.push(join(REPO_ROOT, 'packages', 'jssdk', 'README-AI.md'))
 
 process.exit(checkBlocks({
   label: 'skills-typecheck',


### PR DESCRIPTION
Step 1 of #277 — the non-breaking part, pulled forward into `2.x`.

## What the issue said, and what was actually true

#277 names `skills/b24jssdk-core/SKILL.md` (3 sites) and `skills/b24jssdk-recipes/SKILL.md` (2 sites) as still teaching `LoggerBrowser.build(...)`. **Both were already fixed**, in #401. That measurement was stale.

The same problem was sitting one directory over, in `packages/jssdk/README-AI.md` — which is shipped inside the npm package and written to be read by an agent *before* it writes code, exactly the category the issue was worried about. Five sites.

## The call shape, not just the constructor

`LoggerBrowser` was variadic, so this read naturally:

```ts
logger.info('items:', companies.getData().result)
```

The replacement takes `(message: string, context?: Record<string, any>)`. An array satisfies `Record<string, any>` structurally, so that line **compiles** — then serialises to `{}`, and the value disappears from the log. This is the failure the `logger-context-must-be-object` ESLint rule guards in the recipes, and every call site in this file had it. All five now pass a named object.

## Gating it is the other half

The file sat outside every pass. Renaming the logger would have left it exactly as unverifiable as before, so it now rides with the skills gate — same rationale, same category of file, one line of file list. **The first run found three more defects**, each one something a reader hits on copying:

| Site | Defect |
| --- | --- |
| listing helpers | `EnumCrmEntityTypeId` used, never imported |
| Pull example | `usePullClient('prefix')` — the helper takes no arguments |
| Pull example | `initializeB24Frame()` used, never imported |
| error handling | `e.description` on `AjaxError` — the property is `message` |

83 blocks, 0 errors.

The deprecation table row for `LoggerBrowser` / `LoggerType` stays: it is the migration mapping, and it is descriptive rather than instructional.

## Note for #277

Two things in that issue are now out of date, and I will comment there separately rather than change them here:

- the skills sites it lists are already fixed;
- its checklist still schedules `AjaxResult.isMore/hasMore/getTotal/getNext/fetchNext` for removal, and its "one blocker: `getTotal()` has no replacement" analysis rests on that. **That plan was withdrawn in #408** — the members are no longer deprecated in the source, and `README-AI.md` already documents them as staying. So the decision the issue calls the blocker for 3.0.0 has in fact already been taken.

## Verification

`skills:typecheck-blocks` clean, 115 script tests green, `docs-lint --strict` and `md-internal-links` clean. The `audited:` stamps on six pages moved to the merge date of #443 — the squash landed the day after they were last stamped, which is what the freshness gate is measuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_