### PR TITLE
feat(scripts): check the API Reference index against itself

### DIFF
--- a/scripts/__tests__/check-api-reference-index.test.mjs
+++ b/scripts/__tests__/check-api-reference-index.test.mjs
@@ -339,6 +339,44 @@ test('reads a table row guide cell as linked or not', () => {
   assert.equal(rows.get('versionManager'), false)
 })
 
+test('an empty guide cell is not a guide, even when the description links', () => {
+  // Filtering out blank cells makes the description the "last" one, and any
+  // link in it then reads as a guide — marking an export covered while its own
+  // row says it is not. Found in review.
+  const { rows } = collectPagePositions(page([
+    '## Tools',
+    '',
+    '| [`LsKeys`](https://example.test/ls.ts) | See [the note](/docs/note/). |  |'
+  ].join('\n')))
+
+  assert.equal(rows.get('LsKeys'), false)
+})
+
+test('a separated name list is still a name list', () => {
+  // The page separates with spaces today. A comma-separated rewrite must not
+  // silently empty the list, which would report every name in it as missing
+  // from the index.
+  const { everythingElse } = collectPagePositions(page([
+    '## Everything else',
+    '',
+    '`AppFrame`, `LsKeys`, `RpcMethod`'
+  ].join('\n')))
+
+  assert.deepEqual([...everythingElse], ['AppFrame', 'LsKeys', 'RpcMethod'])
+})
+
+test('a line of prose with backticks is not a name list', () => {
+  // The counterweight to the rule above: scraping backticks from prose would
+  // let `getData` satisfy the gate for a future export of that name.
+  const { everythingElse } = collectPagePositions(page([
+    '## Everything else',
+    '',
+    'Also exported: `AppFrame` and `LsKeys` among others.'
+  ].join('\n')))
+
+  assert.deepEqual([...everythingElse], [])
+})
+
 test('attributes a flat list to the heading above it', () => {
   const { everythingElse, uncovered } = collectPagePositions(page([
     '## Everything else',

--- a/scripts/__tests__/check-api-reference-index.test.mjs
+++ b/scripts/__tests__/check-api-reference-index.test.mjs
@@ -9,7 +9,7 @@
 //
 // Run with: node --test scripts/__tests__/check-api-reference-index.test.mjs
 
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -17,7 +17,13 @@ import { spawnSync } from 'node:child_process'
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { collectValueExports, collectPageNames } from '../check-api-reference-index.mjs'
+import {
+  collectValueExports,
+  collectPageNames,
+  collectPagePositions,
+  checkListConsistency,
+  checkPositionSplit
+} from '../check-api-reference-index.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..', '..')
@@ -303,4 +309,140 @@ test('the real repo passes, and reports the export count', () => {
   const run = spawnSync(process.execPath, [SCRIPT], { cwd: REPO_ROOT, encoding: 'utf8' })
   assert.equal(run.status, 0, run.stderr)
   assert.match(run.stdout, /0 error\(s\), 0 warning\(s\), \d+ public value export\(s\)/)
+})
+
+// ── list consistency (#384) ──────────────────────────────────────────────
+//
+// The #383 gate holds the page against the code and is deliberately scoped to
+// the union of positions on the page. These check the page against itself,
+// which is the drift that gate cannot see: "Not yet covered by a guide" is
+// designed to shrink, and shrinking is the one operation nothing watched.
+
+const page = body => `---
+title: API Reference
+---
+
+${body}
+`
+
+test('reads a table row guide cell as linked or not', () => {
+  const { rows } = collectPagePositions(page([
+    '## Entry points',
+    '',
+    '| Export | What it is | Guide |',
+    '| --- | --- | --- |',
+    '| [`B24Hook`](https://example.test/hook.ts) | Webhook auth. | [guide](/docs/hook/) |',
+    '| [`versionManager`](https://example.test/vm.ts) | Routing. | — |'
+  ].join('\n')))
+
+  assert.equal(rows.get('B24Hook'), true)
+  assert.equal(rows.get('versionManager'), false)
+})
+
+test('attributes a flat list to the heading above it', () => {
+  const { everythingElse, uncovered } = collectPagePositions(page([
+    '## Everything else',
+    '',
+    '`AppFrame` `LsKeys`',
+    '',
+    '## Not yet covered by a guide',
+    '',
+    '`AppFrame` `versionManager`'
+  ].join('\n')))
+
+  assert.deepEqual([...everythingElse], ['AppFrame', 'LsKeys'])
+  assert.deepEqual([...uncovered], ['AppFrame', 'versionManager'])
+})
+
+test('a name in both flat lists is fine — they are different questions', () => {
+  // "Everything else" is about having a row on this page; "Not yet covered" is
+  // about having a guide elsewhere. No row and no guide is a legitimate pair,
+  // and it describes nineteen names on the real page. A check forbidding it was
+  // written first, and this test is what the correction looks like.
+  const positions = collectPagePositions(page([
+    '## Everything else',
+    '',
+    '`AppFrame`',
+    '',
+    '## Not yet covered by a guide',
+    '',
+    '`AppFrame`'
+  ].join('\n')))
+
+  assert.deepEqual(checkListConsistency(positions), [])
+})
+
+test('fails when a name with a guide link is still listed as uncovered', () => {
+  // The drift this whole issue is about: the guide gets written, the row gets
+  // its link, and nobody remembers to delete the name from the list below.
+  const positions = collectPagePositions(page([
+    '## Tools',
+    '',
+    '| [`LsKeys`](https://example.test/ls.ts) | Storage keys. | [guide](/docs/ls-keys/) |',
+    '',
+    '## Not yet covered by a guide',
+    '',
+    '`LsKeys`'
+  ].join('\n')))
+
+  const problems = checkListConsistency(positions)
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /whose table row links to one/)
+  assert.match(problems[0], /LsKeys/)
+})
+
+test('passes when the row still says the guide is missing', () => {
+  const positions = collectPagePositions(page([
+    '## Tools',
+    '',
+    '| [`LsKeys`](https://example.test/ls.ts) | Storage keys. | — |',
+    '',
+    '## Not yet covered by a guide',
+    '',
+    '`LsKeys`'
+  ].join('\n')))
+
+  assert.deepEqual(checkListConsistency(positions), [])
+})
+
+test('fails when a name has a row and is also in "Everything else"', () => {
+  const positions = collectPagePositions(page([
+    '## Tools',
+    '',
+    '| [`LsKeys`](https://example.test/ls.ts) | Storage keys. | — |',
+    '',
+    '## Everything else',
+    '',
+    '`LsKeys`'
+  ].join('\n')))
+
+  const problems = checkListConsistency(positions)
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /in both a domain table and "Everything else"/)
+})
+
+test('fails when an export appears only under "Not yet covered by a guide"', () => {
+  // That list records a missing guide, not a place on this page — so a name
+  // listed there and nowhere else is absent from the index proper.
+  const positions = collectPagePositions(page([
+    '## Not yet covered by a guide',
+    '',
+    '`LsKeys`'
+  ].join('\n')))
+
+  const problems = checkPositionSplit(new Set(['LsKeys']), positions)
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /in neither a domain table nor "Everything else"/)
+})
+
+test('the real page satisfies both consistency checks', () => {
+  const markdown = readFileSync(
+    join(REPO_ROOT, 'docs/content/docs/3.api-reference/1.index.md'),
+    'utf8'
+  )
+  const positions = collectPagePositions(markdown)
+
+  assert.deepEqual(checkListConsistency(positions), [])
+  const entry = join(REPO_ROOT, 'packages/jssdk/src/index.ts')
+  assert.deepEqual(checkPositionSplit(collectValueExports(entry), positions), [])
 })

--- a/scripts/check-api-reference-index.mjs
+++ b/scripts/check-api-reference-index.mjs
@@ -247,9 +247,138 @@ export function collectPageNames(markdown) {
   return names
 }
 
+/**
+ * The same names, but attributed to *where* on the page they sit (#384).
+ *
+ * `collectPageNames` deliberately returns their union, because the #383 gate
+ * asks one question: does the page account for every export. This asks the
+ * question that one cannot — do the page's three lists agree with each other.
+ *
+ * @returns {{
+ *   rows: Map<string, boolean>,   name -> whether its guide cell is a link
+ *   everythingElse: Set<string>,
+ *   uncovered: Set<string>
+ * }}
+ */
+export function collectPagePositions(markdown) {
+  const rows = new Map()
+  const everythingElse = new Set()
+  const uncovered = new Set()
+
+  // Which flat list a name-only line belongs to is decided by the heading above
+  // it, so the page is walked in order rather than scanned as a whole.
+  let section = ''
+
+  for (const line of markdown.split('\n')) {
+    if (line.startsWith('## ')) {
+      section = line.slice(3).trim()
+      continue
+    }
+
+    // A domain-table row: `| [`Name`](source) | description | guide |`.
+    // The guide cell is the last one, and holds either a link or an em dash.
+    const row = line.match(/^\|\s*\[`?([A-Z_$][\w$]*)`?\]\(/i)
+    if (row) {
+      // The guide cell is the last one on the row, and holds a link or an em dash.
+      const guideCell = line.split('|').filter(cell => cell.trim() !== '').at(-1) ?? ''
+      rows.set(row[1], guideCell.includes(']('))
+      continue
+    }
+
+    const trimmed = line.trim()
+    if (trimmed === '' || !/^(?:`[A-Z_$][\w$]*`\s*)+$/i.test(trimmed)) {
+      continue
+    }
+    const target = section.startsWith('Everything else')
+      ? everythingElse
+      : (section.startsWith('Not yet covered') ? uncovered : null)
+    if (target === null) {
+      continue
+    }
+    for (const match of trimmed.matchAll(/`([A-Z_$][\w$]*)`/gi)) {
+      target.add(match[1])
+    }
+  }
+
+  return { rows, everythingElse, uncovered }
+}
+
+/**
+ * Check the page's three lists against each other (#384).
+ *
+ * The #383 gate holds the page against the code, and is scoped to the union of
+ * positions on purpose. That leaves two drifts possible with every gate green,
+ * and the first is the one that matters: **"Not yet covered by a guide" is
+ * designed to shrink, and shrinking is the operation nothing checks.** Someone
+ * writing the guide for `LsKeys` has to remember to delete `LsKeys` from that
+ * list by hand, and if they forget, the page goes on telling readers a page
+ * does not exist after it does — which is worse than saying nothing, because
+ * the reader stops looking.
+ *
+ * @returns {string[]} human-readable problems, empty when the lists agree
+ */
+export function checkListConsistency({ rows, everythingElse, uncovered }) {
+  const problems = []
+
+  const contradicted = [...uncovered].filter(name => rows.get(name) === true).sort()
+  if (contradicted.length > 0) {
+    problems.push(
+      `${contradicted.length} name(s) listed as having no guide, whose table row links to one:\n`
+      + contradicted.map(name => `  - ${name}`).join('\n')
+      + '\n  The guide was written and the row updated; drop the name from '
+      + '"Not yet covered by a guide".'
+    )
+  }
+
+  const bothPlaces = [...everythingElse].filter(name => rows.has(name)).sort()
+  if (bothPlaces.length > 0) {
+    problems.push(
+      `${bothPlaces.length} name(s) in both a domain table and "Everything else":\n`
+      + bothPlaces.map(name => `  - ${name}`).join('\n')
+      + '\n  "Everything else" is defined as the leftovers, so a name with a row '
+      + 'of its own does not belong in it.'
+    )
+  }
+
+  return problems
+}
+
+/**
+ * Every export sits in exactly one of {a domain-table row, "Everything else"}.
+ *
+ * Note this is a different axis from "Not yet covered by a guide", and the
+ * distinction is easy to lose: the first two lists are about *having a row on
+ * this page*, the third about *having a guide elsewhere*. A name legitimately
+ * appears in "Everything else" and in "Not yet covered" at once — no row, no
+ * guide. A check forbidding that fires on nineteen names today, which is how
+ * this comment came to be written.
+ *
+ * @returns {string[]} human-readable problems, empty when the split is clean
+ */
+export function checkPositionSplit(exported, { rows, everythingElse }) {
+  const problems = []
+
+  const unplaced = [...exported]
+    .filter(name => !rows.has(name) && !everythingElse.has(name))
+    .sort()
+  if (unplaced.length > 0) {
+    problems.push(
+      `${unplaced.length} export(s) in neither a domain table nor "Everything else":\n`
+      + unplaced.map(name => `  - ${name}`).join('\n')
+      + '\n  Listing a name only under "Not yet covered by a guide" leaves it out '
+      + 'of the index proper — that list records a missing guide, not a place on '
+      + 'this page.'
+    )
+  }
+
+  return problems
+}
+
 function main() {
   const exported = collectValueExports(ENTRY)
   const onPage = collectPageNames(readFileSync(PAGE, 'utf8'))
+
+  const positions = collectPagePositions(readFileSync(PAGE, 'utf8'))
 
   const missing = [...exported].filter(name => !onPage.has(name)).sort()
   const stale = [...onPage].filter(name => !exported.has(name)).sort()
@@ -276,6 +405,12 @@ function main() {
   const report = createReporter({ label: 'api-reference-index', root: ROOT })
   for (const problem of problems) {
     report.error(PAGE, `the page is out of sync with the code — ${problem}`)
+  }
+  for (const problem of checkListConsistency(positions)) {
+    report.error(PAGE, `the page contradicts itself — ${problem}`)
+  }
+  for (const problem of checkPositionSplit(exported, positions)) {
+    report.error(PAGE, `the page's own lists do not cover the surface — ${problem}`)
   }
   report.note(`${exported.size} public value export(s)`)
 

--- a/scripts/check-api-reference-index.mjs
+++ b/scripts/check-api-reference-index.mjs
@@ -211,6 +211,47 @@ function assertNoMultiDeclarator(entry, source) {
 }
 
 /**
+ * A domain-table row: `| [`Name`](source) | description | guide |`.
+ *
+ * @returns {{ name: string, hasGuide: boolean } | null}
+ */
+function tableRow(line) {
+  const match = line.match(/^\|\s*\[`?([A-Z_$][\w$]*)`?\]\(/i)
+  if (!match) {
+    return null
+  }
+
+  // Split on the pipes and drop the empty strings the leading and trailing
+  // delimiters produce — but keep an empty cell *between* two pipes. Filtering
+  // every blank instead would make a row with an empty guide cell fall back to
+  // its description, and any link in the description would then read as a
+  // guide, marking the export as covered when the row says it is not.
+  const cells = line.split('|').slice(1, -1)
+  const guideCell = cells.at(-1) ?? ''
+
+  return { name: match[1], hasGuide: guideCell.includes('](') }
+}
+
+/**
+ * The names on a line that is nothing but backticked identifiers.
+ *
+ * Separators between them are tolerated — the page uses spaces today, and a
+ * comma-separated rewrite should not silently empty the list. What is not
+ * tolerated is prose: a line with any other word in it is not a name list, and
+ * scraping backticks from prose would let `getData` or `isSuccess` satisfy the
+ * gate for a future export that happens to share the name.
+ *
+ * @returns {string[]}
+ */
+function flatListNames(line) {
+  const trimmed = line.trim()
+  if (trimmed === '' || !/^`[A-Z_$][\w$]*`(?:[\s,;·•]*`[A-Z_$][\w$]*`)*$/i.test(trimmed)) {
+    return []
+  }
+  return [...trimmed.matchAll(/`([A-Z_$][\w$]*)`/gi)].map(match => match[1])
+}
+
+/**
  * The names the page *claims* are exports — read from structured positions only,
  * never from prose.
  *
@@ -228,19 +269,16 @@ function assertNoMultiDeclarator(entry, source) {
 export function collectPageNames(markdown) {
   const names = new Set()
 
-  // A domain-table row: `| [`Name`](source) | description | guide |`.
-  for (const match of markdown.matchAll(/^\|\s*\[`?([A-Z_$][\w$]*)`?\]\(/gim)) {
-    names.add(match[1])
+  for (const line of markdown.split('\n')) {
+    const row = tableRow(line)
+    if (row) {
+      names.add(row.name)
+    }
   }
 
-  // A flat name list — a line that is nothing but backticked identifiers.
   for (const line of markdown.split('\n')) {
-    const trimmed = line.trim()
-    if (trimmed === '' || !/^(?:`[A-Z_$][\w$]*`\s*)+$/i.test(trimmed)) {
-      continue
-    }
-    for (const match of trimmed.matchAll(/`([A-Z_$][\w$]*)`/gi)) {
-      names.add(match[1])
+    for (const name of flatListNames(line)) {
+      names.add(name)
     }
   }
 
@@ -275,28 +313,20 @@ export function collectPagePositions(markdown) {
       continue
     }
 
-    // A domain-table row: `| [`Name`](source) | description | guide |`.
-    // The guide cell is the last one, and holds either a link or an em dash.
-    const row = line.match(/^\|\s*\[`?([A-Z_$][\w$]*)`?\]\(/i)
+    const row = tableRow(line)
     if (row) {
-      // The guide cell is the last one on the row, and holds a link or an em dash.
-      const guideCell = line.split('|').filter(cell => cell.trim() !== '').at(-1) ?? ''
-      rows.set(row[1], guideCell.includes(']('))
+      rows.set(row.name, row.hasGuide)
       continue
     }
 
-    const trimmed = line.trim()
-    if (trimmed === '' || !/^(?:`[A-Z_$][\w$]*`\s*)+$/i.test(trimmed)) {
-      continue
-    }
     const target = section.startsWith('Everything else')
       ? everythingElse
       : (section.startsWith('Not yet covered') ? uncovered : null)
     if (target === null) {
       continue
     }
-    for (const match of trimmed.matchAll(/`([A-Z_$][\w$]*)`/gi)) {
-      target.add(match[1])
+    for (const name of flatListNames(line)) {
+      target.add(name)
     }
   }
 
@@ -376,9 +406,10 @@ export function checkPositionSplit(exported, { rows, everythingElse }) {
 
 function main() {
   const exported = collectValueExports(ENTRY)
-  const onPage = collectPageNames(readFileSync(PAGE, 'utf8'))
+  const markdown = readFileSync(PAGE, 'utf8')
+  const onPage = collectPageNames(markdown)
 
-  const positions = collectPagePositions(readFileSync(PAGE, 'utf8'))
+  const positions = collectPagePositions(markdown)
 
   const missing = [...exported].filter(name => !onPage.has(name)).sort()
   const stale = [...onPage].filter(name => !exported.has(name)).sort()


### PR DESCRIPTION
Closes #384.

## The drift the existing gate cannot see

`check-api-reference-index.mjs` (#383) holds the page against the code, and is scoped to the **union** of positions on the page on purpose. That leaves this invisible:

> **"Not yet covered by a guide" is designed to shrink, and shrinking is the one operation nothing watched.**

Someone writing the guide for `LsKeys` had to remember to delete `LsKeys` from that list by hand. Forget, and the page goes on telling readers a page does not exist after it does — worse than saying nothing, because the reader stops looking. The list names 26 exports today, and #315 is the plan to write guides for them.

`collectPagePositions` reads the same names, but attributed to *where* they sit: table rows with whether their guide cell is a link, and each flat list under its own heading. Three checks then hold the lists against each other.

## One of the three checks was wrong, and running it is what showed that

The issue's suggested fix reads as three symmetrical rules, and I implemented a fourth by pattern-matching: *a name should not appear in both flat lists*. It fired on **nineteen names immediately**.

It was wrong. The lists answer different questions:

| List | Question |
| --- | --- |
| **Everything else** | does it have a row *on this page*? |
| **Not yet covered by a guide** | does it have a guide *elsewhere*? |

No row and no guide is a perfectly legitimate pair, and it describes nineteen exports. Replaced with what the issue actually asked for — every export sits in exactly one of {a table row, "Everything else"} — and the reasoning is now in the code, because the wrong version is the one a reader would write again.

## Verified end to end, not only by unit test

Gave `versionManager`'s row a guide link without touching the list below — exactly the drift #384 describes — and the gate names it:

```
ERROR docs/…/1.index.md the page contradicts itself — 1 name(s) listed as having
no guide, whose table row links to one: versionManager
```

## What `/code-review` found

Three, all fixed:

- **A blank guide cell read as a guide.** Taking the last *non-empty* cell made a row with an empty guide column fall back to its description — and any link in that description then marked the export as covered while its own row says it is not. Cells are dropped by position now, so an empty cell between two pipes survives as one.
- **The flat-list pattern accepted only whitespace between names.** A comma-separated rewrite of either list would have parsed to nothing, and the new split check would then have reported every name in it as missing from the index. Separators are tolerated; prose still is not, because scraping backticks from a sentence would let `getData` satisfy the gate for a future export of that name.
- **The page was read twice.**

Both parsers are now shared between the two collectors rather than written twice — the same argument as #418: a fix in one copy has to reach the other.

## Verification

147 script tests (10 new). Every new check confirmed by mutation, including the two review fixes. The real page satisfies both consistency checks, asserted as a test rather than only observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_