### PR TITLE
docs(contributing): re-measure the typecheck coverage table and point AGENTS.md at it

### DIFF
--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -191,10 +191,15 @@ If you add type-level assertions, use this suffix — a `*.unit.spec.ts` file's 
 
 ## What type-checks what
 
-`pnpm run typecheck` runs nine passes. Each column below is what that pass, and
-only that pass, catches — measured in #419 by injecting a deliberate type error
-into each area and recording which passes went red. Nothing here is inferred from
+`pnpm run typecheck` runs ten passes. Each row below is what that pass, and only
+that pass, catches — measured in #419 by injecting a deliberate type error into
+each area and recording which passes went red. Nothing here is inferred from
 reading a config.
+
+This table is the canonical answer to "do I need to add another pass?".
+`package.json` cannot carry the note itself — it is strict JSON, so a comment
+beside each script is not available — which is why [AGENTS.md](../../AGENTS.md)
+points here instead.
 
 | Pass | The area only it covers |
 | --- | --- |
@@ -208,6 +213,11 @@ reading a config.
 | `skills:typecheck` | the recipe `.ts` files under `skills/b24jssdk-recipes/` |
 | `skills:typecheck-blocks` | `ts` fences in `skills/**/*.md` and in `packages/jssdk/README-AI.md` |
 | `jsdoc:typecheck-blocks` | JSDoc `@example` bodies in `packages/jssdk/src/**/*.ts` |
+
+Last verified by injection 2026-09-01, after `jsdoc:typecheck-blocks` was added
+and `README-AI.md` joined the skills gate. Re-measure the rows you change: the
+claim is "only this pass", and that is a property of the whole set, not of the
+pass you happen to be editing.
 
 Plus the `jsSdk:types` vitest project, which is where the `*.types.spec.ts` pins
 become real — `expectTypeOf` erases at runtime, so under a plain `vitest run` a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,8 +320,13 @@ Check these before adding to the repository, not after:
 
 - **A new script in `scripts/`.** Nine already exist and share one shape; see
   #418. Ask whether an existing one should grow instead.
-- **A new `tsconfig.json` or a tenth `typecheck` pass.** There are already ten
-  and nine; see #419. Each is defensible alone.
+- **A new `tsconfig.json` or an eleventh `typecheck` pass.** There are already
+  ten of each, and #419 measured what every one of them uniquely catches — by
+  injection, not by reading configs. Eight are the only thing standing between a
+  broken area and `main`; the table is in
+  [testing.md](.github/contributing/testing.md#what-type-checks-what). Read it
+  before adding the eleventh, and add a row to it if you do. Each pass is
+  defensible alone; that is exactly why the total needs watching.
 - **A JSDoc block longer than the function it documents.** The longest in the SDK
   is 96 lines. If the reasoning is that long it belongs in
   `.github/contributing/`, with a pointer from the code — see #420 for the


### PR DESCRIPTION
Closes #419.

## What was left

#419 asked for two facts about each `typecheck` pass — how long it takes, and what breaks if it is removed — and both were measured and posted. Three follow-ups were listed. Two are done: `contributing:typecheck` was removed once the measurement showed it redundant, and the fence gap was filed as #435. The third was "a comment in `package.json` next to each pass".

**That one is not available.** `package.json` is strict JSON; there is nowhere to put the note. The nearest workable thing is a table somewhere a reader will actually reach, and a pointer to it from the place the decision gets made.

## What this does

- Re-measures the table **by injection on today's tree**, because the set has changed three times since the original run: `contributing:typecheck` removed, `jsdoc:typecheck-blocks` added (#443), `README-AI.md` joined the skills gate (#446).
- Marks the table with the verification date and the instruction to re-measure a row you change — the claim is "only this pass", which is a property of the whole set, not of the pass being edited.
- Points AGENTS.md at it. The "check before adding" list said "there are already ten and nine; see #419". It now says what the table is for, links to it, and asks anyone adding an eleventh pass to add a row.

## Re-measurement

| Injected in | Passes that went red |
| --- | --- |
| JSDoc `@example` in `packages/jssdk/src/` | `jsdoc:typecheck-blocks` — and nothing else |
| ` ```ts ` fence in `packages/jssdk/README-AI.md` | `skills:typecheck-blocks` — and nothing else |
| ` ```ts ` fence in `.github/contributing/` | **none of the ten** |

The last row is #435, unchanged and now re-confirmed rather than assumed.

Timings were re-taken too, but they are not worth putting in the table: the total came out at ~44 s against ~89 s in the first run, and that gap is warm caches rather than anything that changed. The ranking is what matters and it held — `docs:typecheck` is the single most expensive pass, the four block gates are ~2 s each.

## Verification

`docs-lint --strict` and `md-internal-links` clean (the new anchor link resolves). No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_