### PR TITLE
feat(scripts): compile the ts fences in the contributing guides

### DIFF
--- a/.contributing-typecheck/globals.d.ts
+++ b/.contributing-typecheck/globals.d.ts
@@ -1,0 +1,44 @@
+/**
+ * Ambient declarations for the `ts` fences in `.github/contributing/**.md` (#435).
+ *
+ * Same rule as the skills gate, and for the same reason: **a real export of
+ * `@bitrix24/b24jssdk` is never declared here.** If a fence needs `B24Hook`, the
+ * fence imports it — a reader copying that block gets code that runs. An ambient
+ * for a real export would make the gate green while the snippet stayed broken,
+ * which is the failure the gate exists to prevent.
+ *
+ * What may go here is the surrounding context a guide's excerpt assumes and
+ * deliberately does not show: a client the prose established paragraphs earlier,
+ * a handler the reader is expected to have written.
+ */
+
+// The live client. `B24Frame` rather than `B24Hook` so frame-only members
+// resolve; a fence that constructs its own client shadows this with a local
+// `const`, which is why this is `let` — `declare const` would make that a
+// TS2588 error.
+declare let b24: import('@bitrix24/b24jssdk').B24Frame
+declare let $b24: import('@bitrix24/b24jssdk').B24Frame
+
+// Context these guides' excerpts assume and deliberately do not repeat. None of
+// these is an export of `@bitrix24/b24jssdk` — they belong to the docs app, the
+// test harness and the reproduction harness that each guide is describing, and
+// a reader of that guide already has them in scope.
+
+// `documentation.md`: a Nuxt auto-import in the docs app, not an SDK export.
+declare function useB24(): { get: () => unknown }
+
+// `testing.md`: the integration-test harness, re-exported from
+// `test/0_setup/hooks-integration-jssdk.ts`. Declared loosely on purpose — the
+// real signature is compiled where it lives, by `test:typecheck`.
+declare function setupB24Tests(): {
+  getB24Client: () => import('@bitrix24/b24jssdk').B24Hook
+  getMapId: () => Record<string, any>
+}
+
+// `reproducing-user-reports.md`: the helpers the reproduction harness puts in
+// scope inside its `SCENARIO` block. The shape is what a reader copies, which
+// is the part worth compiling.
+declare function call(method: string, params?: Record<string, any>, options?: { ver?: 'v2' | 'v3' }): Promise<any>
+declare function step(title: string): void
+declare function note(text: string, level?: 'info' | 'ok' | 'err'): void
+declare function verdict(passed: boolean, why: string): void

--- a/.contributing-typecheck/tsconfig.json
+++ b/.contributing-typecheck/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "strict": false,
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "moduleDetection": "force",
+    "allowJs": false,
+    "allowImportingTsExtensions": false,
+    "isolatedModules": false,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "globals.d.ts",
+    "tmp/**/*.ts"
+  ]
+}

--- a/.github/contributing/maintenance.md
+++ b/.github/contributing/maintenance.md
@@ -249,9 +249,18 @@ and CRM ids written as `'D_42'` where the type is `number[]`.
   `filter` actually lives.
 - **Placeholders belong in `globals.d.ts`** — a domain type, a handler the
   reader writes, an id list they already have.
-- **`// @check-ignore` on the line before the fence** skips it. Use it when
-  making the snippet compile would misrepresent it, and say why in the marker.
-  It is the last resort: every ignored fence is a fence the gate stops checking.
+- **`// @check-ignore` on the nearest non-empty line above the fence** skips it.
+  Use it when making the snippet compile would misrepresent it, and say why in
+  the marker. It is the last resort: every ignored fence is a fence the gate
+  stops checking.
+
+  Two mechanics worth knowing before you write one. **Leave a blank line between
+  the marker and the fence** — markdownlint's MD031 wants blank lines around a
+  fence, and the extractor skips blanks when it looks upward, so both are
+  satisfied. And **keep the reason on the marker's own line**: the extractor
+  reads exactly one line, so a reason wrapped onto a second line leaves that
+  second line as the nearest non-empty one and the marker silently stops
+  working. It fails safe — the fence gets compiled — but you will not be told.
 
 The gate proves a fence type-checks. It does not prove the method exists on a
 portal, or that the field names are right — that is what `skills:verify` (#113)

--- a/.github/contributing/package-structure.md
+++ b/.github/contributing/package-structure.md
@@ -40,6 +40,7 @@ A typical helper-style manager (the dominant shape in `src/helper/` and `src/fra
 The template below is the **standalone** flavour:
 
 // @check-ignore: template for a file the reader is about to create; `MyManager` does not exist and the imports are relative to `packages/jssdk/src/<area>/`
+
 ```ts
 // 1. Type imports first (always separate)
 import type { LoggerInterface } from '../logger'
@@ -101,6 +102,7 @@ For transport-layer actions (under `src/core/actions/v2/` and `v3/`) extend `Abs
 A symbol is *only* public once it is re-exported from `packages/jssdk/src/index.ts`. Internal-only helpers stay unexported.
 
 // @check-ignore: `./my-area/my-manager` is the file the reader is about to add, not one that exists
+
 ```ts
 // packages/jssdk/src/index.ts
 export { MyManager } from './my-area/my-manager'
@@ -301,6 +303,7 @@ Use the placeholders directly — never read `package.json` at runtime, never ha
 Add to `packages/jssdk/src/index.ts`:
 
 // @check-ignore: same hypothetical module as above
+
 ```ts
 export { MyManager } from './my-area/my-manager'
 export type { MyManagerOptions } from './my-area/my-manager'

--- a/.github/contributing/package-structure.md
+++ b/.github/contributing/package-structure.md
@@ -39,6 +39,7 @@ A typical helper-style manager (the dominant shape in `src/helper/` and `src/fra
 
 The template below is the **standalone** flavour:
 
+// @check-ignore: template for a file the reader is about to create; `MyManager` does not exist and the imports are relative to `packages/jssdk/src/<area>/`
 ```ts
 // 1. Type imports first (always separate)
 import type { LoggerInterface } from '../logger'
@@ -99,6 +100,7 @@ For transport-layer actions (under `src/core/actions/v2/` and `v3/`) extend `Abs
 
 A symbol is *only* public once it is re-exported from `packages/jssdk/src/index.ts`. Internal-only helpers stay unexported.
 
+// @check-ignore: `./my-area/my-manager` is the file the reader is about to add, not one that exists
 ```ts
 // packages/jssdk/src/index.ts
 export { MyManager } from './my-area/my-manager'
@@ -298,6 +300,7 @@ Use the placeholders directly — never read `package.json` at runtime, never ha
 
 Add to `packages/jssdk/src/index.ts`:
 
+// @check-ignore: same hypothetical module as above
 ```ts
 export { MyManager } from './my-area/my-manager'
 export type { MyManagerOptions } from './my-area/my-manager'

--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -67,6 +67,7 @@ Integration test names follow `<area>-<flavor>.spec.ts`. The `core/` group exerc
 ## Basic Integration Test Structure
 
 // @check-ignore: excerpt of a real test file; its imports are relative to `test/integration/<area>/` and those files are compiled by `test:typecheck`
+
 ```ts
 import { describe, it, expect } from 'vitest'
 import { setupB24Tests } from '../../0_setup/hooks-integration-jssdk'

--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -66,6 +66,7 @@ Integration test names follow `<area>-<flavor>.spec.ts`. The `core/` group exerc
 
 ## Basic Integration Test Structure
 
+// @check-ignore: excerpt of a real test file; its imports are relative to `test/integration/<area>/` and those files are compiled by `test:typecheck`
 ```ts
 import { describe, it, expect } from 'vitest'
 import { setupB24Tests } from '../../0_setup/hooks-integration-jssdk'
@@ -191,7 +192,7 @@ If you add type-level assertions, use this suffix — a `*.unit.spec.ts` file's 
 
 ## What type-checks what
 
-`pnpm run typecheck` runs ten passes. Each row below is what that pass, and only
+`pnpm run typecheck` runs eleven passes. Each row below is what that pass, and only
 that pass, catches — measured in #419 by injecting a deliberate type error into
 each area and recording which passes went red. Nothing here is inferred from
 reading a config.
@@ -213,6 +214,7 @@ points here instead.
 | `skills:typecheck` | the recipe `.ts` files under `skills/b24jssdk-recipes/` |
 | `skills:typecheck-blocks` | `ts` fences in `skills/**/*.md` and in `packages/jssdk/README-AI.md` |
 | `jsdoc:typecheck-blocks` | JSDoc `@example` bodies in `packages/jssdk/src/**/*.ts` |
+| `contributing:typecheck-blocks` | `ts` fences in `.github/contributing/**/*.md` |
 
 Last verified by injection 2026-09-01, after `jsdoc:typecheck-blocks` was added
 and `README-AI.md` joined the skills gate. Re-measure the rows you change: the
@@ -236,11 +238,14 @@ Two results from that measurement are worth carrying:
   fence wrapping the whole body is unwrapped as presentation, and a
   `// @check-ignore` first line skips the block. A same-line `@example 'value'`
   is a value, not code, and is not compiled.
-- **`ts` fences in `.github/contributing/*.md` are compiled by nothing.**
-  Docs fences and skill fences are covered; these are the gap (#435). There is a
-  `test/some-code-from-docs/contributing/` directory of hand-written fixtures
-  whose names mirror the guides, and nothing checks that a fixture still matches
-  the fence it came from.
+- **`ts` fences in `.github/contributing/*.md` were compiled by nothing** until
+  #435 closed it — the last gap. Five of the twelve are marked
+  `// @check-ignore` with a reason, because they cannot compile by design: they
+  are templates for files the reader is about to create, or excerpts whose
+  imports are relative to where the real file lives. The real files are compiled
+  where they live. The `test/some-code-from-docs/contributing/` fixtures stay as
+  runnable examples with their own `.spec.ts` tests; nothing now depends on them
+  matching a guide, because the guide is compiled directly.
 
 A tenth pass, `contributing:typecheck`, was removed once the measurement showed
 it was redundant: it compiled those twelve fixtures alone, and since #428 widened

--- a/.github/contributing/transports-and-results.md
+++ b/.github/contributing/transports-and-results.md
@@ -32,6 +32,7 @@ packages/jssdk/src/core/
 
 `Result` is the uniform return type for every domain method. It carries data, errors, and (for paged endpoints) the next-page handle. **Never return raw axios responses.**
 
+// @check-ignore: SDK-internal excerpt; the import is relative to `packages/jssdk/src/<area>/` and the real file is compiled by `package-jssdk:typecheck`
 ```ts
 import { Result } from '../core/result'
 
@@ -92,6 +93,11 @@ Two error classes, two purposes:
 | `AjaxError` | HTTP / REST API errors (4xx, 5xx, malformed payloads) | Returned via `Result.getErrors()` |
 
 ```ts
+import { SdkError, AjaxError } from '@bitrix24/b24jssdk'
+
+declare const url: string | undefined
+declare const payload: Record<string, unknown>
+
 // SdkError — throw on guard failures inside the SDK.
 // The constructor takes a SdkErrorDetails object, not a string.
 if (!url) {

--- a/.github/contributing/transports-and-results.md
+++ b/.github/contributing/transports-and-results.md
@@ -33,6 +33,7 @@ packages/jssdk/src/core/
 `Result` is the uniform return type for every domain method. It carries data, errors, and (for paged endpoints) the next-page handle. **Never return raw axios responses.**
 
 // @check-ignore: SDK-internal excerpt; the import is relative to `packages/jssdk/src/<area>/` and the real file is compiled by `package-jssdk:typecheck`
+
 ```ts
 import { Result } from '../core/result'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,11 +183,11 @@ jobs:
           name: prepared-workspace
 
       - name: Typecheck
-        # Includes docs:typecheck-blocks and jsdoc:typecheck-blocks — the first
-        # type-checks ```ts fences in docs/content/docs/**/*.md, the second the
-        # JSDoc @example bodies in packages/jssdk/src/**/*.ts (#439). Both compile
-        # against @bitrix24/b24jssdk, so they run after dev:prepare, when dist/
-        # types are available.
+        # Includes the four block gates — ```ts fences in docs/content/docs/**,
+        # in skills/** and .github/contributing/** (#435), plus the JSDoc @example
+        # bodies in packages/jssdk/src/** (#439). All compile against
+        # @bitrix24/b24jssdk, so they run after dev:prepare, when dist/ types are
+        # available.
         run: pnpm run typecheck
 
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ coverage
 .docs-typecheck/tmp/
 .skills-typecheck/tmp/
 .jsdoc-typecheck/tmp/
+.contributing-typecheck/tmp/
 # Scratch file written by the docs-lint freshness test. It is removed in a
 # `finally`, but a killed runner would otherwise leave it as a stray untracked
 # file — ignoring it keeps `git status` honest either way.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "skills:typecheck-blocks": "node scripts/skills-typecheck-blocks.mjs",
     "docs:typecheck-blocks": "node scripts/docs-typecheck.mjs",
     "jsdoc:typecheck-blocks": "node scripts/jsdoc-typecheck-blocks.mjs",
+    "contributing:typecheck-blocks": "node scripts/contributing-typecheck-blocks.mjs",
     "skills:install": "pnpm --dir skills/b24jssdk-recipes install --frozen-lockfile",
     "skills:typecheck": "pnpm run skills:install && tsc -p skills/b24jssdk-recipes/tsconfig.json",
     "package-jssdk:test:run-unit": "vitest run --project jsSdk:unit",
@@ -77,7 +78,7 @@
     "docs:lint-links": "node scripts/docs-link-check.mjs",
     "docs:lint-api-index": "node scripts/check-api-reference-index.mjs",
     "docs:lint:test": "node --test \"scripts/__tests__/**/*.test.mjs\"",
-    "typecheck": "pnpm run package-jssdk:typecheck && pnpm run test:typecheck && pnpm run package-jssdk-nuxt:typecheck && pnpm run docs:typecheck && pnpm run playground-nuxt:typecheck && pnpm run playground-cli:typecheck && pnpm run docs:typecheck-blocks && pnpm run skills:typecheck && pnpm run skills:typecheck-blocks && pnpm run jsdoc:typecheck-blocks",
+    "typecheck": "pnpm run package-jssdk:typecheck && pnpm run test:typecheck && pnpm run package-jssdk-nuxt:typecheck && pnpm run docs:typecheck && pnpm run playground-nuxt:typecheck && pnpm run playground-cli:typecheck && pnpm run docs:typecheck-blocks && pnpm run skills:typecheck && pnpm run skills:typecheck-blocks && pnpm run jsdoc:typecheck-blocks && pnpm run contributing:typecheck-blocks",
     "release:bump": "node scripts/bump-version.mjs"
   },
   "devDependencies": {

--- a/scripts/__tests__/contributing-typecheck-blocks.test.mjs
+++ b/scripts/__tests__/contributing-typecheck-blocks.test.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Tests for scripts/contributing-typecheck-blocks.mjs (#435).
+//
+// Run with: node --test scripts/__tests__/contributing-typecheck-blocks.test.mjs
+//
+// Extraction and reporting are shared with the docs gate and covered by
+// docs-typecheck.test.mjs. What is specific here is the wiring: which files the
+// gate discovers, that an empty sweep is a failure rather than a pass, and that
+// a broken fence in a guide actually fails.
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const SCRIPT = resolve(__dirname, '..', 'contributing-typecheck-blocks.mjs')
+const GUIDES = join(REPO_ROOT, '.github', 'contributing')
+
+// Same convention as the docs and skills tests: the docs-lint CI job runs this
+// file without `dev:prepare`, so the spawning tests skip when dist/ is absent.
+// Real coverage comes from the `typecheck` job, which runs the gate for real.
+const TSC_BIN = join(REPO_ROOT, 'node_modules', 'typescript', 'bin', 'tsc')
+const SDK_TYPES = join(REPO_ROOT, 'packages', 'jssdk', 'dist', 'esm', 'index.d.ts')
+const SKIP = !existsSync(TSC_BIN) || !existsSync(SDK_TYPES)
+
+test('the guides are walked, not listed', () => {
+  // The guides get added to and split regularly, and #420 plans to move more
+  // prose into them. A hand-maintained list went stale once already (#401), so
+  // assert the gate walks the directory rather than naming files.
+  const source = readFileSync(SCRIPT, 'utf8')
+  assert.match(source, /walkMarkdownFiles\(join\(REPO_ROOT, '\.github', 'contributing'\)\)/)
+
+  const onDisk = readdirSync(GUIDES).filter(name => name.endsWith('.md'))
+  assert.ok(onDisk.length > 0, 'no guides found — the layout changed')
+})
+
+test('the guides currently type-check clean', { skip: SKIP }, () => {
+  const result = spawnSync(process.execPath, [SCRIPT], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, GITHUB_ACTIONS: '' }
+  })
+  const output = (result.stdout ?? '') + (result.stderr ?? '')
+
+  assert.equal(result.status, 0, `gate failed:\n${output}`)
+
+  const match = output.match(/contributing-typecheck: (\d+) block\(s\) checked/)
+  assert.ok(match, `expected a block count in:\n${output}`)
+  assert.ok(Number(match[1]) > 0, 'zero blocks checked — the sweep found nothing')
+})
+
+test('a deliberately broken fence in a guide fails the gate', { skip: SKIP }, () => {
+  // The acceptance criterion of #435 is that a broken fence cannot reach main,
+  // and the only proof of that is watching a broken one fail. This is how the
+  // gap was found in the first place (#419), so it is how it is confirmed shut.
+  const target = join(GUIDES, 'transports-and-results.md')
+  const original = readFileSync(target, 'utf8')
+  const marker = 'const result = await b24.actions.v3.call.make({'
+  assert.ok(original.includes(marker), 'the fence this test injects into moved')
+
+  try {
+    writeFileSync(
+      target,
+      original.replace(marker, `const injected: number = 'not a number'\n${marker}`),
+      'utf8'
+    )
+    const run = spawnSync(process.execPath, [SCRIPT], { cwd: REPO_ROOT, encoding: 'utf8' })
+    assert.equal(run.status, 1, 'the gate passed on a fence that does not compile')
+    assert.match(run.stdout, /transports-and-results\.md:\d+:\d+ TS2322/)
+  } finally {
+    writeFileSync(target, original, 'utf8')
+  }
+})
+
+test('an ignored fence carries a reason', () => {
+  // `// @check-ignore` without a reason is how a gate quietly stops covering
+  // something. Five fences are ignored here and each says why; keep it that way.
+  for (const name of readdirSync(GUIDES).filter(f => f.endsWith('.md'))) {
+    const lines = readFileSync(join(GUIDES, name), 'utf8').split('\n')
+    for (const [index, line] of lines.entries()) {
+      const trimmed = line.trim()
+      if (!trimmed.startsWith('// @check-ignore')) continue
+      assert.match(
+        trimmed,
+        /^\/\/ @check-ignore: \S/,
+        `${name}:${index + 1} — an ignored fence must say why`
+      )
+    }
+  }
+})

--- a/scripts/__tests__/docs-typecheck.test.mjs
+++ b/scripts/__tests__/docs-typecheck.test.mjs
@@ -130,6 +130,45 @@ test('extractTsBlocks: @check-ignore not on nearest non-empty line does NOT skip
   assert.equal(blocks.length, 1)
 })
 
+test('extractTsBlocks: a ```ts marker inside a longer fence is text, not a fence', () => {
+  // `.github/contributing/telegram-release-post.md` holds a ````text block —
+  // a template for an announcement post — with ```ts placeholders inside it.
+  // Scanning only for ts openings turned those placeholders into code and the
+  // gate reported TS1127 on `<Snippet1 — compiles>` (#435). Same family as
+  // #441: a fence marker is only a fence where markdown says it is.
+  const md = [
+    '````text',
+    'Post template:',
+    '',
+    '```ts',
+    '<Snippet1 — compiles>',
+    '```',
+    '````',
+    '',
+    '```ts',
+    'const real = 1',
+    '```'
+  ].join('\n')
+
+  const blocks = extractTsBlocks(md)
+  assert.deepEqual(blocks.map(b => b.lines), [['const real = 1']])
+  assert.equal(blocks[0].startLine, 10)
+})
+
+test('extractTsBlocks: a tilde fence is not closed by a backtick run', () => {
+  const md = [
+    '~~~text',
+    '```',
+    '~~~',
+    '',
+    '```ts',
+    'const real = 1',
+    '```'
+  ].join('\n')
+
+  assert.deepEqual(extractTsBlocks(md).map(b => b.lines), [['const real = 1']])
+})
+
 test('extractTsBlocks: line number mapping — error on line 3 of block at startLine=10 → mdLine=12', () => {
   // Build a file where the fence opens at line 9 (0-indexed 8), so startLine=10.
   const prefix = Array.from({ length: 8 }, (_, i) => `// line ${i + 1}`).join('\n')

--- a/scripts/_typecheck-blocks.mjs
+++ b/scripts/_typecheck-blocks.mjs
@@ -52,6 +52,8 @@ export function extractTsBlocks(content, filePath) {
   const blocks = []
   let inFence = false
   let fenceLen = 0
+  let fenceChar = '`'
+  let collecting = false
   let blockLines = []
   let blockStart = 0
   let skip = false
@@ -60,13 +62,28 @@ export function extractTsBlocks(content, filePath) {
     const line = fileLines[i]
 
     if (!inFence) {
-      // Match opening fence: ```ts or ```typescript, with optional [filename] annotation.
-      // Explicitly exclude ```ts-type (type-signature fragments).
-      const match = line.match(/^(`{3,})(typescript|ts)(?:\s+\[.*?\])?\s*$/)
-      if (!match) continue
+      // Every opening fence is tracked, not just the ts ones. A fence of any
+      // language makes its body literal text, and a ```ts marker inside one is
+      // part of that text rather than a fence of its own — which is exactly what
+      // `telegram-release-post.md` contains: a four-backtick ````text block
+      // holding a template for an announcement, with ```ts placeholders inside
+      // it. Scanning only for ts openings turned those placeholders into
+      // TS1127 (#435). Same family as #441: a fence marker is only a fence
+      // where markdown says it is.
+      const open = line.match(/^(`{3,}|~{3,})\s*(\S*)/)
+      if (!open) continue
 
-      fenceLen = match[1].length
+      const isTs = /^(?:typescript|ts)(?:\s+\[.*?\])?$/.test(
+        line.slice(open[1].length).trim()
+      )
+
+      fenceLen = open[1].length
+      fenceChar = open[1][0]
       inFence = true
+      // A non-ts fence is consumed to its close and discarded. `skip` already
+      // means "inside a fence whose content is not compiled", so it carries this
+      // too — and it is reset on close along with everything else.
+      collecting = isTs
       blockLines = []
       // blockStart is the 1-indexed line of the first code line (line after the fence).
       blockStart = i + 2
@@ -79,19 +96,22 @@ export function extractTsBlocks(content, filePath) {
       continue
     }
 
-    // Inside fence — check for matching closing fence.
-    const close = line.match(/^(`{3,})\s*$/)
-    if (close && close[1].length >= fenceLen) {
-      if (!skip && blockLines.length > 0) {
+    // Inside fence — check for matching closing fence. It must be the same
+    // character as the opening one and at least as long, or a ``` inside a
+    // ````text block would close it early.
+    const close = line.match(/^(`{3,}|~{3,})\s*$/)
+    if (close && close[1][0] === fenceChar && close[1].length >= fenceLen) {
+      if (collecting && !skip && blockLines.length > 0) {
         blocks.push({ lines: [...blockLines], startLine: blockStart, filePath })
       }
       inFence = false
       skip = false
+      collecting = false
       blockLines = []
       continue
     }
 
-    if (!skip) blockLines.push(line)
+    if (collecting && !skip) blockLines.push(line)
   }
 
   return blocks

--- a/scripts/contributing-typecheck-blocks.mjs
+++ b/scripts/contributing-typecheck-blocks.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+/**
+ * Type-checks the ```ts / ```typescript fences in `.github/contributing/**.md` (#435).
+ *
+ * The third caller of the same engine, and the last gap in fence coverage.
+ * `docs:typecheck-blocks` has guarded the documentation site since #109,
+ * `skills:typecheck-blocks` the agent-facing skill files since #402, and
+ * `jsdoc:typecheck-blocks` the `@example` bodies since #439. The contributor
+ * guides had nothing — measured, not assumed: #419 injected a type error into a
+ * fence in `transports-and-results.md` and all ten passes stayed green.
+ *
+ * The gap was hidden by a pass that looked like it closed it. `contributing:typecheck`
+ * compiled twelve hand-written fixtures under `test/some-code-from-docs/contributing/`
+ * whose names mirror the guides, and nothing checked that a fixture still matched
+ * the fence it was copied from — so the two could drift apart silently, in either
+ * direction. That pass was removed in #429 once `test:typecheck` covered the same
+ * files; this gate compiles the guides themselves instead of a copy of them.
+ *
+ * Those fixtures stay. Their `.spec.ts` neighbours assert runtime behaviour,
+ * which is a different question from whether the guide compiles, and they are
+ * covered by `test:typecheck` under stricter settings than they ever had here.
+ *
+ * Extraction, `// @check-ignore` handling and diagnostic mapping are shared with
+ * the other three gates — see `_typecheck-blocks.mjs`. What differs is only the
+ * file list and `.contributing-typecheck/globals.d.ts`, whose header explains
+ * what may and may not be declared there.
+ *
+ * Prerequisites: pnpm install && pnpm run dev:prepare (creates dist/ for jssdk types).
+ */
+
+import { resolve, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { requireSdkTypes } from './_require-sdk-types.mjs'
+import { checkBlocks } from './_typecheck-blocks.mjs'
+import { walkMarkdownFiles } from './_docs-utils.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..')
+
+requireSdkTypes('contributing:typecheck-blocks')
+
+// Walked, not listed. The guides are added to and split regularly — #420 plans
+// to move more code-adjacent prose into them — and a hand-maintained list went
+// stale once already in this repository (#401).
+const files = walkMarkdownFiles(join(REPO_ROOT, '.github', 'contributing'))
+
+process.exit(checkBlocks({
+  label: 'contributing-typecheck',
+  repoRoot: REPO_ROOT,
+  checkDir: join(REPO_ROOT, '.contributing-typecheck'),
+  files
+}))


### PR DESCRIPTION
Closes #435.

## What

The last gap in fence coverage, and the one that mattered most for its audience: `.github/contributing/` is where `AGENTS.md` sends both contributors and AI agents for the truth about transports, results, package structure and deprecations. #419 measured it — a type error injected into a fence there went unnoticed by **all ten** passes, while the same injection into a docs page or a skill file was caught immediately.

`contributing:typecheck-blocks` is the fourth caller of the `checkBlocks` engine. Docs fences since #109, skill fences since #402, JSDoc examples since #439, contributor guides now.

## The extractor had to be fixed first

The shared extractor scanned for ` ```ts ` openings only, so a fence marker **inside a longer fence** read as a fence of its own. `telegram-release-post.md` holds a four-backtick ` ````text ` block — the template for an announcement post — with ` ```ts ` placeholders inside it, and the gate duly reported `TS1127: Invalid character` on `<Snippet1 — compiles>`.

Now every opening fence is tracked and a non-ts fence is consumed to its close, and a closing run must match the opening character as well as its length (a ` ``` ` inside a ` ~~~text ` block no longer closes it). Same family as #441: a fence marker is only a fence where markdown says it is.

Both new cases are pinned and **verified by mutation** — each goes red against the code as it was. The other three gates report identical block counts before and after (157 / 83 / 41), so nothing moved elsewhere.

## What the fences turned out to be

Twelve real fences. Not all of them can compile, and that is not a defect:

| | |
| --- | ---: |
| compile, and now must | 7 |
| `// @check-ignore` with a stated reason | 5 |

The five are templates for a file the reader is about to create (`MyManager`, `./my-area/my-manager`) or excerpts whose imports are relative to where the real file lives — `../core/result` from inside `packages/jssdk/src/<area>/`, or a test file's `../../0_setup/…`. Those real files are compiled where they live, by `package-jssdk:typecheck` and `test:typecheck`, under stricter settings than this gate uses. A test asserts every ignore carries a reason, because an unexplained one is how a gate quietly stops covering something.

Two fences were fixed rather than ignored: the error-handling snippet in `transports-and-results.md` used `SdkError`, `AjaxError`, `url` and `payload` with none of them in scope.

`.contributing-typecheck/globals.d.ts` follows the skills rule — **never declare a real SDK export.** What it does declare is context the guides' excerpts assume and do not repeat: `useB24` (a docs-app Nuxt auto-import), `setupB24Tests` (the integration harness), and the `call` / `step` / `note` / `verdict` helpers the reproduction harness puts in scope.

## The fixtures

`test/some-code-from-docs/contributing/` stays, as the issue's acceptance criteria asked to settle. The twelve fixtures are runnable examples with their own `.spec.ts` tests, and `test:typecheck` compiles them. Nothing now depends on them matching a guide, because the guide is compiled directly — which is the drift the issue was actually worried about.

## Verification

Injection: a deliberate error in a real fence fails the gate and names the guide and line — asserted as a test. 121 script tests green, all four block gates clean, `docs-lint --strict` and `md-internal-links` clean. `#418`'s table row will be corrected on that issue separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_