### PR TITLE
fix(core): keep a response without a time block from throwing

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/70.core-ajax-result.md
+++ b/docs/content/docs/2.working-with-the-rest-api/70.core-ajax-result.md
@@ -3,7 +3,7 @@ title: AjaxResult
 description: 'Specialised Result returned by every REST helper. Provides `isMore() / getNext() / getTotal() / getStatus()` for paged responses, and immutable data.'
 category: 'Core'
 navigation.title: AjaxResult
-audited: 2026-08-29
+audited: 2026-09-04
 links:
   - label: AjaxResult
     iconName: GitHubIcon

--- a/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
+++ b/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
@@ -2,7 +2,7 @@
 title: Restrictions System
 description: 'The restrictions system provides a comprehensive mechanism for managing request frequency, operation execution time, and adaptive delays.'
 category: 'limiters'
-audited: 2026-08-18
+audited: 2026-09-04
 navigation.title: Limiters
 links:
   - label: Limiters
@@ -118,6 +118,10 @@ interface OperatingLimitConfig {
 - For batch requests, analyzes all nested methods
 - Automatic cleanup of outdated data (> windowMs + 10 seconds)
 - Logging of heavy requests when exceeding `heavyPercent`{lang="ts-type"}
+
+::warning
+**On a self-hosted portal this limiter is normally inert.** It works from the `operating` / `operating_reset_at` counters in the response's `time` block, and the portal sends them only when its own operating limiter is active — on-premise that reads the `rest` module option `load_limiter_active`, whose default is `N` and which nothing in the product ever sets. Without the counters the SDK skips the bookkeeping rather than invent a `0`, so `OperatingLimiter` neither delays nor reports anything. `RateLimiter` and `AdaptiveDelayer` are unaffected. If you need operating-time throttling on-premise, the administrator has to enable the option **and** configure `load_limiter_connection_name` — enabled without a connection, the counter is a constant zero, which is worse than missing.
+::
 
 ### 3. AdaptiveDelayer (Adaptive Delays)
 

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -2,7 +2,7 @@
 title: Logging & Credential Redaction
 description: 'What the SDK redacts automatically before any request information enters the logger or an AjaxError, what it does not redact, and how to wire a custom logger via setLogger(...) without re-introducing credential leaks.'
 category: 'logging'
-audited: 2026-08-29
+audited: 2026-09-04
 navigation.title: Logging & Redaction
 links:
   - label: redact.ts (canonical key list)

--- a/docs/content/docs/2.working-with-the-rest-api/90.types-payloads.md
+++ b/docs/content/docs/2.working-with-the-rest-api/90.types-payloads.md
@@ -3,7 +3,7 @@ title: Payload types
 description: 'The REST response envelope — PayloadTime, GetPayload, ListPayload, BatchPayload, SuccessPayload, and the Payload union, with a note on the v2 vs v3 envelope status.'
 category: 'Types'
 navigation.title: Payloads
-audited: 2026-08-26
+audited: 2026-09-04
 links:
   - label: payloads
     iconName: GitHubIcon
@@ -16,12 +16,18 @@ links:
 The types in `types/payloads.ts` model the JSON envelope Bitrix24 wraps around every REST response. Most application code never touches these directly — the `actions.v{2,3}.*` helpers unwrap them and hand you [`SuccessPayload`](#successpayload) via `AjaxResult.getData()`. They are documented here because they are re-exported from `@bitrix24/b24jssdk` and describe the raw wire shape.
 
 ::note
-The Bitrix24 REST API always wraps a **successful** response in `{ result, time }` — this holds for both `restApi:v2` and `restApi:v3`. The differences below are confined to the *list* and *batch* envelopes, whose extra pagination fields are v2-only.
+The Bitrix24 REST API wraps a **successful** response in `{ result, time }` for both `restApi:v2` and `restApi:v3`. The differences below are confined to the *list* and *batch* envelopes, whose extra pagination fields are v2-only.
+::
+
+::warning
+**The envelope is not universal.** `rest.documentation.openapi` answers with the OpenAPI document at the **top level** — no `result`, no `time` — measured on an on-premise build, a cloud portal and a cloud sandbox. The types below still declare both fields, because that is what you want for every ordinary method; the SDK's own transport layer is written not to assume them.
 ::
 
 ## `PayloadTime`
 
 The timing block attached to every response envelope. Present on both v2 and v3.
+
+The two `operating*` counters are **optional**, and their absence is the normal state on a self-hosted portal rather than an edge case: the portal adds them only when the operating limiter is active, which on-premise reads the `rest` module option `load_limiter_active` — default `N`, and nothing in the product ever sets it. The SDK skips its operating-time bookkeeping in that case and does not invent a `0`, which would be indistinguishable from a real "nothing consumed yet".
 
 ```ts-type
 type PayloadTime = {
@@ -31,8 +37,8 @@ type PayloadTime = {
   readonly processing: number
   readonly date_start: ISODate
   readonly date_finish: ISODate
-  readonly operating_reset_at: number  // timestamp when part of the method limit is released
-  readonly operating: number           // execution time counted against the method limit
+  readonly operating_reset_at?: number // timestamp when part of the method limit is released
+  readonly operating?: number          // execution time counted against the method limit
 }
 ```
 

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -582,10 +582,17 @@ export abstract class AbstractHttp implements TypeHttp {
       status: response.status
     })
 
-    // 5. Update operating statistics
+    // 5. Update operating statistics — only when the portal sent a `time` block.
+    // It does not always: `rest.documentation.openapi` answers with the OpenAPI
+    // document at the top level, with neither a `result` envelope nor `time`.
+    // The `time!` assertion that used to stand here claimed otherwise, and
+    // `OperatingLimiter.updateStats()` destructured the absent block — so a
+    // perfectly good HTTP 200 came back to the caller as an exception.
     if (result.isSuccess) {
       const time = result.getData()?.time
-      await this._restrictionManager.updateStats(requestId, method, time!)
+      if (time) {
+        await this._restrictionManager.updateStats(requestId, method, time)
+      }
     }
 
     return result

--- a/packages/jssdk/src/core/http/limiters/adaptive-delayer.ts
+++ b/packages/jssdk/src/core/http/limiters/adaptive-delayer.ts
@@ -1,6 +1,7 @@
 import type { AdaptiveConfig, ILimiter } from '../../../types/limiters'
 import type { OperatingLimiter } from './operating-limiter'
 import type { LoggerInterface } from '../../../types/logger'
+import type { PayloadTime } from '../../../types/payloads'
 import { LoggerFactory } from '../../../logger'
 
 /**
@@ -124,7 +125,7 @@ export class AdaptiveDelayer implements ILimiter {
     return maxDelay
   }
 
-  async updateStats(_requestId: string, _method: string, _data: any): Promise<void> {
+  async updateStats(_requestId: string, _method: string, _data: PayloadTime | undefined): Promise<void> {
     // Adaptive delayer updates based on operating limiter
   }
 

--- a/packages/jssdk/src/core/http/limiters/manager.ts
+++ b/packages/jssdk/src/core/http/limiters/manager.ts
@@ -1,5 +1,6 @@
 import type { RestrictionParams, RestrictionManagerStats } from '../../../types/limiters'
 import type { LoggerInterface } from '../../../types/logger'
+import type { PayloadTime } from '../../../types/payloads'
 import { LoggerFactory } from '../../../logger'
 import { RateLimiter } from './rate-limiter'
 import { OperatingLimiter } from './operating-limiter'
@@ -91,10 +92,19 @@ export class RestrictionManager {
     } while (waitTime > 0)
   }
 
+  /**
+   * Fans the response's `time` block out to all three limiters.
+   *
+   * `timeData` is `undefined` when the portal sent no `time` block at all, which
+   * a success legitimately can — `rest.documentation.openapi` answers with the
+   * OpenAPI document at the top level. The transport already skips this call in
+   * that case; the parameter stays optional because `updateStats` is on the
+   * public {@link ILimiter} contract and the transport is not its only caller.
+   */
   async updateStats(
     requestId: string,
     method: string,
-    timeData: any
+    timeData: PayloadTime | undefined
   ): Promise<void> {
     await this.#operatingLimiter.updateStats(requestId, method, timeData)
     await this.#adaptiveDelayer.updateStats(requestId, method, timeData)

--- a/packages/jssdk/src/core/http/limiters/operating-limiter.ts
+++ b/packages/jssdk/src/core/http/limiters/operating-limiter.ts
@@ -140,20 +140,20 @@ export class OperatingLimiter implements ILimiter {
    * Updates operating time statistics for the method.
    *
    * `data` is optional because **a successful response without a `time` block at
-   * all is normal**, in two separate ways measured on live portals:
-   *
-   * - `rest.documentation.openapi` answers with the OpenAPI document at the top
-   *   level — no `result` envelope and no `time` — on every portal tried (an
-   *   on-premise build, a cloud portal and a cloud sandbox);
-   * - on-premise the operating limiter is off by default (the `rest` module's
-   *   `load_limiter_active` option, default `N`, which nothing in the product
-   *   ever sets), so `operating` / `operating_reset_at` are absent for *every*
-   *   method there.
-   *
-   * Destructuring an absent block threw `Cannot destructure property
+   * all is normal**: `rest.documentation.openapi` answers with the OpenAPI
+   * document at the top level — no `result` envelope and no `time` — on every
+   * portal tried (an on-premise build, a cloud portal and a cloud sandbox).
+   * Destructuring the absent block threw `Cannot destructure property
    * 'operating' of 'data' as it is undefined` and turned a fine HTTP 200 into an
    * exception. Same shape as #338, one level over: there the missing key was
    * `result`, here it is `time`.
+   *
+   * A `time` block that arrives *without* the counters is a second, separate
+   * case and was never the crash — the `operating === undefined` check below has
+   * always caught it. It is the normal on-premise state, because the operating
+   * limiter is off by default there (the `rest` module's `load_limiter_active`
+   * option, default `N`, which nothing in the product ever sets), so the
+   * counters are missing from every response on such a portal.
    *
    * No counters are synthesised when the block is absent. A fabricated
    * `operating: 0` is indistinguishable from a real "nothing consumed yet" and
@@ -184,7 +184,15 @@ export class OperatingLimiter implements ILimiter {
     const stats = this.#methodStats.get(method)!
 
     stats.operating = operating * 1000
-    stats.operating_reset_at = operating_reset_at * 1000
+    // Held apart from `operating` deliberately. The two counters travel together
+    // on every portal seen, but the type no longer promises that, and the old
+    // unconditional `operating_reset_at * 1000` would have written `NaN` into
+    // the stats if one ever arrived without the other — and `NaN` compares false
+    // against every threshold, so the limiter would have stopped waiting rather
+    // than failed visibly. Keeping the previous reset point is the safe reading.
+    if (operating_reset_at !== undefined) {
+      stats.operating_reset_at = operating_reset_at * 1000
+    }
     stats.lastUpdated = Date.now()
 
     // Check for heavy requests

--- a/packages/jssdk/src/core/http/limiters/operating-limiter.ts
+++ b/packages/jssdk/src/core/http/limiters/operating-limiter.ts
@@ -137,9 +137,34 @@ export class OperatingLimiter implements ILimiter {
   }
 
   /**
-   * Updates operating time statistics for the method
+   * Updates operating time statistics for the method.
+   *
+   * `data` is optional because **a successful response without a `time` block at
+   * all is normal**, in two separate ways measured on live portals:
+   *
+   * - `rest.documentation.openapi` answers with the OpenAPI document at the top
+   *   level — no `result` envelope and no `time` — on every portal tried (an
+   *   on-premise build, a cloud portal and a cloud sandbox);
+   * - on-premise the operating limiter is off by default (the `rest` module's
+   *   `load_limiter_active` option, default `N`, which nothing in the product
+   *   ever sets), so `operating` / `operating_reset_at` are absent for *every*
+   *   method there.
+   *
+   * Destructuring an absent block threw `Cannot destructure property
+   * 'operating' of 'data' as it is undefined` and turned a fine HTTP 200 into an
+   * exception. Same shape as #338, one level over: there the missing key was
+   * `result`, here it is `time`.
+   *
+   * No counters are synthesised when the block is absent. A fabricated
+   * `operating: 0` is indistinguishable from a real "nothing consumed yet" and
+   * would make the limiter confidently wrong — on-premise that exact value is
+   * what an enabled-but-unconfigured limiter reports.
    */
-  async updateStats(requestId: string, method: string, data: PayloadTime): Promise<void> {
+  async updateStats(requestId: string, method: string, data?: PayloadTime): Promise<void> {
+    if (!data) {
+      return
+    }
+
     this.#cleanupOldStats()
 
     // all in seconds

--- a/packages/jssdk/src/core/http/limiters/rate-limiter.ts
+++ b/packages/jssdk/src/core/http/limiters/rate-limiter.ts
@@ -1,5 +1,6 @@
 import type { ILimiter, RateLimitConfig } from '../../../types/limiters'
 import type { LoggerInterface } from '../../../types/logger'
+import type { PayloadTime } from '../../../types/payloads'
 import { LoggerFactory } from '../../../logger'
 
 /**
@@ -130,7 +131,7 @@ export class RateLimiter implements ILimiter {
    * Successful request handler.
    * If everything is OK, we'll restore the limits.
    */
-  async updateStats(requestId: string, method: string, _data: any): Promise<void> {
+  async updateStats(requestId: string, method: string, _data: PayloadTime | undefined): Promise<void> {
     // skip accounting of `batch` subqueries
     if (method.startsWith('batch::')) {
       return

--- a/packages/jssdk/src/types/limiters.ts
+++ b/packages/jssdk/src/types/limiters.ts
@@ -1,4 +1,5 @@
 import type { LoggerInterface } from './logger'
+import type { PayloadTime } from './payloads'
 /**
  * Types and interfaces for configuring rate-limiting and adaptive throttling of REST API requests.
  * These settings control the operating time window, per-window limits, and adaptive pause behaviour.
@@ -178,7 +179,13 @@ export interface ILimiter {
   getLogger(): LoggerInterface
   canProceed(requestId: string, method: string, params?: any): Promise<boolean>
   waitIfNeeded(requestId: string, method: string, params?: any): Promise<number>
-  updateStats(requestId: string, method: string, data: any): Promise<void>
+  /**
+   * @param data - the response's `time` block, or `undefined` when the portal
+   *   sent none. Not every success carries one — `rest.documentation.openapi`
+   *   answers with the OpenAPI document at the top level — so an implementation
+   *   must tolerate its absence rather than assume it away.
+   */
+  updateStats(requestId: string, method: string, data: PayloadTime | undefined): Promise<void>
   reset(): Promise<void>
   getStats(): Record<string, any>
 }

--- a/packages/jssdk/src/types/payloads.ts
+++ b/packages/jssdk/src/types/payloads.ts
@@ -10,12 +10,22 @@ export type PayloadTime = {
   readonly date_finish: ISODate
   /**
    * timestamp - when part of the limit for this method will be released.
+   *
+   * Optional: absent whenever `operating` is — see below.
    */
-  readonly operating_reset_at: number
+  readonly operating_reset_at?: number
   /**
    * indicates the execution time of a request to a specific method.
+   *
+   * Optional, and missing is the *normal* on-premise state rather than an edge
+   * case: `CRestServer::appendDebugInfo()` adds the counters only when the
+   * operating limiter is active, which on-premise reads the `rest` module option
+   * `load_limiter_active` — default `N`, and nothing in the product ever sets
+   * it. `OperatingLimiter` therefore skips its bookkeeping instead of assuming a
+   * number, and does not synthesise a `0`: that value is indistinguishable from
+   * a real "nothing consumed yet".
    */
-  readonly operating: number
+  readonly operating?: number
 }
 
 export type GetPayload<P> = {
@@ -68,8 +78,14 @@ export type Payload<P>
 /**
  * Public shape of a successful REST response, as exposed by `AjaxResult.getData()`.
  *
- * The Bitrix24 REST API always wraps a success response in `{ result, time }` —
- * this is true for both `restApi:v2` and `restApi:v3`. Any v2-only envelope
+ * The Bitrix24 REST API wraps a success response in `{ result, time }` for both
+ * `restApi:v2` and `restApi:v3` — but not universally, so neither field may be
+ * assumed present at runtime: `rest.documentation.openapi` answers with the
+ * OpenAPI document at the top level, with no `result` and no `time`, measured on
+ * an on-premise build, a cloud portal and a cloud sandbox. The fields stay
+ * required here because they are what a caller wants for every ordinary method;
+ * code in the transport layer that must survive any response is written against
+ * that reality instead (see `OperatingLimiter.updateStats`). Any v2-only envelope
  * fields (`next`, `total`) are intentionally NOT part of this type: they have
  * no `restApi:v3` counterpart, and the SDK's `actions.v{2,3}.{callList,fetchList}`
  * helpers handle pagination internally so consumers never need to read them.

--- a/test/0_setup/hooks-under-load-jssdk.ts
+++ b/test/0_setup/hooks-under-load-jssdk.ts
@@ -234,7 +234,11 @@ export class LoadTesterV2 extends AbstractLoadTester {
       return (new Result<TestResult>()).setData({
         requestId,
         duration,
-        operating: response.getData()!.time.operating
+        // `?? 0` because the counters are optional: a portal with its operating
+        // limiter off sends no `operating` at all. Zero is what this harness's
+        // own catch branch already reports for "nothing measured", so the two
+        // paths stay comparable.
+        operating: response.getData()!.time.operating ?? 0
       })
     } catch (error) {
       return (new Result<TestResult>())
@@ -383,7 +387,11 @@ export class LoadTesterV3 extends AbstractLoadTester {
       return (new Result<TestResult>()).setData({
         requestId,
         duration,
-        operating: response.getData()!.time.operating
+        // `?? 0` because the counters are optional: a portal with its operating
+        // limiter off sends no `operating` at all. Zero is what this harness's
+        // own catch branch already reports for "nothing measured", so the two
+        // paths stay comparable.
+        operating: response.getData()!.time.operating ?? 0
       })
     } catch (error) {
       return (new Result<TestResult>())

--- a/test/integration/core/response-without-time.unit.spec.ts
+++ b/test/integration/core/response-without-time.unit.spec.ts
@@ -98,6 +98,13 @@ describe('a response without a `time` block', () => {
     vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
       .mockResolvedValue(OPENAPI_DOCUMENT_RESPONSE)
 
+    // Asserting *which* guard did the work, not merely that nothing threw. The
+    // two guards — `if (time)` at the call site and `if (!data) return` in the
+    // limiter — cover for each other completely: with both in place, removing
+    // either one leaves every black-box assertion green. Only the call count
+    // separates them, so it is what this case pins.
+    const updateStats = vi.spyOn(RestrictionManager.prototype, 'updateStats')
+
     // The assertion that matters: this used to throw.
     const response = await b24.actions.v3.call.make<Record<string, unknown>>({
       method: 'rest.documentation.openapi'
@@ -105,12 +112,16 @@ describe('a response without a `time` block', () => {
 
     expect(response.isSuccess).toBe(true)
     expect(response.getData()).toBeDefined()
+    // The call site must not reach the limiter at all when there is no `time`.
+    expect(updateStats).not.toHaveBeenCalled()
   })
 
   it('@apiV3 does not throw when `time` is present but carries no operating counters', async () => {
     b24 = buildHook()
     vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
       .mockResolvedValue(RESPONSE_WITHOUT_OPERATING)
+
+    const updateStats = vi.spyOn(RestrictionManager.prototype, 'updateStats')
 
     const response = await b24.actions.v3.call.make<{ items: Array<{ id: number }> }>({
       method: 'main.eventlog.list',
@@ -119,6 +130,9 @@ describe('a response without a `time` block', () => {
 
     expect(response.isSuccess).toBe(true)
     expect(response.getData()!.result.items).toEqual([{ id: 1 }])
+    // `time` is here, so the call site passes it on — the counters being absent
+    // is the limiter's business, and it has always handled that (see below).
+    expect(updateStats).toHaveBeenCalledOnce()
   })
 
   it('@apiV3 still accepts a response that does carry the counters', async () => {
@@ -136,9 +150,11 @@ describe('a response without a `time` block', () => {
   })
 
   it('updateStats tolerates an absent time block from any caller', async () => {
-    // The v2 batch strategy calls this directly with the per-command `time`,
-    // which is equally absent when the portal sends none — so the guard has to
-    // live in the limiter, not only at the transport call site.
+    // `updateStats` is on the exported `ILimiter` contract, so the transport is
+    // not its only caller — the v2 batch strategy calls it per command. That one
+    // guards its own call, but the contract has to hold for a caller that does
+    // not, which is why the guard lives in the limiter as well as at the call
+    // site. This is the case that goes red if the limiter's guard is removed.
     const manager = new RestrictionManager(ParamsFactory.getDefault())
 
     await expect(

--- a/test/integration/core/response-without-time.unit.spec.ts
+++ b/test/integration/core/response-without-time.unit.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression: a successful response **without a `time` block** must come back to
+ * the caller, not blow up.
+ *
+ * Before the fix, `_createAjaxResultFromResponse` read `result.getData()?.time`
+ * and passed it on with a non-null assertion, and
+ * `OperatingLimiter.updateStats()` destructured it — so a fine HTTP 200 turned
+ * into `Cannot destructure property 'operating' of 'data' as it is undefined`.
+ *
+ * Two independent ways a portal legitimately answers without those fields, both
+ * measured live:
+ *
+ * - `rest.documentation.openapi` returns the OpenAPI document at the **top
+ *   level** — no `result` envelope and no `time` — on every portal tried: an
+ *   on-premise build (SM_VERSION 26.700.0), a cloud portal and a cloud sandbox.
+ *   That method is what the docs call the source of truth for v3 discovery, so
+ *   the crash made the documented discovery flow impossible.
+ * - On-premise the operating limiter is **off by default** (the `rest` module's
+ *   `load_limiter_active` option defaults to `N` and nothing in the product ever
+ *   sets it), so `operating` / `operating_reset_at` are missing from *every*
+ *   response there.
+ *
+ * Same shape as #338, one level over: there the absent key was `result`, here it
+ * is `time`.
+ *
+ * `*.unit.spec.ts` — no real Bitrix24 portal required (axios is mocked).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { ApiVersion, B24Hook, ParamsFactory } from '../../../packages/jssdk/src/'
+import { RestrictionManager } from '../../../packages/jssdk/src/core/http/limiters/manager'
+
+/** What `rest.documentation.openapi` actually answers: no envelope, no `time`. */
+const OPENAPI_DOCUMENT_RESPONSE = {
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: {} as never,
+  data: {
+    openapi: '3.0.0',
+    info: { title: 'Bitrix24 REST V3 API', version: '1.0.0' },
+    servers: [],
+    tags: [{ name: 'main', description: 'main module methods' }],
+    paths: { '/main.eventlog.list': {} },
+    components: {}
+  }
+}
+
+/** An on-premise portal with the limiter off: `time` present, counters absent. */
+const RESPONSE_WITHOUT_OPERATING = {
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: {} as never,
+  data: {
+    result: { items: [{ id: 1 }] },
+    time: {
+      start: 0, finish: 0, duration: 0, processing: 0,
+      date_start: '1970-01-01T00:00:00+00:00',
+      date_finish: '1970-01-01T00:00:00+00:00'
+    }
+  }
+}
+
+/** A cloud portal with the limiter on — the shape that always worked. */
+const RESPONSE_WITH_OPERATING = {
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: {} as never,
+  data: {
+    result: { items: [{ id: 1 }] },
+    time: {
+      start: 0, finish: 0, duration: 0, processing: 0,
+      date_start: '1970-01-01T00:00:00+00:00',
+      date_finish: '1970-01-01T00:00:00+00:00',
+      operating_reset_at: 1, operating: 0.5
+    }
+  }
+}
+
+function buildHook(): B24Hook {
+  return B24Hook.fromWebhookUrl('https://example.bitrix24.com/rest/1/SECRET', {
+    restrictionParams: { ...ParamsFactory.getDefault(), retryDelay: 1 }
+  })
+}
+
+describe('a response without a `time` block', () => {
+  let b24: B24Hook | null = null
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    b24?.destroy()
+    b24 = null
+  })
+
+  it('@apiV3 does not throw when the payload has neither `result` nor `time`', async () => {
+    b24 = buildHook()
+    vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue(OPENAPI_DOCUMENT_RESPONSE)
+
+    // The assertion that matters: this used to throw.
+    const response = await b24.actions.v3.call.make<Record<string, unknown>>({
+      method: 'rest.documentation.openapi'
+    })
+
+    expect(response.isSuccess).toBe(true)
+    expect(response.getData()).toBeDefined()
+  })
+
+  it('@apiV3 does not throw when `time` is present but carries no operating counters', async () => {
+    b24 = buildHook()
+    vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue(RESPONSE_WITHOUT_OPERATING)
+
+    const response = await b24.actions.v3.call.make<{ items: Array<{ id: number }> }>({
+      method: 'main.eventlog.list',
+      params: { select: ['id'] }
+    })
+
+    expect(response.isSuccess).toBe(true)
+    expect(response.getData()!.result.items).toEqual([{ id: 1 }])
+  })
+
+  it('@apiV3 still accepts a response that does carry the counters', async () => {
+    b24 = buildHook()
+    vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue(RESPONSE_WITH_OPERATING)
+
+    const response = await b24.actions.v3.call.make<{ items: Array<{ id: number }> }>({
+      method: 'main.eventlog.list',
+      params: { select: ['id'] }
+    })
+
+    expect(response.isSuccess).toBe(true)
+    expect(response.getData()!.time.operating).toBe(0.5)
+  })
+
+  it('updateStats tolerates an absent time block from any caller', async () => {
+    // The v2 batch strategy calls this directly with the per-command `time`,
+    // which is equally absent when the portal sends none — so the guard has to
+    // live in the limiter, not only at the transport call site.
+    const manager = new RestrictionManager(ParamsFactory.getDefault())
+
+    await expect(
+      manager.updateStats('unit-test', 'main.eventlog.list', undefined)
+    ).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What breaks

`rest.documentation.openapi` answers HTTP 200 with the OpenAPI document at the **top
level** — no `result` envelope and no `time` block. `_createAjaxResultFromResponse` passed
that absent block on with a non-null assertion and `OperatingLimiter.updateStats()`
destructured it, so a perfectly good response reached the caller as:

```
Cannot destructure property 'operating' of 'data' as it is undefined
```

Reproduced on three portals: an on-premise build (`SM_VERSION 26.700.0`), a cloud portal,
and a disposable cloud sandbox. Same shape as #338, one level over — there the missing key
was `result`, here it is `time`.

That method is the one the docs call the source of truth for v3 discovery, so the crash sat
directly on the documented discovery flow.

## A second, separate case — which was *not* a crash

An earlier revision of this description claimed a second path to the same exception: a
`time` block arriving without the counters, which is the normal on-premise state because the
operating limiter is off by default there (`CRestServer::appendDebugInfo()` adds
`operating` / `operating_reset_at` only when `LoadLimiter::isActive()`, which on-premise
reads the `rest` module option `load_limiter_active` — default `N`, and nothing in the
product ever writes it).

**That path never threw.** `OperatingLimiter.updateStats` has checked
`operating === undefined || operating === null` since before this branch. The only crash is
a wholly absent `time`. The claim is corrected here and in the JSDoc, because a reader who
trusts the wrong version will add a guard that already exists.

The state itself is real and now documented — see below.

## The change

`updateStats` takes the block as optional and returns early when it is absent; the transport
only calls it when the portal sent one.

**No counters are synthesised.** A fabricated `operating: 0` is indistinguishable from a
real "nothing consumed yet", and on-premise that exact value is what an
enabled-but-unconfigured limiter reports (no Redis connection in
`load_limiter_connection_name`). Inventing it would make the limiter confidently wrong
rather than honestly blind — so the guard skips the update instead of feeding it a zero.

## From the review panel

**QA, by mutation — the headline guard was covered by nothing.** The two guards cover for
each other completely: with both in place, reverting either left all four black-box cases
green. Only the call count separates them, so the two absent-`time` cases now assert whether
the limiter is reached at all. Confirmed both ways: removing the call-site guard reddens
case 1, removing the limiter's reddens case 4.

**The types asserted what the fix disproves.** `PayloadTime.operating` and
`operating_reset_at` are optional now, and `SuccessPayload`'s comment no longer promises
`{ result, time }` universally. Making them optional immediately found a latent `NaN`:
`operating_reset_at * 1000` ran unconditionally, and `NaN` compares false against every
threshold — a half-populated block would have made the limiter stop waiting rather than fail
visibly.

**`ILimiter.updateStats` and all three implementations took `data: any`**, so the optionality
stopped at one of them and the compiler carried none of it. All four say
`PayloadTime | undefined` now.

**The blast radius left the source.** On a self-hosted portal this limiter is normally
inert — a deployment class, not an edge case — so `77.limiters.md` says so, including that
enabling it without `load_limiter_connection_name` gives a constant zero, which is worse
than missing.

**Security:** no leak, and no new bypass — the throttle is self-protection, and an attacker
who can strip `time` from an HTTPS response can already do worse. The observability point
(the limiter goes blind silently where it used to throw) is answered by documenting the
state rather than a per-call log line, which on-premise would fire on every request.

**Deliberately not touched:** the `getData()?.result` snippets on the v3 discovery page and
in the recipes skill. They read `undefined` today, and the next PR in this series wraps an
envelope-less body into `result` — they are written for the world after it, so correcting
them here would only have to be undone.

## Tests

`test/integration/core/response-without-time.unit.spec.ts`, project `jsSdk:unit` — axios
mocked, no portal needed. Four cases:

1. a payload with neither `result` nor `time` — the case that used to throw, and now also
   asserts `updateStats` is never reached;
2. `time` present but carrying no operating counters (an on-premise portal), asserting the
   call *is* made — the counters are the limiter's business, not the call site's;
3. `time` with counters — the shape that always worked, pinned so the guard cannot swallow it;
4. `updateStats` called with `undefined` directly, because it is on the exported `ILimiter`
   contract and the transport is not its only caller.

## Checks

- `pnpm typecheck` — clean
- `pnpm lint`, `pnpm lint:md`, `lint:v3-refs` — clean
- `docs-lint --strict` — 0 errors, 0 warnings
- all four block gates — clean
- `pnpm vitest run --project jsSdk:unit` — 595 passed, 0 failed

## Scope

First of five separate changes from a v3 audit against live portals (see the audit comment
on #113); each one is its own PR rather than a batch. This one is the crash. The next takes
up what happens to the body of a response that has no `result` key at all — related, but a
different decision, so it is kept apart.
