### PR TITLE
refactor(scripts): one reporter, and GitHub annotations for every check

### DIFF
--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -200,11 +200,12 @@ reading a config.
 
 Every check in `scripts/` reports through
 [`_reporter.mjs`](../../scripts/_reporter.mjs): one line shape
-(`ERROR path:line:col message`), one summary (`label: N error(s), M
-warning(s), …`), one exit rule — errors always fail, warnings only under
-`--strict` — and a GitHub annotation on every problem, so a CI failure lands on
-the pull request diff instead of only in the job log. Add a check, use the
-reporter.
+(`ERROR path:line:col message`), one summary
+(`label: N <noun>(s), M warning(s), …` — the noun stays the check's own, so
+`md-internal-links` counts broken links rather than generic errors), one exit
+rule — errors always fail, warnings only under `--strict` — and a GitHub
+annotation on every problem, so a CI failure lands on the pull request diff
+instead of only in the job log. Add a check, use the reporter.
 
 This table is the canonical answer to "do I need to add another pass?".
 `package.json` cannot carry the note itself — it is strict JSON, so a comment

--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -198,6 +198,14 @@ that pass, catches — measured in #419 by injecting a deliberate type error int
 each area and recording which passes went red. Nothing here is inferred from
 reading a config.
 
+Every check in `scripts/` reports through
+[`_reporter.mjs`](../../scripts/_reporter.mjs): one line shape
+(`ERROR path:line:col message`), one summary (`label: N error(s), M
+warning(s), …`), one exit rule — errors always fail, warnings only under
+`--strict` — and a GitHub annotation on every problem, so a CI failure lands on
+the pull request diff instead of only in the job log. Add a check, use the
+reporter.
+
 This table is the canonical answer to "do I need to add another pass?".
 `package.json` cannot carry the note itself — it is strict JSON, so a comment
 beside each script is not available — which is why [AGENTS.md](../../AGENTS.md)

--- a/scripts/__tests__/check-api-reference-index.test.mjs
+++ b/scripts/__tests__/check-api-reference-index.test.mjs
@@ -265,8 +265,8 @@ test('fails, naming the export, when the page omits one', () => {
   }, (root) => {
     const run = runAgainst(root)
     assert.equal(run.status, 1)
-    assert.match(run.stderr, /does not list/)
-    assert.match(run.stderr, /- Forgotten/)
+    assert.match(run.stdout, /does not list/)
+    assert.match(run.stdout, /- Forgotten/)
   })
 })
 
@@ -282,8 +282,8 @@ test('fails, naming the row, when the page lists something no longer exported', 
   }, (root) => {
     const run = runAgainst(root)
     assert.equal(run.status, 1)
-    assert.match(run.stderr, /not public exports/)
-    assert.match(run.stderr, /- RenamedFrom/)
+    assert.match(run.stdout, /not public exports/)
+    assert.match(run.stdout, /- RenamedFrom/)
   })
 })
 
@@ -294,13 +294,13 @@ test('reports both directions at once', () => {
   }, (root) => {
     const run = runAgainst(root)
     assert.equal(run.status, 1)
-    assert.match(run.stderr, /- Added/)
-    assert.match(run.stderr, /- Removed/)
+    assert.match(run.stdout, /- Added/)
+    assert.match(run.stdout, /- Removed/)
   })
 })
 
 test('the real repo passes, and reports the export count', () => {
   const run = spawnSync(process.execPath, [SCRIPT], { cwd: REPO_ROOT, encoding: 'utf8' })
   assert.equal(run.status, 0, run.stderr)
-  assert.match(run.stdout, /public value export\(s\) — all present/)
+  assert.match(run.stdout, /0 error\(s\), 0 warning\(s\), \d+ public value export\(s\)/)
 })

--- a/scripts/__tests__/contributing-typecheck-blocks.test.mjs
+++ b/scripts/__tests__/contributing-typecheck-blocks.test.mjs
@@ -48,7 +48,7 @@ test('the guides currently type-check clean', { skip: SKIP }, () => {
 
   assert.equal(result.status, 0, `gate failed:\n${output}`)
 
-  const match = output.match(/contributing-typecheck: (\d+) block\(s\) checked/)
+  const match = output.match(/contributing-typecheck: [^\n]*\D(\d+) block\(s\) checked/)
   assert.ok(match, `expected a block count in:\n${output}`)
   assert.ok(Number(match[1]) > 0, 'zero blocks checked — the sweep found nothing')
 })

--- a/scripts/__tests__/docs-typecheck.test.mjs
+++ b/scripts/__tests__/docs-typecheck.test.mjs
@@ -255,7 +255,7 @@ function runTypecheckScript(env = {}) {
 test('docs-typecheck: against the real docs tree exits 0', { skip: INTEGRATION_SKIP }, () => {
   const r = runTypecheckScript()
   assert.equal(r.status, 0, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
-  assert.match(r.stdout, /block\(s\) checked, 0 error\(s\)/)
+  assert.match(r.stdout, /0 error\(s\), 0 warning\(s\), \d+ block\(s\) checked/)
 })
 
 test('docs-typecheck: a deliberately broken block causes exit 1 with correct file:line output', { skip: INTEGRATION_SKIP }, () => {

--- a/scripts/__tests__/md-internal-links.test.mjs
+++ b/scripts/__tests__/md-internal-links.test.mjs
@@ -82,7 +82,8 @@ test('md-internal-links: a missing repo-relative target exits 1', () => {
 
     const r = runCheck(root)
     assert.equal(r.status, 1, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
-    assert.match(r.stdout, /BROKEN/)
+    assert.match(r.stdout, /ERROR/)
+    assert.match(r.stdout, /broken link/)
     assert.match(r.stdout, /does-not-exist\.md/)
     assert.match(r.stdout, /1 broken link\(s\)/)
   })

--- a/scripts/__tests__/reporter.test.mjs
+++ b/scripts/__tests__/reporter.test.mjs
@@ -188,6 +188,9 @@ test('annotation text cannot inject a second workflow command', () => {
     return report.finish()
   }))
 
-  assert.doesNotMatch(out, /^::add-mask::/m)
+  // Indenting is not enough — Actions trims leading whitespace before parsing a
+  // `::` command, so the printed line must carry no newline at all.
+  assert.doesNotMatch(out, /^\s*::add-mask::/m)
+  assert.match(out, /first \| ::add-mask::secret/)
   assert.match(out, /%0A::add-mask::secret/)
 })

--- a/scripts/__tests__/reporter.test.mjs
+++ b/scripts/__tests__/reporter.test.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// Tests for scripts/_reporter.mjs (#418).
+//
+// Run with: node --test scripts/__tests__/reporter.test.mjs
+//
+// The reason this module exists is the GitHub annotations: before it, only the
+// block gates emitted them, so six checks failed in CI as plain log text with
+// nothing on the pull request diff. Most of what is pinned here is therefore
+// about the annotation and the exit code — the two things a CI run depends on.
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createReporter, escapeAnnotation } from '../_reporter.mjs'
+
+/** Run `fn` with stdout captured, returning everything it wrote. */
+function capture(fn) {
+  const lines = []
+  const log = console.log
+  const write = process.stdout.write.bind(process.stdout)
+  console.log = (...args) => lines.push(args.join(' '))
+  process.stdout.write = (chunk) => {
+    lines.push(String(chunk).replace(/\n$/, ''))
+    return true
+  }
+  try {
+    const result = fn()
+    return { out: lines.join('\n'), result }
+  } finally {
+    console.log = log
+    process.stdout.write = write
+  }
+}
+
+function withCI(value, fn) {
+  const before = process.env.GITHUB_ACTIONS
+  if (value === undefined) {
+    delete process.env.GITHUB_ACTIONS
+  } else {
+    process.env.GITHUB_ACTIONS = value
+  }
+  try {
+    return fn()
+  } finally {
+    if (before === undefined) {
+      delete process.env.GITHUB_ACTIONS
+    } else {
+      process.env.GITHUB_ACTIONS = before
+    }
+  }
+}
+
+test('an error prints the file relative to the root', () => {
+  const { out } = capture(() => {
+    const report = createReporter({ label: 'demo', root: '/repo' })
+    report.error('/repo/docs/page.md', 'something is wrong')
+    return report.finish()
+  })
+
+  assert.match(out, /ERROR.*docs\/page\.md something is wrong/)
+})
+
+test('line and column are appended when given, omitted when not', () => {
+  const { out } = capture(() => {
+    const report = createReporter({ label: 'demo', root: '/repo' })
+    report.error('/repo/a.md', 'with position', { line: 12, col: 3 })
+    report.error('/repo/b.md', 'without position')
+    return report.finish()
+  })
+
+  assert.match(out, /a\.md:12:3 with position/)
+  assert.match(out, /b\.md without position/)
+})
+
+test('a check with no file to blame is still attributable', () => {
+  // Whole-repository invariants have nothing to point at. The label stands in,
+  // so the line does not begin with a bare message.
+  const { out } = capture(() => {
+    const report = createReporter({ label: 'demo', root: '/repo' })
+    report.error(null, 'the invariant does not hold')
+    return report.finish()
+  })
+
+  assert.match(out, /ERROR.*demo the invariant does not hold/)
+})
+
+test('errors fail, warnings do not — unless strict', () => {
+  const warnOnly = () => {
+    const report = createReporter({ label: 'demo' })
+    report.warn('f', 'a warning')
+    return report
+  }
+
+  assert.equal(capture(() => warnOnly().finish()).result, 0)
+  assert.equal(capture(() => warnOnly().finish({ strict: true })).result, 1)
+
+  const withError = capture(() => {
+    const report = createReporter({ label: 'demo' })
+    report.error('f', 'an error')
+    return report.finish()
+  })
+  assert.equal(withError.result, 1)
+})
+
+test('a clean run exits 0 and says so', () => {
+  const { out, result } = capture(() => createReporter({ label: 'demo' }).finish())
+
+  assert.equal(result, 0)
+  assert.match(out, /demo: 0 error\(s\), 0 warning\(s\)/)
+})
+
+test('the summary keeps the check own noun', () => {
+  // Uniform level, check-specific noun: "1 broken link(s)" is more use to a
+  // reader than "1 problem(s)", and unifying the format should not cost that.
+  const { out } = capture(() => {
+    const report = createReporter({ label: 'links', errorNoun: 'broken link' })
+    report.error('f', 'gone')
+    return report.finish()
+  })
+
+  assert.match(out, /links: 1 broken link\(s\), 0 warning\(s\)/)
+})
+
+test('notes are appended to the summary in order', () => {
+  const { out } = capture(() => {
+    const report = createReporter({ label: 'demo' })
+    report.note('136 internal link(s) checked')
+    return report.finish()
+  })
+
+  assert.match(out, /demo: 0 error\(s\), 0 warning\(s\), 136 internal link\(s\) checked/)
+})
+
+test('max caps what is printed but not what is counted', () => {
+  const { out, result } = capture(() => {
+    const report = createReporter({ label: 'demo', root: '/repo', max: 2 })
+    for (let i = 0; i < 5; i++) {
+      report.error(`/repo/f${i}.md`, 'boom')
+    }
+    return report.finish()
+  })
+
+  assert.equal(result, 1)
+  assert.match(out, /f0\.md/)
+  assert.match(out, /f1\.md/)
+  assert.doesNotMatch(out, /f2\.md/, 'printed past the cap')
+  assert.match(out, /5 error\(s\)/, 'the count must not be capped')
+  assert.match(out, /3 not shown/)
+})
+
+test('a GitHub annotation is emitted only under GITHUB_ACTIONS', () => {
+  // This is the whole point of the module: before it, six checks failed in CI
+  // with nothing on the diff.
+  const inCI = withCI('true', () => capture(() => {
+    const report = createReporter({ label: 'demo', root: '/repo' })
+    report.error('/repo/docs/page.md', 'broken', { line: 7, col: 2, code: 'TS1234' })
+    return report.finish()
+  }))
+  assert.match(inCI.out, /^::error file=docs\/page\.md,line=7,col=2::TS1234: broken$/m)
+
+  const local = withCI(undefined, () => capture(() => {
+    const report = createReporter({ label: 'demo', root: '/repo' })
+    report.error('/repo/docs/page.md', 'broken')
+    return report.finish()
+  }))
+  assert.doesNotMatch(local.out, /::error/)
+})
+
+test('a warning annotates as a warning, not an error', () => {
+  const { out } = withCI('true', () => capture(() => {
+    const report = createReporter({ label: 'demo', root: '/repo' })
+    report.warn('/repo/a.md', 'soft')
+    return report.finish()
+  }))
+
+  assert.match(out, /^::warning file=a\.md::soft$/m)
+})
+
+test('annotation text cannot inject a second workflow command', () => {
+  // A message carrying a newline would otherwise let the next line be read as
+  // its own ::command — ::add-mask:: or ::set-env:: among them.
+  assert.equal(escapeAnnotation('a\nb'), 'a%0Ab')
+  assert.equal(escapeAnnotation('100%'), '100%25')
+  assert.equal(escapeAnnotation('a\r\nb'), 'a%0D%0Ab')
+
+  const { out } = withCI('true', () => capture(() => {
+    const report = createReporter({ label: 'demo', root: '/repo' })
+    report.error('/repo/a.md', 'first\n::add-mask::secret')
+    return report.finish()
+  }))
+
+  assert.doesNotMatch(out, /^::add-mask::/m)
+  assert.match(out, /%0A::add-mask::secret/)
+})

--- a/scripts/__tests__/reporter.test.mjs
+++ b/scripts/__tests__/reporter.test.mjs
@@ -211,14 +211,26 @@ test('a lone carriage return is a line boundary too', () => {
 test('an escape character in a path cannot repaint the log', () => {
   // ANSI in a filename could otherwise clear the line and hide what a check
   // reported, which is a quieter failure than a forged command.
-  const { out } = capture(() => {
-    const report = createReporter({ label: 'demo', root: '/repo' })
-    report.error(`/repo/c${ESC}[2Km.md`, 'ansi in a path')
-    return report.finish()
-  })
+  //
+  // Both modes, deliberately. The first version of this test ran without
+  // pinning `GITHUB_ACTIONS`, so it never exercised the annotation — and passed
+  // locally while CI, where the variable is set, found the escape character
+  // reaching `file=` untouched.
+  for (const ci of ['true', undefined]) {
+    const { out } = withCI(ci, () => capture(() => {
+      const report = createReporter({ label: 'demo', root: '/repo' })
+      report.error(`/repo/c${ESC}[2Km.md`, 'ansi in a path')
+      return report.finish()
+    }))
 
-  assert.doesNotMatch(out, new RegExp(`c${ESC}`))
-  assert.match(out, /c\[2Km\.md ansi in a path/)
+    assert.doesNotMatch(out, new RegExp(`c${ESC}`), `escape survived with GITHUB_ACTIONS=${ci}`)
+    assert.match(out, /c\[2Km\.md ansi in a path/)
+  }
+})
+
+test('escapeAnnotation drops control characters as well as escaping newlines', () => {
+  assert.equal(escapeAnnotation(`a${ESC}[2Kb`), 'a[2Kb')
+  assert.equal(escapeAnnotation(`a${String.fromCharCode(0)}b`), 'ab')
 })
 
 test('annotation text cannot inject a second workflow command', () => {

--- a/scripts/__tests__/reporter.test.mjs
+++ b/scripts/__tests__/reporter.test.mjs
@@ -175,6 +175,52 @@ test('a warning annotates as a warning, not an error', () => {
   assert.match(out, /^::warning file=a\.md::soft$/m)
 })
 
+const LF = String.fromCharCode(10)
+const CR = String.fromCharCode(13)
+const ESC = String.fromCharCode(27)
+
+test('a file path cannot inject a workflow command', () => {
+  // A POSIX filename may hold anything but `/` and NUL — newline included — and
+  // these checks walk directories a contributor edits freely. The path is
+  // therefore the most naturally attacker-controlled input on the line, and it
+  // was the half the first version of this defence left unprotected.
+  const { out } = withCI('true', () => capture(() => {
+    const report = createReporter({ label: 'demo', root: '/repo' })
+    report.error(`/repo/a.md${LF}::add-mask::pwned`, 'msg')
+    return report.finish()
+  }))
+
+  assert.doesNotMatch(out, /^\s*::add-mask::/m)
+  assert.match(out, /a\.md \| ::add-mask::pwned msg/)
+})
+
+test('a lone carriage return is a line boundary too', () => {
+  // The runner is .NET-based and treats a bare `\r` as one, which is why
+  // escapeAnnotation escapes it beside `\n`. A collapse that only handles `\n`
+  // does not match that threat model.
+  const { out } = withCI('true', () => capture(() => {
+    const report = createReporter({ label: 'demo', root: '/repo' })
+    report.error('/repo/a.md', `first${CR}::add-mask::pwned`)
+    return report.finish()
+  }))
+
+  assert.doesNotMatch(out, new RegExp(`${CR}::add-mask::`))
+  assert.match(out, /first \| ::add-mask::pwned/)
+})
+
+test('an escape character in a path cannot repaint the log', () => {
+  // ANSI in a filename could otherwise clear the line and hide what a check
+  // reported, which is a quieter failure than a forged command.
+  const { out } = capture(() => {
+    const report = createReporter({ label: 'demo', root: '/repo' })
+    report.error(`/repo/c${ESC}[2Km.md`, 'ansi in a path')
+    return report.finish()
+  })
+
+  assert.doesNotMatch(out, new RegExp(`c${ESC}`))
+  assert.match(out, /c\[2Km\.md ansi in a path/)
+})
+
 test('annotation text cannot inject a second workflow command', () => {
   // A message carrying a newline would otherwise let the next line be read as
   // its own ::command — ::add-mask:: or ::set-env:: among them.

--- a/scripts/__tests__/skills-typecheck-blocks.test.mjs
+++ b/scripts/__tests__/skills-typecheck-blocks.test.mjs
@@ -54,7 +54,7 @@ test('every skill directory is covered, not a hand-written list', () => {
   }
 
   // The block count is reported, and it is not zero.
-  const match = output.match(/skills-typecheck: (\d+) block\(s\) checked/)
+  const match = output.match(/skills-typecheck: [^\n]*\D(\d+) block\(s\) checked/)
   assert.ok(match, `expected a block count in:\n${output}`)
   assert.ok(Number(match[1]) > 0, 'zero blocks checked — the sweep found nothing')
 })

--- a/scripts/_reporter.mjs
+++ b/scripts/_reporter.mjs
@@ -32,13 +32,27 @@ const RED = '\u001B[31m'
 const YELLOW = '\u001B[33m'
 const RESET = '\u001B[0m'
 
+// Everything below C0 except tab, carriage return and line feed, plus DEL.
+// The three exceptions are handled separately: tab is harmless, and CR and LF
+// are the line boundaries each of the two paths deals with in its own way.
+// eslint-disable-next-line no-control-regex -- matching control characters is the point
+const CONTROL = /[\u0000-\u0008\v\f\u000E-\u001F\u007F]/g
+
 /**
  * GitHub Actions workflow commands use %25/%0D/%0A as escape sequences.
  * Without escaping, a message containing a literal newline could inject
  * additional workflow commands (e.g. ::set-env::, ::add-mask::).
+ *
+ * Other control characters are dropped rather than escaped: an escape character
+ * reaching the annotation would paint ANSI into the CI log just as it would on
+ * the printed line, and an annotation has no use for one.
  */
 export function escapeAnnotation(s) {
-  return String(s).replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A')
+  return String(s)
+    .replaceAll(CONTROL, '')
+    .replace(/%/g, '%25')
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A')
 }
 
 /**
@@ -62,10 +76,7 @@ export function escapeAnnotation(s) {
  * check reported.
  */
 function oneLine(value) {
-  return String(value)
-    // eslint-disable-next-line no-control-regex -- stripping control characters is the point
-    .replaceAll(/[\u0000-\u0008\v\f\u000E-\u001F\u007F]/g, '')
-    .replaceAll(/\r\n?|\n/g, ' | ')
+  return String(value).replaceAll(CONTROL, '').replaceAll(/\r\n?|\n/g, ' | ')
 }
 
 /**

--- a/scripts/_reporter.mjs
+++ b/scripts/_reporter.mjs
@@ -42,6 +42,33 @@ export function escapeAnnotation(s) {
 }
 
 /**
+ * Make a value safe to interpolate into the human-readable line.
+ *
+ * The line goes to the runner's stdout, and GitHub parses a workflow command
+ * from *any* line there — after trimming leading whitespace, so indenting a
+ * continuation does not help. Anything that can start a new line therefore has
+ * to go: a lone `\r` is a line boundary to the .NET-based runner, which is why
+ * `escapeAnnotation` escapes it alongside `\n`, and this has to match that
+ * threat model rather than only handling `\n`.
+ *
+ * **Applied to the path as well as the message.** A POSIX filename may contain
+ * anything but `/` and NUL, newline included, and these checks walk directories
+ * a contributor edits freely — so a file named to embed a workflow command is
+ * the most naturally attacker-controlled input here, and it reaches the line
+ * through the path rather than through the message.
+ *
+ * Other control characters are dropped outright: an escape character in a
+ * filename could otherwise repaint the log with ANSI sequences and hide what a
+ * check reported.
+ */
+function oneLine(value) {
+  return String(value)
+    // eslint-disable-next-line no-control-regex -- stripping control characters is the point
+    .replaceAll(/[\u0000-\u0008\v\f\u000E-\u001F\u007F]/g, '')
+    .replaceAll(/\r\n?|\n/g, ' | ')
+}
+
+/**
  * @param {object} options
  * @param {string} options.label       prefix for the summary line, e.g. `docs-lint`
  * @param {string} [options.root]      paths are printed relative to this
@@ -82,13 +109,9 @@ export function createReporter({
     const prefix = level === 'error' ? `${RED}ERROR${RESET}` : `${YELLOW}WARN ${RESET}`
     const body = code ? `${code}: ${message}` : String(message)
 
-    // The printed line is collapsed to one line, not merely indented. GitHub
-    // parses a workflow command from *any* line on stdout and trims leading
-    // whitespace before doing so, so an indented `::add-mask::…` would still be
-    // read as a command — through the human-readable half, which no amount of
-    // escaping the annotation would have caught. Multi-line messages exist:
-    // several checks build a bulleted list into one message.
-    console.log(`${prefix} ${where}${position} ${body.replaceAll(/\r?\n\s*/g, ' | ')}`)
+    // Both halves go through `oneLine` — see its comment for why the path needs
+    // it as much as the message does.
+    console.log(`${prefix} ${oneLine(where)}${position} ${oneLine(body)}`)
 
     if (isCI()) {
       const parts = [`file=${escapeAnnotation(where)}`]

--- a/scripts/_reporter.mjs
+++ b/scripts/_reporter.mjs
@@ -1,0 +1,148 @@
+/**
+ * One way to report a problem, for every check in `scripts/` (#418).
+ *
+ * The checks each grew their own reporting: `ERROR` / `BROKEN` / `V3-DRIFT` / a
+ * bare `CSP …` prefix, four wordings of the summary line, and problems written
+ * to stdout in some and stderr in others. That is survivable. What is not is the
+ * reason this module exists:
+ *
+ * **Only the block gates emitted GitHub annotations.** `docs-typecheck` and its
+ * three siblings go through `checkBlocks`, which writes `::error file=…,line=…`,
+ * so their failures land inline on the pull request diff. The other six wrote
+ * plain text, so a reviewer had to open the job log and find the line by eye —
+ * for exactly the checks a contributor is most likely to trip: a broken link, a
+ * stale `audited:` stamp, a missing API-reference row.
+ *
+ * A shared reporter fixes that once instead of six times, which is the whole
+ * argument of #418: a fix written in one copy reaches everyone.
+ *
+ * What it deliberately does **not** do is flatten the vocabulary. A broken link
+ * is still counted as a broken link in the summary — the level is uniform, the
+ * noun stays the check's own.
+ */
+
+import { relative } from 'node:path'
+
+// Read at emit time, not at import. Capturing it in a module constant makes the
+// annotation path untestable without spawning a subprocess, and means a caller
+// that sets the variable itself is ignored.
+const isCI = () => process.env.GITHUB_ACTIONS === 'true'
+
+const RED = '\u001B[31m'
+const YELLOW = '\u001B[33m'
+const RESET = '\u001B[0m'
+
+/**
+ * GitHub Actions workflow commands use %25/%0D/%0A as escape sequences.
+ * Without escaping, a message containing a literal newline could inject
+ * additional workflow commands (e.g. ::set-env::, ::add-mask::).
+ */
+export function escapeAnnotation(s) {
+  return String(s).replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A')
+}
+
+/**
+ * @param {object} options
+ * @param {string} options.label       prefix for the summary line, e.g. `docs-lint`
+ * @param {string} [options.root]      paths are printed relative to this
+ * @param {string} [options.errorNoun] what an error is called in the summary
+ *   ("error", "broken link", "problem") — singular; `(s)` is appended
+ * @param {string} [options.warnNoun]  same for warnings, default "warning"
+ * @param {number} [options.max]       stop printing after this many problems.
+ *   They are still counted, and the summary says how many were withheld.
+ */
+export function createReporter({
+  label,
+  root = process.cwd(),
+  errorNoun = 'error',
+  warnNoun = 'warning',
+  max = Number.POSITIVE_INFINITY
+} = {}) {
+  let errors = 0
+  let warnings = 0
+  let printed = 0
+  const notes = []
+
+  function emit(level, file, message, { line, col, code } = {}) {
+    if (level === 'error') {
+      errors++
+    } else {
+      warnings++
+    }
+
+    if (printed >= max) {
+      return
+    }
+    printed++
+
+    // A check with nothing to point at — a whole-repository invariant — passes
+    // no file; the line then carries the label so it is still attributable.
+    const where = file ? relative(root, file) : label
+    const position = line === undefined ? '' : `:${line}${col === undefined ? '' : `:${col}`}`
+    const prefix = level === 'error' ? `${RED}ERROR${RESET}` : `${YELLOW}WARN ${RESET}`
+    const body = code ? `${code}: ${message}` : String(message)
+
+    // Newlines are folded out of the printed line, not only out of the
+    // annotation. GitHub parses a workflow command from *any* line on stdout,
+    // so a message carrying a newline could put `::add-mask::…` at the start of
+    // one — through the human-readable half, which no amount of escaping the
+    // annotation would have caught. Multi-line messages exist: several checks
+    // build a bulleted list into one message.
+    console.log(`${prefix} ${where}${position} ${body.replace(/\r?\n/g, '\n  ')}`)
+
+    if (isCI()) {
+      const parts = [`file=${escapeAnnotation(where)}`]
+      if (line !== undefined) {
+        parts.push(`line=${line}`)
+      }
+      if (col !== undefined) {
+        parts.push(`col=${col}`)
+      }
+      process.stdout.write(
+        `::${level === 'error' ? 'error' : 'warning'} ${parts.join(',')}::${escapeAnnotation(body)}\n`
+      )
+    }
+  }
+
+  return {
+    error: (file, message, position) => emit('error', file, message, position),
+    warn: (file, message, position) => emit('warn', file, message, position),
+
+    /** Extra text for the summary line, e.g. "134 internal link(s) checked". */
+    note: text => notes.push(text),
+
+    get errors() {
+      return errors
+    },
+    get warnings() {
+      return warnings
+    },
+
+    /**
+     * Print the summary and return the process exit code.
+     *
+     * One rule everywhere: any error fails; warnings fail only under `strict`.
+     *
+     * @param {object} [options]
+     * @param {boolean} [options.strict] treat warnings as failures
+     * @returns {number} 0 clean, 1 on failure
+     */
+    finish({ strict = false } = {}) {
+      const withheld = errors + warnings - printed
+      const parts = [`${errors} ${errorNoun}(s)`, `${warnings} ${warnNoun}(s)`, ...notes]
+      if (withheld > 0) {
+        parts.push(`${withheld} not shown`)
+      }
+
+      console.log(`\n${label}: ${parts.join(', ')}`)
+
+      if (errors > 0) {
+        return 1
+      }
+      if (strict && warnings > 0) {
+        return 1
+      }
+      return 0
+    }
+  }
+}

--- a/scripts/_reporter.mjs
+++ b/scripts/_reporter.mjs
@@ -82,13 +82,13 @@ export function createReporter({
     const prefix = level === 'error' ? `${RED}ERROR${RESET}` : `${YELLOW}WARN ${RESET}`
     const body = code ? `${code}: ${message}` : String(message)
 
-    // Newlines are folded out of the printed line, not only out of the
-    // annotation. GitHub parses a workflow command from *any* line on stdout,
-    // so a message carrying a newline could put `::add-mask::…` at the start of
-    // one — through the human-readable half, which no amount of escaping the
-    // annotation would have caught. Multi-line messages exist: several checks
-    // build a bulleted list into one message.
-    console.log(`${prefix} ${where}${position} ${body.replace(/\r?\n/g, '\n  ')}`)
+    // The printed line is collapsed to one line, not merely indented. GitHub
+    // parses a workflow command from *any* line on stdout and trims leading
+    // whitespace before doing so, so an indented `::add-mask::…` would still be
+    // read as a command — through the human-readable half, which no amount of
+    // escaping the annotation would have caught. Multi-line messages exist:
+    // several checks build a bulleted list into one message.
+    console.log(`${prefix} ${where}${position} ${body.replaceAll(/\r?\n\s*/g, ' | ')}`)
 
     if (isCI()) {
       const parts = [`file=${escapeAnnotation(where)}`]

--- a/scripts/_typecheck-blocks.mjs
+++ b/scripts/_typecheck-blocks.mjs
@@ -22,17 +22,9 @@
  */
 
 import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs'
-import { join, relative, basename } from 'node:path'
+import { join, basename } from 'node:path'
 import { spawnSync } from 'node:child_process'
-
-const IS_CI = process.env.GITHUB_ACTIONS === 'true'
-
-// GitHub Actions workflow commands use %25/%0D/%0A as escape sequences.
-// Without escaping, a tsc message containing a literal newline could inject
-// additional workflow commands (e.g. ::set-env::, ::add-mask::).
-function escapeAnnotation(s) {
-  return s.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A')
-}
+import { createReporter } from './_reporter.mjs'
 
 /**
  * Extract ```ts / ```typescript fenced blocks from a markdown file.
@@ -132,18 +124,7 @@ export function checkBlocks({ label, repoRoot, checkDir, files, extract = extrac
   const tmpDir = join(checkDir, 'tmp')
   const tsconfigPath = join(checkDir, 'tsconfig.json')
   const tscBin = join(repoRoot, 'node_modules', 'typescript', 'bin', 'tsc')
-  let errors = 0
-
-  function logError(mdFile, mdLine, col, code, message) {
-    const relFile = relative(repoRoot, mdFile)
-    console.log(`\u001B[31mERROR\u001B[0m ${relFile}:${mdLine}:${col} ${code}: ${message}`)
-    if (IS_CI) {
-      process.stdout.write(
-        `::error file=${escapeAnnotation(relFile)},line=${mdLine},col=${col}::${escapeAnnotation(code)}: ${escapeAnnotation(message)}\n`
-      )
-    }
-    errors++
-  }
+  const report = createReporter({ label, root: repoRoot })
 
   if (!existsSync(tscBin)) {
     console.error(`\u001B[31mERROR\u001B[0m ${label}: TypeScript not installed — run \`pnpm install\``)
@@ -206,17 +187,16 @@ export function checkBlocks({ label, repoRoot, checkDir, files, extract = extrac
     const block = blockMap.get(basename(rawPath))
     if (!block) {
       // Error in globals.d.ts or an untracked file — surface it as infrastructure noise.
-      console.error(`\u001B[31mERROR\u001B[0m ${label}: infrastructure error — ${rawPath}: ${code}: ${message}`)
-      errors++
+      report.error(null, `infrastructure error — ${rawPath}: ${message}`, { code })
       continue
     }
     const mdLine = block.startLine + (Number.parseInt(lineStr, 10) - 1)
-    logError(block.filePath, mdLine, Number.parseInt(colStr, 10), code, message)
+    report.error(block.filePath, message, { line: mdLine, col: Number.parseInt(colStr, 10), code })
   }
 
   // Remove tmp on success; keep on failure for local debugging.
-  if (errors === 0) rmSync(tmpDir, { recursive: true })
+  if (report.errors === 0) rmSync(tmpDir, { recursive: true })
 
-  console.log(`\n${label}: ${blockIndex} block(s) checked, ${errors} error(s)`)
-  return errors > 0 ? 1 : 0
+  report.note(`${blockIndex} block(s) checked`)
+  return report.finish()
 }

--- a/scripts/check-api-reference-index.mjs
+++ b/scripts/check-api-reference-index.mjs
@@ -30,6 +30,7 @@
 import { readFileSync, existsSync } from 'node:fs'
 import { dirname, resolve, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { createReporter } from './_reporter.mjs'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 // Overridable so the fixture tests can drive the real entry point end to end,
@@ -272,14 +273,16 @@ function main() {
     )
   }
 
-  if (problems.length > 0) {
-    console.error(
-      `docs/content/docs/3.api-reference/1.index.md is out of sync with the code.\n\n${problems.join('\n\n')}`
-    )
-    process.exit(1)
+  const report = createReporter({ label: 'api-reference-index', root: ROOT })
+  for (const problem of problems) {
+    report.error(PAGE, `the page is out of sync with the code — ${problem}`)
   }
+  report.note(`${exported.size} public value export(s)`)
 
-  console.log(`api-reference index: ${exported.size} public value export(s) — all present, none stale.`)
+  const code = report.finish()
+  if (code !== 0) {
+    process.exit(code)
+  }
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {

--- a/scripts/check-docs-csp-present.mjs
+++ b/scripts/check-docs-csp-present.mjs
@@ -23,7 +23,7 @@
  */
 
 import { readFileSync, existsSync } from 'node:fs'
-import { resolve, dirname, relative } from 'node:path'
+import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { walkFiles } from './_docs-utils.mjs'
 import { createReporter } from './_reporter.mjs'
@@ -56,10 +56,10 @@ const problems = []
 
 for (const file of pages) {
   const html = readFileSync(file, 'utf8')
-  const where = relative(ROOT, file)
+  const at = message => problems.push({ file, message })
   const headStart = html.indexOf('<head>')
   if (headStart < 0) {
-    problems.push(`${where}: no <head>`)
+    at('no <head>')
     continue
   }
   const headEnd = html.indexOf('</head>')
@@ -67,22 +67,22 @@ for (const file of pages) {
     // Unguarded, `indexOf` returns -1 and `slice(start, -1)` silently becomes
     // "the whole document bar its last character" — so the body gets scanned
     // and the "first in <head>" assertion answers about the wrong text.
-    problems.push(`${where}: no closing </head>`)
+    at('no closing </head>')
     continue
   }
   const head = html.slice(headStart + '<head>'.length, headEnd)
   const matches = head.match(TAG) ?? []
 
   if (matches.length === 0) {
-    problems.push(`${where}: no Content-Security-Policy meta tag`)
+    at('no Content-Security-Policy meta tag')
     continue
   }
   if (matches.length > 1) {
-    problems.push(`${where}: ${matches.length} CSP meta tags — both are enforced, as their intersection`)
+    at(`${matches.length} CSP meta tags — both are enforced, as their intersection`)
   }
   const preceding = head.slice(0, head.search(TAG)).trim()
   if (preceding !== '') {
-    problems.push(`${where}: the CSP is not first in <head>; "${preceding.slice(0, 70)}" precedes it`)
+    at(`the CSP is not first in <head>; "${preceding.slice(0, 70)}" precedes it`)
   }
   // Every match, not just the first: with two tags the second could be the one
   // missing a directive, and reporting only "there are two" would name the
@@ -91,7 +91,7 @@ for (const file of pages) {
     for (const directive of REQUIRED) {
       if (!tag.includes(directive)) {
         const which = matches.length > 1 ? ` (tag ${index + 1} of ${matches.length})` : ''
-        problems.push(`${where}: the policy no longer contains ${directive}${which}`)
+        at(`the policy no longer contains ${directive}${which}`)
       }
     }
   }
@@ -106,7 +106,7 @@ const report = createReporter({
   max: 20
 })
 for (const problem of problems) {
-  report.error(null, problem)
+  report.error(problem.file, problem.message)
 }
 report.note(`${pages.length} page(s) checked`)
 process.exit(report.finish())

--- a/scripts/check-docs-csp-present.mjs
+++ b/scripts/check-docs-csp-present.mjs
@@ -26,6 +26,7 @@ import { readFileSync, existsSync } from 'node:fs'
 import { resolve, dirname, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { walkFiles } from './_docs-utils.mjs'
+import { createReporter } from './_reporter.mjs'
 
 const ROOT = process.env.DOCS_CSP_ROOT
   ? resolve(process.env.DOCS_CSP_ROOT)
@@ -96,12 +97,16 @@ for (const file of pages) {
   }
 }
 
-for (const problem of problems.slice(0, 20)) {
-  console.log(`CSP ${problem}`)
+const report = createReporter({
+  label: 'docs-csp-present',
+  root: ROOT,
+  errorNoun: 'problem',
+  // A broken build breaks every page identically; twenty samples say what is
+  // wrong, and the count says how widely.
+  max: 20
+})
+for (const problem of problems) {
+  report.error(null, problem)
 }
-if (problems.length > 20) {
-  console.log(`… and ${problems.length - 20} more`)
-}
-
-console.log(`docs-csp-present: ${problems.length} problem(s) across ${pages.length} page(s)`)
-process.exit(problems.length > 0 ? 1 : 0)
+report.note(`${pages.length} page(s) checked`)
+process.exit(report.finish())

--- a/scripts/check-v3-method-refs.mjs
+++ b/scripts/check-v3-method-refs.mjs
@@ -17,9 +17,10 @@
  */
 
 import { readFileSync } from 'node:fs'
-import { join, resolve, dirname, relative } from 'node:path'
+import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { walkFiles } from './_docs-utils.mjs'
+import { createReporter } from './_reporter.mjs'
 
 const ROOT = process.env.V3_CHECK_ROOT
   ? resolve(process.env.V3_CHECK_ROOT)
@@ -39,12 +40,13 @@ function markdownFiles() {
   return files
 }
 
-let problems = 0
+const report = createReporter({
+  label: 'check-v3-method-refs',
+  root: ROOT,
+  errorNoun: 'problem'
+})
 
-function fail(file, message) {
-  console.log(`\x1B[31mV3-DRIFT\x1B[0m ${relative(ROOT, file)}: ${message}`)
-  problems += 1
-}
+const fail = (file, message) => report.error(file, message)
 
 function checkPhantomActions(file, body) {
   for (const m of body.matchAll(/actions\.v3\.([a-zA-Z]\w*)/g)) {
@@ -66,8 +68,5 @@ for (const file of markdownFiles()) {
   checkPhantomActions(file, body)
 }
 
-if (problems > 0) {
-  console.log(`\ncheck-v3-method-refs: ${problems} problem(s) found`)
-  process.exit(1)
-}
-console.log('check-v3-method-refs: 0 problem(s) across docs, skills, README-AI')
+report.note('across docs, skills, README-AI')
+process.exit(report.finish())

--- a/scripts/docs-link-check.mjs
+++ b/scripts/docs-link-check.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs'
 import { join, resolve, relative, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { walkMarkdownFiles, parseFrontmatter } from './_docs-utils.mjs'
+import { createReporter } from './_reporter.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..')
@@ -12,18 +13,14 @@ const DOCS_ROOT = process.env.DOCS_LINK_CHECK_ROOT
   : join(REPO_ROOT, 'docs', 'content', 'docs')
 const URL_PREFIX = '/docs/'
 
-let errors = 0
-let warnings = 0
+const report = createReporter({
+  label: 'docs-link-check',
+  root: REPO_ROOT,
+  errorNoun: 'broken link'
+})
 
-function logError(file, message) {
-  console.log(`\x1B[31mERROR\x1B[0m ${relative(REPO_ROOT, file)}: ${message}`)
-  errors++
-}
-
-function logWarn(file, message) {
-  console.log(`\x1B[33mWARN \x1B[0m ${relative(REPO_ROOT, file)}: ${message}`)
-  warnings++
-}
+const logError = (file, message) => report.error(file, message)
+const logWarn = (file, message) => report.warn(file, message)
 
 // Map a file path under DOCS_ROOT to its public URL.
 // `1.getting-started/2.installation/3.react.md`
@@ -188,8 +185,7 @@ function main() {
     }
   }
 
-  console.log(`\ndocs-link-check: ${errors} broken link(s), ${warnings} warning(s)`)
-  if (errors > 0) process.exit(1)
+  process.exit(report.finish())
 }
 
 main()

--- a/scripts/docs-lint.mjs
+++ b/scripts/docs-lint.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
 import { readFileSync, statSync, existsSync } from 'node:fs'
-import { join, resolve, relative, dirname } from 'node:path'
+import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { execFileSync } from 'node:child_process'
 import { walkMarkdownFiles, parseFrontmatter, isFreshnessTrackedSource } from './_docs-utils.mjs'
+import { createReporter } from './_reporter.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..')
@@ -27,14 +28,14 @@ const GITHUB_SOURCE_PREFIX = 'https://github.com/bitrix24/b24jssdk/blob/main/'
 
 const STRICT = process.argv.includes('--strict')
 
-let errors = 0
-let warnings = 0
+const report = createReporter({ label: 'docs-lint', root: REPO_ROOT })
 
 function log(level, file, message) {
-  const tag = level === 'error' ? '\x1B[31mERROR\x1B[0m' : '\x1B[33mWARN \x1B[0m'
-  console.log(`${tag} ${relative(REPO_ROOT, file)}: ${message}`)
-  if (level === 'error') errors++
-  else warnings++
+  if (level === 'error') {
+    report.error(file, message)
+  } else {
+    report.warn(file, message)
+  }
 }
 
 function extractGithubLinkPaths(arrayItems) {
@@ -265,9 +266,7 @@ function main() {
     )
   }
 
-  console.log(`\ndocs-lint: ${errors} error(s), ${warnings} warning(s)`)
-  if (errors > 0) process.exit(1)
-  if (STRICT && warnings > 0) process.exit(1)
+  process.exit(report.finish({ strict: STRICT }))
 }
 
 // Run only when executed directly (e.g. `node scripts/docs-lint.mjs`), not when

--- a/scripts/md-internal-links.mjs
+++ b/scripts/md-internal-links.mjs
@@ -18,8 +18,9 @@
  */
 
 import { readFileSync, existsSync, readdirSync } from 'node:fs'
-import { resolve, dirname, join, relative } from 'node:path'
+import { resolve, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { createReporter } from './_reporter.mjs'
 
 // MD_INTERNAL_LINKS_ROOT overrides the scan root (used by the fixture tests).
 const ROOT = process.env.MD_INTERNAL_LINKS_ROOT
@@ -166,7 +167,11 @@ function anchorsFor(resolvedPath) {
   return anchors
 }
 
-let broken = 0
+const report = createReporter({
+  label: 'md-internal-links',
+  root: ROOT,
+  errorNoun: 'broken link'
+})
 let checked = 0
 
 for (const file of targetFiles()) {
@@ -185,8 +190,7 @@ for (const file of targetFiles()) {
     checked += 1
     const resolved = resolve(dir, path)
     if (!existsSync(resolved)) {
-      broken += 1
-      console.log(`\x1B[31mBROKEN\x1B[0m ${relative(ROOT, file)} → ${target}`)
+      report.error(file, `broken link → ${target}`)
       continue
     }
     // A link to a heading that no longer exists lands the reader at the top of
@@ -209,11 +213,10 @@ for (const file of targetFiles()) {
       // A stray `%` that is not an escape — compare it as written.
     }
     if (!anchorsFor(resolved).has(fragment)) {
-      broken += 1
-      console.log(`\x1B[31mBROKEN\x1B[0m ${relative(ROOT, file)} → ${target} (no such heading in ${path})`)
+      report.error(file, `broken link → ${target} (no such heading in ${path})`)
     }
   }
 }
 
-console.log(`\nmd-internal-links: ${broken} broken link(s), ${checked} internal link(s) checked`)
-process.exit(broken > 0 ? 1 : 0)
+report.note(`${checked} internal link(s) checked`)
+process.exit(report.finish())


### PR DESCRIPTION
The remaining half of #418. Discovery was shared in #437; reporting was still written per script.

## The cosmetics are not why this was worth doing

The eleven checks each grew their own: `ERROR` / `BROKEN` / `V3-DRIFT` / a bare `CSP` prefix, four wordings of the summary, problems on stdout in some and stderr in others. Survivable.

What was not: **only the block gates emitted GitHub annotations.** `checkBlocks` writes `::error file=…,line=…`, so a failing fence lands inline on the pull request diff. The other six wrote plain text — a reviewer had to open the job log and find the line by eye, for exactly the checks a contributor trips most often: a broken link, a stale `audited:` stamp, a missing API-reference row.

`scripts/_reporter.mjs` fixes that once instead of six times, which is the argument of #418 in one sentence.

Before:

```
BROKEN AGENTS.md → ./nope.md
md-internal-links: 1 broken link(s), 1 internal link(s) checked
```

After:

```
ERROR AGENTS.md broken link → ./nope.md
::error file=AGENTS.md::broken link → ./nope.md
md-internal-links: 1 broken link(s), 0 warning(s), 1 internal link(s) checked
```

## What is uniform, and what is deliberately not

Uniform: the line shape (`ERROR path:line:col message`), the summary (`label: N …, M warning(s), …`), and one exit rule — **errors always fail, warnings only under `--strict`**.

Not uniform, on purpose: the vocabulary. A broken link is still counted as a broken link and a phantom action as a problem. `1 problem(s)` would be worse for the reader, and unifying the format should not cost that.

## Three defects found while doing it

- **`GITHUB_ACTIONS` was read at import time.** That made the annotation path untestable without spawning a subprocess, and ignored a caller that sets the variable itself. Read at emit time now.
- **Escaping the annotation is not enough.** GitHub parses a workflow command from *any* stdout line, so a message carrying a newline could put `::add-mask::…` at the start of one through the human-readable half. My first fix indented the continuation — which does nothing, because Actions trims leading whitespace before parsing. Caught in review; the printed line is now collapsed onto one line, and the test asserts that rather than the anchor it was accidentally checking. **The hole predates this PR.**
- **`check-docs-csp-present` named no file**, so every annotation would have read `file=docs-csp-present` — a path that does not exist, which GitHub drops. Also caught in review. It now carries the page with each problem. Missed because it is the one script whose output a normal run never shows: it needs a built site.

## Verification

All eleven checks run clean. 132 script tests green (11 new, for the reporter). Annotations verified by running two checks under `GITHUB_ACTIONS=true` against deliberately broken fixtures — including `check-docs-csp-present`, against a built page with no CSP.

Six test assertions were updated where they pinned the old per-script format. Each change is a format this PR is explicitly changing, not a weakened assertion.

## Note

The first commit here was made on `main` by mistake — a `git checkout -b` that failed silently at the start of the work. Nothing was pushed; the commit was moved onto this branch and `main` reset to `origin/main` before any push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_