### PR TITLE
docs(contributing): retire the argument #439 disproved, and refresh the counts

### DIFF
--- a/.github/contributing/package-structure.md
+++ b/.github/contributing/package-structure.md
@@ -1,6 +1,6 @@
 # Package Structure
 
-<sub>Last reviewed: 2026-08-31.</sub>
+<sub>Last reviewed: 2026-09-02.</sub>
 
 > **Agent-facing mirror:** the published surface from the angle of agents writing usage code lives in [`b24jssdk-core/`](../../skills/b24jssdk-core/SKILL.md), [`b24jssdk-frame-ui/`](../../skills/b24jssdk-frame-ui/SKILL.md), and [`b24jssdk-helpers/`](../../skills/b24jssdk-helpers/SKILL.md). Keep this guide and those skills in sync when the underlying API changes.
 
@@ -146,9 +146,10 @@ export type { TypeMyPayload } from './types/payloads'
 
 ## How much of a JSDoc block belongs in the code
 
-The longest block in `packages/jssdk/src/` was 97 lines. Eighteen are over
-thirty. Long comments are not the problem — the ones explaining *why* are the
-most valuable thing in this codebase. **Placement** is (#420).
+The longest block in `packages/jssdk/src/` was 97 lines when this was written;
+it is 55 now, and seventeen of the 746 blocks are still over thirty. Long
+comments are not the problem — the ones explaining *why* are the most valuable
+thing in this codebase. **Placement** is (#420).
 
 ### The threshold
 
@@ -171,16 +172,24 @@ here.
 Reasoning, alternatives considered, history, and worked examples. Two reasons,
 one of them measurable:
 
-- **Examples in JSDoc are compiled by nothing.** There are 57 `@example` blocks
-  in `packages/jssdk/src/`, about 460 lines, and no pass type-checks them —
-  while `ts` fences in `docs/content/**` and `skills/**` are compiled on
-  every CI run (#439). That is not theoretical: three of those examples did not
-  compile, all dereferencing `getData()` without the `!` its
-  `T | null | undefined` return has required since #395. An example in a guide is
-  checked; the same example above the function is not.
 - **A stale claim in the code rots silently.** `docs-lint`, `md-internal-links`
-  and the fence typecheck keep the Markdown guides honest. Nothing watches a
-  comment.
+  and the fence typechecks keep the Markdown guides honest about their links,
+  their freshness stamps and whether their code compiles. Nothing watches a
+  sentence in a comment.
+
+  This is the remaining reason, and it is worth being honest about how the
+  other one went. The original argument here was that JSDoc examples were
+  compiled by nothing while `ts` fences in the guides were compiled on every CI
+  run — 57 `@example` blocks, about 460 lines, unchecked, three of them broken.
+  **That gap is closed:** `jsdoc:typecheck-blocks` has compiled them since #443,
+  43 blocks on every run, and the three broken ones are fixed. An example above
+  a function is now checked exactly as an example in a guide is, so it is no
+  longer a reason to move one.
+
+  Note also what rots and what does not. The paragraph you are reading was
+  itself stale for two days after #443 landed — prose in a guide is no safer
+  from that than prose in a comment. What the gates protect is the *code* in
+  both places; the sentences around it are on us either way.
 
 ### The shape that works
 

--- a/.github/contributing/package-structure.md
+++ b/.github/contributing/package-structure.md
@@ -181,13 +181,13 @@ one of them measurable:
   other one went. The original argument here was that JSDoc examples were
   compiled by nothing while `ts` fences in the guides were compiled on every CI
   run — 57 `@example` blocks, about 460 lines, unchecked, three of them broken.
-  **That gap is closed:** `jsdoc:typecheck-blocks` has compiled them since #443,
+  **That gap is closed:** `jsdoc:typecheck-blocks` has compiled them since #439,
   43 blocks on every run, and the three broken ones are fixed. An example above
   a function is now checked exactly as an example in a guide is, so it is no
   longer a reason to move one.
 
   Note also what rots and what does not. The paragraph you are reading was
-  itself stale for two days after #443 landed — prose in a guide is no safer
+  itself stale for two days after #439 landed — prose in a guide is no safer
   from that than prose in a comment. What the gates protect is the *code* in
   both places; the sentences around it are on us either way.
 

--- a/.github/contributing/testing.md
+++ b/.github/contributing/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-<sub>Last reviewed: 2026-08-31.</sub>
+<sub>Last reviewed: 2026-09-02.</sub>
 
 > **Agent-facing mirror:** recipe `.ts` files under [`skills/b24jssdk-recipes/examples/`](../../skills/b24jssdk-recipes/examples/) are validated by `pnpm run skills:typecheck` against the built SDK types, and their internals by `pnpm run skills:test`. Both install the recipes' own dependencies first — that directory is not a workspace member, so `express` / `grammy` / `node-cron` / `openai` live there rather than in the root manifest; see [README-DEPS.md](../../skills/b24jssdk-recipes/README-DEPS.md) for why. They complement (not replace) the integration suite covered here. When you change the underlying API or its result shapes, refresh both.
 
@@ -241,9 +241,10 @@ Two results from that measurement are worth carrying:
   smoke tests for the published package shape rather than typechecks of the
   playgrounds. An error inside either playground is caught by its own pass and by
   nothing else.
-- **JSDoc `@example` bodies used to be compiled by nothing** — 41 of them, the
-  ones an IDE shows on hover. `jsdoc:typecheck-blocks` closed that in #439; the
-  first run went red on every single block. An `@example` body is extracted from
+- **JSDoc `@example` bodies used to be compiled by nothing** — the ones an IDE
+  shows on hover. `jsdoc:typecheck-blocks` closed that in #439; there were 41
+  then, the first run went red on every single one, and the count moves with the
+  source rather than staying at 41. An `@example` body is extracted from
   the line after the tag to the next tag or the end of the comment, a Markdown
   fence wrapping the whole body is unwrapped as presentation, and a
   `// @check-ignore` first line skips the block. A same-line `@example 'value'`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,8 +318,9 @@ findings about wording.
 
 Check these before adding to the repository, not after:
 
-- **A new script in `scripts/`.** Nine already exist and share one shape; see
-  #418. Ask whether an existing one should grow instead.
+- **A new script in `scripts/`.** Eleven checks already exist over five shared
+  modules; see #418. Ask whether an existing one should grow instead, and report
+  through [`_reporter.mjs`](scripts/_reporter.mjs) if it is genuinely new.
 - **A new `tsconfig.json` or an eleventh `typecheck` pass.** There are already
   ten of each, and #419 measured what every one of them uniquely catches — by
   injection, not by reading configs. Eight are the only thing standing between a
@@ -328,7 +329,7 @@ Check these before adding to the repository, not after:
   before adding the eleventh, and add a row to it if you do. Each pass is
   defensible alone; that is exactly why the total needs watching.
 - **A JSDoc block longer than the function it documents.** The longest in the SDK
-  is 96 lines. If the reasoning is that long it belongs in
+  is 55 lines. If the reasoning is that long it belongs in
   `.github/contributing/`, with a pointer from the code — see #420 for the
   shape that works.
 - **Code written for a use case that does not exist yet.** `aggregate.ts` is the


### PR DESCRIPTION
Refs #420, #418.

## The guidance had two reasons, and one of them is no longer true

`package-structure.md` tells a contributor when a long JSDoc block belongs in a guide instead of the code. It gave two reasons. The first:

> **Examples in JSDoc are compiled by nothing.** There are 57 `@example` blocks in `packages/jssdk/src/`, about 460 lines, and no pass type-checks them — while `ts` fences in `docs/content/**` and `skills/**` are compiled on every CI run (#439). … An example in a guide is checked; the same example above the function is not.

**That gap has been closed since #439.** `jsdoc:typecheck-blocks` compiles them on every run — 43 blocks today — and the three broken examples the passage cites are fixed. An example above a function is now checked exactly as one in a guide is, so it is no longer a reason to move anything.

Removed, and replaced with what the second reason (stale prose rots silently) actually implies once you notice this passage was itself an instance of it: it stood wrong for two days after #439 landed. Prose in a guide is no safer from rot than prose in a comment — what the gates protect is the *code* in both places. Said out loud rather than quietly deleting the half that turned out wrong.

## Counts refreshed, by measuring rather than remembering

| Claim | Was | Is |
| --- | --- | --- |
| longest JSDoc block in the SDK | 97 lines | **55** (#440 moved the two worst) |
| blocks over thirty lines | eighteen | **seventeen**, of 746 |
| scripts in `scripts/` | "nine already exist" | **eleven checks over five shared modules** |
| `@example` blocks | "41 of them" | no longer pinned to a number, and says why |

The same numbers appear in `AGENTS.md`'s "check before adding" list, so they moved too — and that entry now points at `_reporter.mjs`, since a twelfth check should report through it.

## Also checked, and correct

`docs-csp.md` claims "151 pages, the tag first on every one". The built site has exactly 151 HTML pages. Left alone.

## Verification

`lint:md`, `md-internal-links`, `docs-lint --strict` and all four block gates clean; 136 script tests green. No code touched.

`/code-review` caught one thing: the new text credited #443 (the PR) while the paragraph next door credits #439 (the issue). Now consistent on the issue, where the reasoning lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_