### PR TITLE
fix(recipes): validate the portal URLs an install event carries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,10 @@ coverage
 /docs/llms-full.txt
 .claude/channels/
 .claude/debug/
+# Isolated git worktrees a review agent works in — tooling scratch, and the
+# checkout inside is a second copy of this repository, which must never be
+# committed into it.
+.claude/worktrees/
 
 # docs-typecheck generated temp files (scripts/docs-typecheck.mjs)
 .docs-typecheck/tmp/

--- a/docs/content/docs/2.working-with-the-rest-api/79.security.md
+++ b/docs/content/docs/2.working-with-the-rest-api/79.security.md
@@ -1,7 +1,7 @@
 ---
 title: Security for event-receiver apps
 description: 'Two hardening patterns for any server that receives Bitrix24 outbound events or OAuth install/uninstall callbacks: reply 200 before you verify, and compare application_token in constant time.'
-audited: 2026-08-26
+audited: 2026-09-04
 navigation.title: Security
 links:
   - label: Recipe 7 — webhook handler (source)
@@ -137,6 +137,52 @@ async function handleUninstall(req: Request, res: Response) {
 }
 ```
 
+## Pattern 3 — Validate the portal URLs an install event carries
+
+Install is the one callback that **cannot** verify its caller, and no amount of
+care changes that: `application_token` is *issued* by the install event, so a
+first-time handler has nothing to compare against. Bitrix24 sends no pre-shared
+secret with `ONAPPINSTALL`. That is a platform constraint.
+
+So the question is not how to reject a forged install — you cannot — but what a
+forged install is *worth*. That depends entirely on what you do with three
+fields it carries.
+
+| Field | What trusting it means |
+| --- | --- |
+| `client_endpoint` | Where every later REST call for that portal goes. A forged one reads your business data and answers in Bitrix24's place. |
+| `server_endpoint` | Where the SDK POSTs `client_id`, **`client_secret`** and `refresh_token` on every token refresh. A forged one leaks the **application-wide** secret — every portal, not just the one whose `member_id` was guessed. |
+| `domain` | What the other two are checked against, and what your logs will say. |
+
+`server_endpoint` is the one to think about twice, and it is also the one most
+easily got wrong in the other direction: **it is not the portal.** On the cloud
+it is a shared token server — `oauth.bitrix.info` — for every portal, so a check
+that requires it to match `domain` rejects every legitimate cloud install.
+
+What to check before persisting:
+
+- `https:` only, and no credentials embedded in the URL.
+- `client_endpoint` on the same host as `domain`. This needs no list, so it
+  holds for a self-hosted portal whose host nobody could have listed.
+- `domain` and `server_endpoint` each against their own allow-list — and make
+  both configurable. A boxed Bitrix24 lives at whatever domain its owner chose
+  and is its own token server, so hard-coded `*.bitrix24.*` suffixes reject
+  every legitimate on-premise install. Naming one known host is *stronger* than
+  a suffix default, not weaker.
+- Log the reason, answer nothing. Telling the caller which check it tripped
+  turns the endpoint into an oracle for finding one that passes.
+
+With those, the worst a forged install achieves is a corrupted record — that
+portal's calls fail, which is noisy and recoverable. Without them it is a
+credential leak.
+
+**None of this makes the endpoint safe to expose carelessly.** It is still an
+unauthenticated write to your datastore, so put it behind a network control: an
+allow-list of Bitrix24's egress ranges, or a secret path segment.
+
+[Recipe 12](/docs/examples/oauth-install/) implements this in
+`skills/b24jssdk-recipes/lib/portal-url.ts`.
+
 ## Checklist
 
 **Every event-receiver endpoint** (`event.bind` handlers):
@@ -154,6 +200,7 @@ async function handleUninstall(req: Request, res: Response) {
 - On uninstall, verify `application_token` **before** deleting credentials.
 - Treat a missing record as idempotent success (no error — it is already gone).
 - Store tokens with restrictive permissions (file mode `0o600` or a datastore with per-tenant isolation).
+- **Validate the portal URLs before persisting them** (Pattern 3), and put `/install` behind a network control.
 
 ## See also
 

--- a/docs/content/docs/99.examples/12.oauth-install.md
+++ b/docs/content/docs/99.examples/12.oauth-install.md
@@ -26,6 +26,14 @@ Use this as the scaffold for a multi-tenant backend that serves many Bitrix24 po
 **Security.** The install / uninstall URLs are publicly reachable. Follow the two hardening patterns in [Security for event-receiver apps](/docs/working-with-the-rest-api/security/) — reply `200` before verifying, and verify `application_token` in constant time **before deleting credentials** on uninstall.
 ::
 
+::warning
+**The install endpoint cannot authenticate its caller, and no code can change that.** `application_token` is *issued* by the install event, so a first-time handler has nothing to compare against. Anyone who reaches `/install` and knows a `member_id` can post an install for that portal.
+
+What the recipe does control is what a forged install is *worth*. The stored `client_endpoint` decides where the app's REST calls go, and `server_endpoint` is where the SDK posts `client_id`, **`client_secret`** and `refresh_token` on every token refresh — so an unchecked forgery does not merely corrupt one portal's record, it hands over the application-wide secret. The recipe therefore validates all three URLs before persisting them (see `B24_ALLOWED_PORTAL_HOSTS` below), which leaves a forged install able to break one portal's calls and nothing more.
+
+That is a reduction, not a fix. **Put `/install` behind a network control** — an allow-list of Bitrix24's egress ranges, or a secret path segment — as you would any unauthenticated endpoint that writes to your database.
+::
+
 ## Stack
 
 Node.js 20+, `express`.
@@ -47,7 +55,21 @@ export B24_CLIENT_SECRET='...'
 # .oauth-store.json in the working directory, which is rarely where you
 # want portal credentials to live on a real server.
 export B24_OAUTH_STORE='/var/lib/myapp/tokens.json'
+
+# Optional, and required for self-hosted portals. Which hosts an install event
+# may name, comma-separated. An entry starting with a dot is a suffix.
+#
+# The defaults cover the cloud: `.bitrix24.com`, `.bitrix24.ru` and the other
+# regional suffixes for the portal, and `oauth.bitrix.info` /
+# `oauth.bitrix24.tech` for the token server. A boxed Bitrix24 lives at
+# whatever domain its owner chose and is its own token server, so it is
+# rejected until you name it — and naming one known host is *stronger* than
+# the cloud default, not weaker.
+export B24_ALLOWED_PORTAL_HOSTS='intranet.example.com'
+export B24_ALLOWED_OAUTH_HOSTS='intranet.example.com'
 ```
+
+`server_endpoint` is not the portal. On the cloud it is a shared token server for every portal, which is why it has its own list rather than being required to match `domain`.
 
 In the Bitrix24 dev console:
 

--- a/skills/b24jssdk-recipes/SKILL.md
+++ b/skills/b24jssdk-recipes/SKILL.md
@@ -72,6 +72,7 @@ Check for the recipe's startup log line rather than trusting the exit code.
 | --- | --- | --- |
 | `lib/funnel.ts` | `baseStage`, `analyseFunnel`, `DealRow`, `StageStat` | recipes 01, 03, 06 |
 | `lib/crypto.ts` | `safeEqual` | recipes 07, 12 |
+| `lib/portal-url.ts` | `checkPortalUrls` | recipe 12 |
 
 `baseStage(s)` strips the multi-funnel category prefix (`"C2:WON"` → `"WON"`), falling
 back to the original string when the part after the colon is empty (`"C2:"` → `"C2:"`).

--- a/skills/b24jssdk-recipes/examples/12-oauth-install.ts
+++ b/skills/b24jssdk-recipes/examples/12-oauth-install.ts
@@ -309,6 +309,18 @@ async function main() {
     throw new Error('B24_CLIENT_ID and B24_CLIENT_SECRET env vars are required')
   }
 
+  // Say this at startup, not only when the first install is refused. Portal-URL
+  // validation fails closed, and it fails quietly from Bitrix24's side — the
+  // endpoint still answers 200, so a self-hosted operator who has not set the
+  // allow-lists sees installs simply not arrive. One line here is the
+  // difference between "nothing works" and "I know which env var to set".
+  if (!process.env.B24_ALLOWED_PORTAL_HOSTS && !process.env.B24_ALLOWED_OAUTH_HOSTS) {
+    logger.info(
+      'portal-URL validation is using the Bitrix24 cloud defaults; a self-hosted portal '
+      + 'must set B24_ALLOWED_PORTAL_HOSTS and B24_ALLOWED_OAUTH_HOSTS or its installs will be refused'
+    )
+  }
+
   const port = Number(process.env.PORT ?? 3001)
   const app = express()
   app.use(express.json())

--- a/skills/b24jssdk-recipes/examples/12-oauth-install.ts
+++ b/skills/b24jssdk-recipes/examples/12-oauth-install.ts
@@ -41,6 +41,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { safeEqual } from '../lib/crypto'
+import { checkPortalUrls } from '../lib/portal-url'
 
 const logger = Logger.create('OAuthInstall')
 logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO, { useStyles: false }))
@@ -155,7 +156,28 @@ export function toOAuthParams(auth: InstallEventPayload['auth']): B24OAuthParams
   }
 }
 
-async function handleInstall(req: Request, res: Response) {
+/**
+ * Handle `ONAPPINSTALL`.
+ *
+ * **This endpoint cannot authenticate its caller, and that is a platform
+ * constraint rather than an omission here:** `application_token` is *issued* by
+ * this very event, so a first-time handler has nothing to compare against. Any
+ * POST that reaches `/install` is therefore accepted, and someone who knows or
+ * guesses a `member_id` can overwrite that portal's record (#389).
+ *
+ * What that is *worth* to them is the part this code controls. The stored
+ * `domain` / `client_endpoint` / `server_endpoint` decide where every later call
+ * for the portal goes, so without a check a forged install redirects the app's
+ * own traffic — with its business data — to the forger's server, whose answers
+ * the app then trusts. `checkPortalUrls` removes that: the worst a forged
+ * install can do is corrupt a record so calls fail, which is noisy and
+ * recoverable.
+ *
+ * It does **not** make the endpoint safe to expose carelessly. Put it behind
+ * whatever network control your deployment allows — an allow-list of Bitrix24's
+ * ranges, or a secret path segment — and read the security guide.
+ */
+export async function handleInstall(req: Request, res: Response) {
   const payload = req.body as InstallEventPayload
   // Always 200 — even on bad payloads — so Bitrix24 doesn't retry for 24h.
   res.status(200).send('ok')
@@ -165,7 +187,23 @@ async function handleInstall(req: Request, res: Response) {
     return
   }
 
+  const badUrls = checkPortalUrls(payload.auth)
+  if (badUrls !== null) {
+    // Log the reason, answer nothing: telling the caller which check it tripped
+    // turns the endpoint into an oracle for finding one that passes.
+    logger.warning(`[install] refusing implausible portal URLs for member=${payload.auth.member_id}: ${badUrls}`)
+    return
+  }
+
   const params = toOAuthParams(payload.auth)
+
+  // Not protection — observability. A legitimate reinstall lands here too, so
+  // this cannot refuse; what it can do is stop a silent takeover being silent.
+  const existing = await getCredentials(params.memberId)
+  if (existing) {
+    logger.warning(`[install] overwriting existing credentials for member=${params.memberId}`)
+  }
+
   await saveCredentials(params.memberId, {
     ...params,
     applicationToken: payload.auth.application_token

--- a/skills/b24jssdk-recipes/lib/portal-url.ts
+++ b/skills/b24jssdk-recipes/lib/portal-url.ts
@@ -1,0 +1,176 @@
+/**
+ * Validation for the portal URLs an install event carries (#389).
+ *
+ * `ONAPPINSTALL` hands you `domain`, `client_endpoint` and `server_endpoint`,
+ * and an app that persists them is trusting them: every later call for that
+ * portal goes wherever they point. The install endpoint cannot authenticate its
+ * caller — `application_token` is *issued* by that very event, so a first-time
+ * handler has nothing to compare against — which means a forged install is
+ * possible by design, and the question is what it can achieve.
+ *
+ * Without a check it achieves two things, and the second is worse than #389
+ * describes. `client_endpoint` redirects the app's REST calls, so its business
+ * data goes to the forger and it reads the forger's answers as Bitrix24's.
+ * `server_endpoint` is where the SDK POSTs `client_id`, **`client_secret`** and
+ * `refresh_token` on every token refresh (`oauth/auth.ts`) — so a forged one
+ * hands over the application-wide secret, compromising every portal rather than
+ * the one whose `member_id` was guessed.
+ *
+ * With the check, the worst a forged install can do is corrupt a record so
+ * calls for that portal fail — noisy, recoverable, and not a leak.
+ *
+ * Three layers, because they fail for different reasons:
+ *
+ *   1. **Shape.** `https:` only, no embedded credentials. Works everywhere.
+ *   2. **Consistency.** `client_endpoint` must be on the same host as `domain`.
+ *      Needs no list, so it holds for a self-hosted portal too.
+ *   3. **Host allowlist**, separately for the portal and for the OAuth server —
+ *      they are genuinely different hosts, which is the part that is easy to
+ *      get wrong. See below.
+ *
+ * **`server_endpoint` is not the portal.** On the cloud it is the shared token
+ * server — `https://oauth.bitrix.info/rest/` — for every portal, so requiring it
+ * to match `domain` would reject every legitimate cloud install. That mistake
+ * was caught here by a test, not by reading: the existing fixture for this
+ * recipe had it right all along.
+ *
+ * **Both allowlists have to be configurable, and that is not a detail.** A
+ * self-hosted (boxed) Bitrix24 lives at whatever domain its owner chose —
+ * `intranet.example.com` — and is its own OAuth server, so hard-coded
+ * `*.bitrix24.*` suffixes would reject every legitimate on-premise install. The
+ * defaults cover the cloud; `B24_ALLOWED_PORTAL_HOSTS` and
+ * `B24_ALLOWED_OAUTH_HOSTS` replace them. An app serving self-hosted customers
+ * must set them, and setting them to one known host each is *stronger* than the
+ * cloud default, not weaker.
+ */
+
+/** Cloud portal suffixes. A leading dot, so `evil-bitrix24.com` cannot match. */
+const DEFAULT_ALLOWED_SUFFIXES = [
+  '.bitrix24.com',
+  '.bitrix24.ru',
+  '.bitrix24.by',
+  '.bitrix24.kz',
+  '.bitrix24.ua',
+  '.bitrix24.de',
+  '.bitrix24.eu',
+  '.bitrix24.pl',
+  '.bitrix24.es',
+  '.bitrix24.fr',
+  '.bitrix24.it',
+  '.bitrix24.com.br',
+  '.bitrix24.in',
+  '.bitrix24.vn',
+  '.bitrix24.jp',
+  '.bitrix24.tr'
+]
+
+/** Cloud OAuth token servers. Not portal hosts — see the header. */
+const DEFAULT_ALLOWED_OAUTH_HOSTS = ['oauth.bitrix.info', 'oauth.bitrix24.tech']
+
+/**
+ * Hosts an install event may name.
+ *
+ * `B24_ALLOWED_PORTAL_HOSTS` is a comma-separated list. An entry starting with
+ * a dot is a suffix (`.bitrix24.com` matches `acme.bitrix24.com` but not
+ * `bitrix24.com` itself and not `evil-bitrix24.com`); anything else is an exact
+ * host, which is what a self-hosted deployment wants.
+ */
+function allowedHosts(variable: string, fallback: string[]): string[] {
+  const configured = process.env[variable]
+  if (configured === undefined || configured.trim() === '') {
+    return fallback
+  }
+
+  return configured
+    .split(',')
+    .map(entry => entry.trim().toLowerCase())
+    .filter(entry => entry !== '')
+}
+
+function hostIsAllowed(host: string, allowed: string[]): boolean {
+  const lower = host.toLowerCase()
+  return allowed.some(entry => (entry.startsWith('.') ? lower.endsWith(entry) : lower === entry))
+}
+
+/**
+ * The host of a `domain` field, which arrives bare (`acme.bitrix24.com`) rather
+ * than as a URL. Returns `null` if it is not a plausible host — an empty
+ * string, a URL, something with a slash or a colon in it.
+ */
+function domainHost(domain: string): string | null {
+  if (domain === '' || /[/\\:\s]/.test(domain)) {
+    return null
+  }
+  return domain.toLowerCase()
+}
+
+/** One endpoint URL, parsed and shape-checked. Returns `null` if unusable. */
+function endpointHost(value: string): string | null {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    return null
+  }
+
+  // `https:` only — an `http:` endpoint would carry the access token in clear,
+  // and anything else (`javascript:`, `file:`) has no business here at all.
+  if (url.protocol !== 'https:') {
+    return null
+  }
+
+  // `https://portal@attacker.example/` parses with host `attacker.example`, so
+  // a reader eyeballing the stored value can be fooled even when the check is
+  // not. Refuse rather than normalise.
+  if (url.username !== '' || url.password !== '') {
+    return null
+  }
+
+  return url.hostname.toLowerCase()
+}
+
+/**
+ * Check the portal URLs from an install payload.
+ *
+ * @returns `null` when they are acceptable, or a reason string naming what
+ *   failed. The reason is for the app's own log — do not send it back to the
+ *   caller, which would tell a prober which check it tripped.
+ */
+export function checkPortalUrls(auth: {
+  domain: string
+  client_endpoint: string
+  server_endpoint: string
+}): string | null {
+  const domain = domainHost(auth.domain)
+  if (domain === null) {
+    return 'domain is not a plausible host'
+  }
+
+  if (!hostIsAllowed(domain, allowedHosts('B24_ALLOWED_PORTAL_HOSTS', DEFAULT_ALLOWED_SUFFIXES))) {
+    return 'domain host is not allowed (set B24_ALLOWED_PORTAL_HOSTS for a self-hosted portal)'
+  }
+
+  // The portal's own REST endpoint. This one must be the portal, which holds
+  // even for a host nobody could have put on a list.
+  const clientHost = endpointHost(auth.client_endpoint)
+  if (clientHost === null) {
+    return 'client_endpoint is not an https URL without credentials'
+  }
+  if (clientHost !== domain) {
+    return 'client_endpoint host does not match domain'
+  }
+
+  // The OAuth token server, which on the cloud is shared and is *not* the
+  // portal — so this cannot be the same check. A self-hosted portal is its own
+  // token server, hence the second branch.
+  const serverHost = endpointHost(auth.server_endpoint)
+  if (serverHost === null) {
+    return 'server_endpoint is not an https URL without credentials'
+  }
+  const oauthAllowed = allowedHosts('B24_ALLOWED_OAUTH_HOSTS', DEFAULT_ALLOWED_OAUTH_HOSTS)
+  if (serverHost !== domain && !hostIsAllowed(serverHost, oauthAllowed)) {
+    return 'server_endpoint is neither the portal nor a known OAuth server (set B24_ALLOWED_OAUTH_HOSTS)'
+  }
+
+  return null
+}

--- a/skills/b24jssdk-recipes/lib/portal-url.ts
+++ b/skills/b24jssdk-recipes/lib/portal-url.ts
@@ -44,7 +44,17 @@
  * cloud default, not weaker.
  */
 
-/** Cloud portal suffixes. A leading dot, so `evil-bitrix24.com` cannot match. */
+/**
+ * Cloud portal suffixes. A leading dot, so `evil-bitrix24.com` cannot match.
+ *
+ * **This list is a snapshot and will go stale.** When Bitrix24 opens a region
+ * this does not name, installs from it are refused until someone edits this
+ * array — and nothing will tell you, because the failure looks like "installs
+ * stopped arriving". That is the price of failing closed, taken deliberately:
+ * the alternative is accepting an unknown host, which is the hole this exists
+ * to shut. An app that knows its own customers should narrow both lists with
+ * the environment variables rather than rely on this staying current.
+ */
 const DEFAULT_ALLOWED_SUFFIXES = [
   '.bitrix24.com',
   '.bitrix24.ru',
@@ -81,10 +91,42 @@ function allowedHosts(variable: string, fallback: string[]): string[] {
     return fallback
   }
 
-  return configured
+  const entries = configured
     .split(',')
     .map(entry => entry.trim().toLowerCase())
     .filter(entry => entry !== '')
+
+  // A value like `,` is non-empty but parses to nothing, which would refuse
+  // every install — an outage that looks like the portal has gone quiet rather
+  // than like a typo. Fail loudly at the point of the mistake instead.
+  if (entries.length === 0) {
+    throw new Error(`${variable} is set but lists no hosts`)
+  }
+
+  // `.com` would re-open exactly the hole this file closes: every `*.com` host
+  // accepted. A suffix has to name something you control, which means at least
+  // two labels after the leading dot.
+  for (const entry of entries) {
+    if (entry.startsWith('.') && entry.slice(1).split('.').filter(Boolean).length < 2) {
+      throw new Error(`${variable} entry "${entry}" is too broad — a suffix must name a domain, not a TLD`)
+    }
+  }
+
+  return entries
+}
+
+/**
+ * A syntactically plausible hostname: at least two non-empty labels, each of
+ * letters, digits and hyphens.
+ *
+ * Without the "non-empty label" part, the bare string `.bitrix24.com` passes
+ * `endsWith('.bitrix24.com')` and is accepted as a portal. No resolver would
+ * answer for it, so it is not a route to an attacker's host — but accepting a
+ * value that cannot exist is the kind of gap that becomes one later.
+ */
+function isPlausibleHost(host: string): boolean {
+  const labels = host.split('.')
+  return labels.length >= 2 && labels.every(label => /^[a-z0-9-]+$/.test(label))
 }
 
 function hostIsAllowed(host: string, allowed: string[]): boolean {
@@ -98,10 +140,8 @@ function hostIsAllowed(host: string, allowed: string[]): boolean {
  * string, a URL, something with a slash or a colon in it.
  */
 function domainHost(domain: string): string | null {
-  if (domain === '' || /[/\\:\s]/.test(domain)) {
-    return null
-  }
-  return domain.toLowerCase()
+  const lower = domain.toLowerCase()
+  return isPlausibleHost(lower) ? lower : null
 }
 
 /** One endpoint URL, parsed and shape-checked. Returns `null` if unusable. */
@@ -126,7 +166,8 @@ function endpointHost(value: string): string | null {
     return null
   }
 
-  return url.hostname.toLowerCase()
+  const host = url.hostname.toLowerCase()
+  return isPlausibleHost(host) ? host : null
 }
 
 /**

--- a/test/integration/skills-recipes/oauth-install.unit.spec.ts
+++ b/test/integration/skills-recipes/oauth-install.unit.spec.ts
@@ -227,3 +227,126 @@ describe('handleUninstall (recipe 12)', () => {
     expect(existsSync(storeFile)).toBe(false)
   })
 })
+
+/**
+ * #389 — `handleInstall` cannot authenticate its caller, so what a forged
+ * install can *achieve* is the thing under test.
+ *
+ * The endpoint accepts any POST by design: `application_token` is issued by
+ * this very event, so a first-time handler has nothing to compare against.
+ * What it must not do is persist portal URLs that redirect the app's later
+ * traffic — that turns a forged install from "corrupt one record" into "read
+ * the app's business data and answer for Bitrix24".
+ */
+describe('handleInstall (recipe 12)', () => {
+  const installPayload = (over: Record<string, string> = {}) => ({
+    event: 'ONAPPINSTALL',
+    data: { VERSION: '1', ACTIVE: '1', LANGUAGE_ID: 'en' },
+    ts: '1893456000',
+    auth: authPayload(over)
+  })
+
+  it('stores the credentials for a plausible payload', async () => {
+    writeStore({})
+    const { handleInstall } = await loadRecipe()
+    const { res, state } = fakeRes()
+
+    await handleInstall({ body: installPayload() } as never, res as never)
+
+    expect(state.code).toBe(200)
+    expect(readStore()['member-abc'].accessToken).toBe('at-1')
+  })
+
+  it('always answers 200, so Bitrix24 does not retry for 24h', async () => {
+    writeStore({})
+    const { handleInstall } = await loadRecipe()
+    const { res, state } = fakeRes()
+
+    await handleInstall({ body: { event: 'ONAPPINSTALL', auth: {} } } as never, res as never)
+
+    expect(state.code).toBe(200)
+  })
+
+  // The attack this closes. Each of these payloads would otherwise be persisted
+  // verbatim, and every later `clientForMember()` call for that portal would go
+  // to the attacker's host carrying whatever the app sends.
+  for (const [name, over] of [
+    ['an endpoint on a foreign host', { client_endpoint: 'https://attacker.example/rest/' }],
+    // Worse than the client one: the SDK POSTs client_id, client_secret and
+    // refresh_token here on every refresh, so a forged server_endpoint leaks
+    // the application-wide secret, not just this portal's data.
+    ['a server endpoint on a foreign host', { server_endpoint: 'https://attacker.example/rest/' }],
+    ['a lookalike domain', { domain: 'evil-bitrix24.com', client_endpoint: 'https://evil-bitrix24.com/rest/', server_endpoint: 'https://evil-bitrix24.com/rest/' }],
+    ['a plain-http endpoint', { client_endpoint: 'http://acme.bitrix24.com/rest/' }],
+    // Host matches `domain`, so the consistency check passes it — only the
+    // credentials check refuses it. Written the other way round (credentials
+    // naming the portal, host naming the attacker) the test would pass for the
+    // wrong reason, which is how it was written first.
+    ['credentials embedded in the URL', { client_endpoint: 'https://user:pass@acme.bitrix24.com/rest/' }],
+    ['a domain that is really a URL', { domain: 'https://attacker.example' }]
+  ] as const) {
+    it(`refuses ${name}, leaving any existing record intact`, async () => {
+      writeStore({ 'member-abc': { applicationToken: 'real-token', accessToken: 'real-at' } })
+      const { handleInstall } = await loadRecipe()
+      const { res, state } = fakeRes()
+
+      await handleInstall({ body: installPayload(over) } as never, res as never)
+
+      expect(state.code).toBe(200)
+      expect(readStore()['member-abc'].accessToken).toBe('real-at')
+    })
+  }
+
+  it('accepts the shared cloud OAuth server, which is not the portal host', async () => {
+    // `server_endpoint` is `oauth.bitrix.info` for every cloud portal. Requiring
+    // it to match `domain` would reject every legitimate cloud install — which
+    // is exactly what the first version of this check did.
+    writeStore({})
+    const { handleInstall } = await loadRecipe()
+    const { res } = fakeRes()
+
+    await handleInstall({
+      body: installPayload({ server_endpoint: 'https://oauth.bitrix24.tech/rest/' })
+    } as never, res as never)
+
+    expect(readStore()['member-abc'].accessToken).toBe('at-1')
+  })
+
+  it('accepts a self-hosted portal once its host is allow-listed', async () => {
+    // The check would otherwise reject every on-premise install, since a boxed
+    // portal lives at whatever domain its owner chose.
+    writeStore({})
+    process.env.B24_ALLOWED_PORTAL_HOSTS = 'intranet.example.com'
+    try {
+      const { handleInstall } = await loadRecipe()
+      const { res } = fakeRes()
+
+      await handleInstall({
+        body: installPayload({
+          domain: 'intranet.example.com',
+          client_endpoint: 'https://intranet.example.com/rest/',
+          server_endpoint: 'https://intranet.example.com/rest/'
+        })
+      } as never, res as never)
+
+      expect(readStore()['member-abc'].accessToken).toBe('at-1')
+    } finally {
+      delete process.env.B24_ALLOWED_PORTAL_HOSTS
+    }
+  })
+
+  it('still refuses a foreign host when an allow-list is configured', async () => {
+    writeStore({})
+    process.env.B24_ALLOWED_PORTAL_HOSTS = 'intranet.example.com'
+    try {
+      const { handleInstall } = await loadRecipe()
+      const { res } = fakeRes()
+
+      await handleInstall({ body: installPayload() } as never, res as never)
+
+      expect(readStore()).toEqual({})
+    } finally {
+      delete process.env.B24_ALLOWED_PORTAL_HOSTS
+    }
+  })
+})

--- a/test/integration/skills-recipes/oauth-install.unit.spec.ts
+++ b/test/integration/skills-recipes/oauth-install.unit.spec.ts
@@ -283,7 +283,23 @@ describe('handleInstall (recipe 12)', () => {
     // naming the portal, host naming the attacker) the test would pass for the
     // wrong reason, which is how it was written first.
     ['credentials embedded in the URL', { client_endpoint: 'https://user:pass@acme.bitrix24.com/rest/' }],
-    ['a domain that is really a URL', { domain: 'https://attacker.example' }]
+    ['a plain-http server endpoint', { server_endpoint: 'http://oauth.bitrix.info/rest/' }],
+    ['credentials in the server endpoint', { server_endpoint: 'https://user:pass@oauth.bitrix.info/rest/' }],
+    ['a domain that is really a URL', { domain: 'https://attacker.example' }],
+    // Ends with an allowed suffix, so the allow-list would pass it. Only the
+    // hostname-shape check refuses it — which is the point: without a case like
+    // this, disabling that check leaves every test green.
+    ['a path smuggled into the domain', {
+      domain: 'attacker.example/acme.bitrix24.com',
+      client_endpoint: 'https://attacker.example/acme.bitrix24.com/rest/'
+    }],
+    // A bare suffix has an empty leftmost label, so no resolver would answer for
+    // it — but `.bitrix24.com`.endsWith(`.bitrix24.com`) is true, so the
+    // allow-list alone would accept it.
+    ['a domain that is only a suffix', {
+      domain: '.bitrix24.com',
+      client_endpoint: 'https://.bitrix24.com/rest/'
+    }]
   ] as const) {
     it(`refuses ${name}, leaving any existing record intact`, async () => {
       writeStore({ 'member-abc': { applicationToken: 'real-token', accessToken: 'real-at' } })
@@ -335,6 +351,57 @@ describe('handleInstall (recipe 12)', () => {
     }
   })
 
+  it('refuses an OAuth server that is neither the portal nor on the list', async () => {
+    // `B24_ALLOWED_OAUTH_HOSTS` had no coverage at all, so nothing pinned that
+    // narrowing it actually narrows anything.
+    writeStore({})
+    process.env.B24_ALLOWED_OAUTH_HOSTS = 'oauth.bitrix.info'
+    try {
+      const { handleInstall } = await loadRecipe()
+      const { res } = fakeRes()
+
+      await handleInstall({
+        body: installPayload({ server_endpoint: 'https://oauth.bitrix24.tech/rest/' })
+      } as never, res as never)
+
+      expect(readStore()).toEqual({})
+    } finally {
+      delete process.env.B24_ALLOWED_OAUTH_HOSTS
+    }
+  })
+
+  it('refuses an allow-list that lists no hosts, rather than refusing everything quietly', async () => {
+    // `,` is non-empty but parses to nothing. Silently allowing nothing is an
+    // outage that looks like the portal has gone quiet.
+    writeStore({})
+    process.env.B24_ALLOWED_PORTAL_HOSTS = ','
+    try {
+      const { handleInstall } = await loadRecipe()
+      const { res } = fakeRes()
+
+      await expect(
+        handleInstall({ body: installPayload() } as never, res as never)
+      ).rejects.toThrow(/lists no hosts/)
+    } finally {
+      delete process.env.B24_ALLOWED_PORTAL_HOSTS
+    }
+  })
+
+  it('refuses a suffix broad enough to re-open the hole', async () => {
+    writeStore({})
+    process.env.B24_ALLOWED_PORTAL_HOSTS = '.com'
+    try {
+      const { handleInstall } = await loadRecipe()
+      const { res } = fakeRes()
+
+      await expect(
+        handleInstall({ body: installPayload() } as never, res as never)
+      ).rejects.toThrow(/too broad/)
+    } finally {
+      delete process.env.B24_ALLOWED_PORTAL_HOSTS
+    }
+  })
+
   it('still refuses a foreign host when an allow-list is configured', async () => {
     writeStore({})
     process.env.B24_ALLOWED_PORTAL_HOSTS = 'intranet.example.com'
@@ -348,5 +415,80 @@ describe('handleInstall (recipe 12)', () => {
     } finally {
       delete process.env.B24_ALLOWED_PORTAL_HOSTS
     }
+  })
+})
+
+/**
+ * `checkPortalUrls` directly, asserting *which* check refused.
+ *
+ * Driving it through `handleInstall` cannot do this. The layers overlap on
+ * purpose — a malformed `domain` that still ends with an allowed suffix also
+ * fails the `client_endpoint === domain` comparison, so disabling either shape
+ * check alone leaves every black-box test green. That is defence in depth
+ * working, and it is also why two tests here were vacuous before this block
+ * existed. Asserting the reason string is what tells the layers apart.
+ */
+describe('checkPortalUrls (recipe 12)', () => {
+  const auth = (over: Record<string, string> = {}) => ({
+    domain: 'acme.bitrix24.com',
+    client_endpoint: 'https://acme.bitrix24.com/rest/',
+    server_endpoint: 'https://oauth.bitrix.info/rest/',
+    ...over
+  })
+
+  it('accepts a normal cloud payload', async () => {
+    const { checkPortalUrls } = await import('../../../skills/b24jssdk-recipes/lib/portal-url')
+    expect(checkPortalUrls(auth())).toBeNull()
+  })
+
+  it('accepts a cloud portal that names itself as its own token server', async () => {
+    const { checkPortalUrls } = await import('../../../skills/b24jssdk-recipes/lib/portal-url')
+    expect(checkPortalUrls(auth({ server_endpoint: 'https://acme.bitrix24.com/rest/' }))).toBeNull()
+  })
+
+  it('is not fooled by case', async () => {
+    const { checkPortalUrls } = await import('../../../skills/b24jssdk-recipes/lib/portal-url')
+    expect(checkPortalUrls(auth({
+      domain: 'ACME.BITRIX24.COM',
+      client_endpoint: 'https://ACME.BITRIX24.COM/rest/'
+    }))).toBeNull()
+  })
+
+  // Each of these ends with an allowed suffix, so the allow-list would pass it.
+  // The reason string proves the shape check is what refuses it.
+  for (const [name, domain] of [
+    ['a path smuggled in', 'attacker.example/acme.bitrix24.com'],
+    ['a bare suffix with no leftmost label', '.bitrix24.com'],
+    ['an empty label in the middle', 'acme..bitrix24.com'],
+    ['a port', 'acme.bitrix24.com:8443'],
+    ['whitespace', 'acme .bitrix24.com'],
+    // A single label is a host on a local network, never a portal. It is also
+    // the only case the "at least two labels" clause uniquely catches — without
+    // it the allow-list refuses this, but for a different reason.
+    ['a single label', 'localhost']
+  ] as const) {
+    it(`refuses ${name} on shape, not on the allow-list`, async () => {
+      const { checkPortalUrls } = await import('../../../skills/b24jssdk-recipes/lib/portal-url')
+      expect(checkPortalUrls(auth({ domain }))).toBe('domain is not a plausible host')
+    })
+  }
+
+  it('refuses an endpoint whose host is not a plausible host', async () => {
+    const { checkPortalUrls } = await import('../../../skills/b24jssdk-recipes/lib/portal-url')
+    // An IPv6 literal parses, and `hostname` keeps the brackets. A portal is
+    // never one, and letting it through would compare bracketed text to a name.
+    expect(checkPortalUrls(auth({ client_endpoint: 'https://[::1]/rest/' })))
+      .toBe('client_endpoint is not an https URL without credentials')
+  })
+
+  it('names the domain check before the endpoint checks', async () => {
+    // Order matters for the log: a payload wrong in several ways should report
+    // the first thing wrong with it, not the last.
+    const { checkPortalUrls } = await import('../../../skills/b24jssdk-recipes/lib/portal-url')
+    expect(checkPortalUrls({
+      domain: 'attacker.example',
+      client_endpoint: 'http://attacker.example/rest/',
+      server_endpoint: 'http://attacker.example/rest/'
+    })).toMatch(/^domain host is not allowed/)
   })
 })


### PR DESCRIPTION
Closes #389.

## The problem is not that install is unauthenticated — it is what that is worth

Recipe 12's `/install` accepts any POST and persists `domain`, `client_endpoint` and `server_endpoint` verbatim. It **cannot** authenticate its caller, and no code changes that: `application_token` is *issued* by the install event, so a first-time handler has nothing to compare against. The uninstall path next door has verified it in constant time since #388; the asymmetry is easy to miss because the two sit together.

So the question is what a forged install achieves. Reading `oauth/auth.ts` while writing this made it **worse than #389 describes**:

| Field | What trusting it means |
| --- | --- |
| `client_endpoint` | Every later REST call for that portal. A forgery reads the app's business data and answers in Bitrix24's place. |
| `server_endpoint` | Where the SDK POSTs `client_id`, **`client_secret`** and `refresh_token` on every token refresh. A forgery leaks the **application-wide** secret — every portal, not just the one whose `member_id` was guessed. |

The issue offered three options and recommended (2) validate + (3) document. That is what this does. (1) first-write-wins was skipped for the reason the issue gives: reinstall and `ONAPPUPDATE` would need a state machine this recipe does not have, and getting it wrong teaches a reinstall bug.

After the change, the worst a forged install achieves is a corrupted record — that portal's calls fail, which is noisy and recoverable.

## The two things that were easy to get wrong

**`server_endpoint` is not the portal.** On the cloud it is a shared token server — `oauth.bitrix.info` — for every portal. My first version required it to match `domain`, which would have rejected **every legitimate cloud install**. The recipe's own existing test fixture caught it; it had the right value all along.

**Both allow-lists must be configurable.** A boxed Bitrix24 lives at whatever domain its owner chose and is its own token server, so hard-coded `*.bitrix24.*` suffixes would refuse every on-premise install — the audience the project is measuring right now in the v3 audit.

## What the panel found

Five reviewers plus `/code-review`. This is runtime security in code that gets copied into real deployments, so the full panel rather than review alone.

**Security** — three gaps, none exploitable, all fixed: the literal string `.bitrix24.com` was accepted as a portal (it does end with `.bitrix24.com`); `B24_ALLOWED_PORTAL_HOSTS=","` parsed to nothing and silently refused everything; nothing stopped an operator writing `.com`, which re-opens the hole. Hostname shape is now checked, and both misconfigurations throw at the point of the mistake.

**QA** — **a second vacuous test, of the same shape as the first.** The layers overlap on purpose, so a malformed `domain` that still ends with an allowed suffix also fails the `client_endpoint === domain` comparison — disabling either shape check alone left every black-box test green. Fixed by testing `checkPortalUrls` directly and asserting *which* check refused; the reason string is what tells the layers apart. QA also named four uncovered branches, all now covered, including `B24_ALLOWED_OAUTH_HOSTS`, which had none.

**CTO** — the cloud suffix list is a snapshot that will go stale with no signal; the module now says so rather than leaving it implied. And a self-hosted operator who had not set the allow-lists saw installs simply stop arriving, since the endpoint still answers `200`; the recipe now says at startup which variables to set.

**Docs** — verified every claim against the code and `oauth/auth.ts`, found the prose accurate, and caught the recipes `SKILL.md` `lib/` table missing the new module.

**Engineer** — no findings.

## Verification

204 recipe tests. **Every branch isolated and confirmed by mutation**, including the two that cannot be reached through `handleInstall`. `skills:typecheck`, `test:typecheck`, `skills:typecheck-blocks`, `docs-lint --strict`, `lint:md` all clean.

## Also here

`.claude/worktrees/` is gitignored — a review agent works in a git worktree inside the repository, and that checkout is a second copy of the repository which must never be committed into it.

## Follow-up, not in scope

Security noted that `member_id` is used unsanitised as a store key, so `"__proto__"` silently swallows an install. Pre-existing and unrelated to URL validation — I will file it rather than widen this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_