### PR TITLE
fix(core): wrap a response body that has no result key into result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Bug Fixes
 
+* **A response body with no `result` key now reaches you instead of being dropped.** `AjaxResult.getData()` rebuilds the payload from two named keys, so a body carrying neither was projected away and a *successful* call handed back `{ result: undefined, time: undefined }`. Such a body is wrapped now: the whole body becomes `result`.
+
+    `rest.documentation.openapi` answers exactly that way — the OpenAPI document at the top level, no envelope — which is the method the docs call the source of truth for v3 discovery, so `getData()?.result` on the discovery page now returns the document it always promised.
+
+    **Worth knowing if you wrote a guard around the old behaviour:** where an envelope-less body used to make `getData()!.result` `undefined`, it is now the body. A check shaped like `if (!getData()?.result)` will no longer treat such a response as empty. An error body is unaffected — it is recognised before the wrap and stays an error.
+
+    `SuccessPayload.time` and `GetPayload.time` are **optional** as a consequence: a wrapped body has no `time`, and nothing is invented to fill it. If you read a field off `time`, guard it — the compiler will now say so.
+
+    Also fixed on the same path: an HTTP 200 with a `null` body threw a `TypeError` from the success-path log line and from `getData()`, which the request path re-wrapped as `JSSDK_UNKNOWN_ERROR`. It now comes back as an ordinary empty success.
+
 * **A webhook URL in a log line no longer shows its secret.** The redactor masks a credential that is an object key or half of a `key=value` query pair. A Bitrix24 webhook secret is neither — it is a path segment, `/rest/<userId>/<secret>/` (and `/rest/api/<userId>/<secret>/` under `restApi:v3`) — so it stayed readable while the rest of the line was masked.
 
     It shows up there because the redactor runs over response bodies as well as over the params you sent, and a portal method can return such a URL: `rest.deferredbatch.downloadresult` answers with a `downloadUrl` built from the calling webhook. The secret segment is masked now; the host and the user id stay readable, so the line is still useful for debugging.

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: CallV2.make
 description: 'A method for making Bitrix24 REST API version 2 calls.'
 category: 'actions'
-audited: 2026-08-31
+audited: 2026-09-05
 restApiVersion: 'rest-api-ver2'
 navigation.title: Call
 links:
@@ -73,7 +73,7 @@ The `options` object contains the following properties:
 
 This object provides:
 
-- `.getData(): SuccessPayload<T> | undefined`{lang="ts-type"} — returns the success envelope `{ result: T, time: PayloadTime }`, or `undefined` when the request failed. Check `.isSuccess` first.
+- `.getData(): SuccessPayload<T> | undefined`{lang="ts-type"} — returns the success envelope `{ result: T, time?: PayloadTime }`, or `undefined` when the request failed. Check `.isSuccess` first. `time` is optional — not every response carries one, and the SDK does not invent it.
 - `.isSuccess: boolean`{lang="ts-type"} — flag indicating successful request execution.
 - `.getErrorMessages(): string[]`{lang="ts-type"} — array of error messages.
 

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallV3.make
 description: 'Method for making Bitrix24 REST API version 3 calls.'
 category: 'actions'
-audited: 2026-08-31
+audited: 2026-09-05
 restApiVersion: 'rest-api-ver3'
 navigation.title: Call
 links:
@@ -64,7 +64,7 @@ The `options` object contains the following properties:
 
 This object provides:
 
-- `.getData(): SuccessPayload<T> | undefined`{lang="ts-type"} — returns the success envelope `{ result: T, time: PayloadTime }`, or `undefined` when the request failed. Check `.isSuccess` first.
+- `.getData(): SuccessPayload<T> | undefined`{lang="ts-type"} — returns the success envelope `{ result: T, time?: PayloadTime }`, or `undefined` when the request failed. Check `.isSuccess` first. `time` is optional — not every response carries one, and the SDK does not invent it.
 - `.isSuccess: boolean`{lang="ts-type"} — flag indicating successful request execution.
 - `.getErrorMessages(): string[]`{lang="ts-type"} — array of error messages.
 

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: BatchV2.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 2. Allows executing up to 50 commands in a single API call.'
 category: 'actions'
-audited: 2026-08-31
+audited: 2026-09-05
 restApiVersion: 'rest-api-ver2'
 navigation.title: Batch
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3. Allows executing up to 50 commands in a single API call.'
 category: 'actions'
-audited: 2026-08-31
+audited: 2026-09-05
 restApiVersion: 'rest-api-ver3'
 navigation.title: Batch
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV2.make
 description: 'Method for executing batch requests with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-09-01
+audited: 2026-09-05
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3 with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-09-01
+audited: 2026-09-05
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: BatchByChunk

--- a/docs/content/docs/2.working-with-the-rest-api/6.errors.md
+++ b/docs/content/docs/2.working-with-the-rest-api/6.errors.md
@@ -3,7 +3,7 @@ title: Error codes and handling
 description: 'Reference for SdkError and AjaxError codes raised by the SDK, plus the Bitrix24 REST error codes that surface through them.'
 navigation:
   title: Errors
-audited: 2026-08-29
+audited: 2026-09-05
 links:
   - label: SdkError
     iconName: GitHubIcon

--- a/docs/content/docs/2.working-with-the-rest-api/7.discovering-v3-methods.md
+++ b/docs/content/docs/2.working-with-the-rest-api/7.discovering-v3-methods.md
@@ -1,7 +1,7 @@
 ---
 title: Discovering v3 methods (OpenAPI)
 description: 'Use rest.documentation.openapi to fetch the portal''s own machine-readable list of every available REST API v3 method — the source of truth the SDK relies on instead of a hardcoded allowlist. Especially useful for AI agents and codegen.'
-audited: 2026-06-25
+audited: 2026-09-04
 navigation:
   title: Discovering v3 methods
 links:
@@ -34,6 +34,13 @@ to the server and lets it decide. When you need to know *what's actually there*
 The document reflects the **modules installed on this portal** and the **scopes
 your token holds**, so two portals can return different method sets. Always treat
 it as portal-specific, not a global catalogue.
+::
+
+::warning
+This method answers **without the usual envelope**: the OpenAPI document arrives
+at the top level, with no `result` wrapper and no `time` block. The SDK wraps it
+back into `result` so the snippets below work, but a raw HTTP client will see the
+document itself as the response body.
 ::
 
 ## Calling it through the SDK

--- a/docs/content/docs/2.working-with-the-rest-api/70.core-ajax-result.md
+++ b/docs/content/docs/2.working-with-the-rest-api/70.core-ajax-result.md
@@ -3,7 +3,7 @@ title: AjaxResult
 description: 'Specialised Result returned by every REST helper. Provides `isMore() / getNext() / getTotal() / getStatus()` for paged responses, and immutable data.'
 category: 'Core'
 navigation.title: AjaxResult
-audited: 2026-09-04
+audited: 2026-09-05
 links:
   - label: AjaxResult
     iconName: GitHubIcon
@@ -29,7 +29,11 @@ links:
 getData(): undefined | SuccessPayload<T>
 ```
 
-Returns `undefined`{lang="ts-type"} when the result is not successful. On success, returns a frozen object with `result`, `next`, `total`, `time` (only the fields present in the original payload). Use `T` to type the underlying `result`:
+Returns `undefined`{lang="ts-type"} when the result is not successful. On success, returns a frozen `{ result, time }`{lang="ts-type"} — and only those two. The `restApi:v2`-only envelope fields `next` and `total` are **not** carried through; read them with [`isMore()`](#ismore) and [`getTotal()`](#gettotal), or let `callList`{lang="ts-type"} / `fetchList`{lang="ts-type"} page for you.
+
+`time` is optional: a response does not always carry one, and the SDK does not invent it — see [`PayloadTime`](/docs/working-with-the-rest-api/types-payloads).
+
+Use `T` to type the underlying `result`:
 
 ```ts
 const response = await $b24.actions.v2.call.make<{ id: number, title: string }[]>({
@@ -42,8 +46,12 @@ if (!response.isSuccess) {
   throw new Error(response.getErrorMessages().join('; '))
 }
 
-const data = response.getData()!     // { result: { id, title }[], next?: number, total?: number, time }
+const data = response.getData()!     // { result: { id, title }[], time?: PayloadTime }
 ```
+
+::note
+**A body that is not an envelope is wrapped.** If the response carries no `result` key at all, the whole body becomes `result` rather than being dropped. `rest.documentation.openapi` answers that way — the OpenAPI document at the top level — so `getData()!.result`{lang="ts-type"} is the document, with `time`{lang="ts-type"} `undefined`{lang="ts-type"}. See [Discovering v3 methods](/docs/working-with-the-rest-api/discovering-v3-methods).
+::
 
 ## Pagination
 

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -2,7 +2,7 @@
 title: Logging & Credential Redaction
 description: 'What the SDK redacts automatically before any request information enters the logger or an AjaxError, what it does not redact, and how to wire a custom logger via setLogger(...) without re-introducing credential leaks.'
 category: 'logging'
-audited: 2026-09-04
+audited: 2026-09-05
 navigation.title: Logging & Redaction
 links:
   - label: redact.ts (canonical key list)

--- a/docs/content/docs/2.working-with-the-rest-api/90.types-payloads.md
+++ b/docs/content/docs/2.working-with-the-rest-api/90.types-payloads.md
@@ -3,7 +3,7 @@ title: Payload types
 description: 'The REST response envelope — PayloadTime, GetPayload, ListPayload, BatchPayload, SuccessPayload, and the Payload union, with a note on the v2 vs v3 envelope status.'
 category: 'Types'
 navigation.title: Payloads
-audited: 2026-09-04
+audited: 2026-09-05
 links:
   - label: payloads
     iconName: GitHubIcon
@@ -20,7 +20,7 @@ The Bitrix24 REST API wraps a **successful** response in `{ result, time }` for 
 ::
 
 ::warning
-**The envelope is not universal.** `rest.documentation.openapi` answers with the OpenAPI document at the **top level** — no `result`, no `time` — measured on an on-premise build, a cloud portal and a cloud sandbox. The types below still declare both fields, because that is what you want for every ordinary method; the SDK's own transport layer is written not to assume them.
+**The envelope is not universal.** `rest.documentation.openapi` answers with the OpenAPI document at the **top level** — no `result`, no `time` — measured on an on-premise build, a cloud portal and a cloud sandbox. `AjaxResult.getData()` wraps such a body so `result` is the document itself; `time` has nothing to fill it with and stays `undefined`{lang="ts-type"}.
 ::
 
 ## `PayloadTime`
@@ -49,9 +49,11 @@ The envelope for a single-item read — the common `{ result, time }` shape.
 ```ts-type
 type GetPayload<P> = {
   readonly result: P
-  readonly time: PayloadTime
+  readonly time?: PayloadTime
 }
 ```
+
+`time` is optional here, and coupled to [`SuccessPayload`](#successpayload) below: `AjaxResult.getData()` returns a `SuccessPayload`{lang="ts-type"} where the `IResult`{lang="ts-type"} contract expects a `Payload`{lang="ts-type"}, so this union member has to stay assignable from it.
 
 ## `ListPayload`
 
@@ -114,9 +116,11 @@ The public shape of a successful response, as returned by `AjaxResult.getData()`
 ```ts-type
 type SuccessPayload<P> = {
   readonly result: P
-  readonly time: PayloadTime
+  readonly time?: PayloadTime
 }
 ```
+
+`result` is always here, because a body with no `result` key is **wrapped** — the whole body becomes `result` rather than being dropped. `time` cannot be filled in the same way, so it is optional: guard before reading a field off it.
 
 `SuccessPayload` is intentionally the common `{ result, time }` shape — identical for v2 and v3. The v2-only list fields (`next`, `total`) are **deliberately excluded**: they have no `restApi:v3` counterpart, and the SDK's `callList` / `fetchList` helpers handle pagination internally, so consumers never read them off the envelope.
 

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -548,13 +548,18 @@ export abstract class AbstractHttp implements TypeHttp {
     // wired logger sink — mirror the `post/send` redaction on the success path. (#69)
     // A v3 method outside the `result` envelope (e.g. `rest.documentation.openapi`)
     // makes this `undefined` rather than a string; `truncateForLog` coerces it. (#338)
-    const resultFormattedForLog = JSON.stringify(redactSensitiveParams(response.data.result), null, 0)
+    // `?.` on the body itself, not only on `.result`: a success is not always an
+    // object. An HTTP 200 whose body is `null` made this line throw, and the
+    // request path then re-wrapped that `TypeError` as `JSSDK_UNKNOWN_ERROR` —
+    // a fine response reaching the caller as an unrecognisable failure, the same
+    // shape as #338 and #456 one field over.
+    const resultFormattedForLog = JSON.stringify(redactSensitiveParams(response.data?.result), null, 0)
     this.getLogger().info(
       `post/response`, {
         requestId,
         // responseFull: JSON.stringify(response.data, null, 2),
         result: truncateForLog(resultFormattedForLog),
-        time: JSON.stringify(response.data.time, null, 0)
+        time: JSON.stringify(response.data?.time, null, 0)
       }
     ).catch(() => {})
 

--- a/packages/jssdk/src/core/http/ajax-result.ts
+++ b/packages/jssdk/src/core/http/ajax-result.ts
@@ -83,10 +83,11 @@ export class AjaxResult<T = unknown> extends Result<Payload<T>> implements IResu
   /**
    * The success payload as `{ result, time }`.
    *
-   * A response whose body carries **no `result` key at all** is wrapped: the
-   * whole body becomes `result`. Without that the body is simply lost — this
-   * method rebuilds the payload from two named keys, so anything else on it is
-   * projected away and the caller gets `{ result: undefined, time: undefined }`.
+   * A response whose body is **not an envelope** — anything but a plain object
+   * with a `result` key — is wrapped: the whole body becomes `result`. Without
+   * that the body is simply lost, because this method rebuilds the payload from
+   * two named keys, so everything else on it is projected away and the caller
+   * gets `{ result: undefined, time: undefined }` from a call that succeeded.
    *
    * That is not hypothetical. `rest.documentation.openapi` answers with the
    * OpenAPI document at the top level — no envelope, no `time` — on every portal
@@ -112,10 +113,24 @@ export class AjaxResult<T = unknown> extends Result<Payload<T>> implements IResu
 
     const payload = this._data as SuccessPayload<T>
 
-    if (payload && typeof payload === 'object' && !('result' in payload)) {
+    // Asked the other way round — "is this an envelope?" rather than "is this
+    // envelope-less?" — so that everything which is not one takes the wrap. A
+    // body that is `null`, a bare `true`, a string or an array carries no
+    // `result` either, and reading `.result` off `null` threw a `TypeError`
+    // where the whole point of this branch is that a success reaches its caller.
+    //
+    // No `Array.isArray` check: `'result' in []` is already false, so an array
+    // takes the wrap regardless. Adding one would be a branch no input can tell
+    // apart from its absence — which is worse than not having it.
+    const isEnvelope = payload !== null
+      && typeof payload === 'object'
+      && 'result' in payload
+
+    if (!isEnvelope) {
       return Object.freeze({
         result: payload as unknown as T,
-        time: (payload as { time?: PayloadTime }).time
+        // Read off the body when it happens to carry one; never invented.
+        time: (payload as { time?: PayloadTime } | null)?.time
       }) as SuccessPayload<T>
     }
 

--- a/packages/jssdk/src/core/http/ajax-result.ts
+++ b/packages/jssdk/src/core/http/ajax-result.ts
@@ -1,5 +1,5 @@
 import type { IResult } from '../result'
-import type { Payload, SuccessPayload } from '../../types/payloads'
+import type { Payload, PayloadTime, SuccessPayload } from '../../types/payloads'
 import type { ValidationDetail } from './parse-error-payload'
 import { parseErrorPayload } from './parse-error-payload'
 import type { TypeCallParams, TypeHttp } from '../../types/http'
@@ -80,12 +80,44 @@ export class AjaxResult<T = unknown> extends Result<Payload<T>> implements IResu
     return this._errors.size === 0
   }
 
+  /**
+   * The success payload as `{ result, time }`.
+   *
+   * A response whose body carries **no `result` key at all** is wrapped: the
+   * whole body becomes `result`. Without that the body is simply lost — this
+   * method rebuilds the payload from two named keys, so anything else on it is
+   * projected away and the caller gets `{ result: undefined, time: undefined }`.
+   *
+   * That is not hypothetical. `rest.documentation.openapi` answers with the
+   * OpenAPI document at the top level — no envelope, no `time` — on every portal
+   * measured (an on-premise build, a cloud portal, a cloud sandbox). It is the
+   * method our own docs call the source of truth for v3 discovery, and its
+   * documented snippet reads `getData()?.result`; the wrap is what makes that
+   * snippet true rather than a promise the transport quietly breaks.
+   *
+   * Done here rather than in the constructor on purpose: `#processErrors()` runs
+   * against the raw body and detects an error by its `error` key. Wrapping
+   * earlier would hide `error` one level down and turn every error response into
+   * a "successful" one. By the time this method runs, `isSuccess` has already
+   * been decided.
+   *
+   * `b24phpsdk` resolves the same problem the same way — `Response.php` moves a
+   * body with no `result` key under `result`, naming this very endpoint in its
+   * comment.
+   */
   override getData(): undefined | SuccessPayload<T> {
     if (!this.isSuccess) {
       return undefined
     }
 
     const payload = this._data as SuccessPayload<T>
+
+    if (payload && typeof payload === 'object' && !('result' in payload)) {
+      return Object.freeze({
+        result: payload as unknown as T,
+        time: (payload as { time?: PayloadTime }).time
+      }) as SuccessPayload<T>
+    }
 
     return Object.freeze({
       result: payload.result,

--- a/packages/jssdk/src/types/payloads.ts
+++ b/packages/jssdk/src/types/payloads.ts
@@ -28,9 +28,18 @@ export type PayloadTime = {
   readonly operating?: number
 }
 
+/**
+ * The wire envelope of an ordinary single-method response.
+ *
+ * `time` is optional here for the same reason it is on {@link SuccessPayload},
+ * and the two are coupled: `AjaxResult.getData()` returns a `SuccessPayload`
+ * where the `IResult` contract expects a `Payload`, so this union member has to
+ * stay assignable from it. A required `time` here would make that assignment
+ * fail the moment the output type admitted an absent one.
+ */
 export type GetPayload<P> = {
   readonly result: P
-  readonly time: PayloadTime
+  readonly time?: PayloadTime
 }
 
 // @todo ! add api3
@@ -79,14 +88,17 @@ export type Payload<P>
  * Public shape of a successful REST response, as exposed by `AjaxResult.getData()`.
  *
  * The Bitrix24 REST API wraps a success response in `{ result, time }` for both
- * `restApi:v2` and `restApi:v3` — but not universally, so neither field may be
- * assumed present at runtime: `rest.documentation.openapi` answers with the
- * OpenAPI document at the top level, with no `result` and no `time`, measured on
- * an on-premise build, a cloud portal and a cloud sandbox. The fields stay
- * required here because they are what a caller wants for every ordinary method;
- * code in the transport layer that must survive any response is written against
- * that reality instead (see `OperatingLimiter.updateStats`). Any v2-only envelope
- * fields (`next`, `total`) are intentionally NOT part of this type: they have
+ * `restApi:v2` and `restApi:v3` — but not universally:
+ * `rest.documentation.openapi` answers with the OpenAPI document at the top
+ * level, with no `result` and no `time`, measured on an on-premise build, a
+ * cloud portal and a cloud sandbox.
+ *
+ * `result` is always here regardless, because `getData()` wraps such a body —
+ * the body itself becomes `result`, which is what makes that method usable at
+ * all. `time` cannot be manufactured the same way, so it is optional.
+ *
+ * Any v2-only envelope fields (`next`, `total`) are intentionally NOT part of
+ * this type — nor are they returned by `getData()` — because they have
  * no `restApi:v3` counterpart, and the SDK's `actions.v{2,3}.{callList,fetchList}`
  * helpers handle pagination internally so consumers never need to read them.
  *
@@ -94,5 +106,12 @@ export type Payload<P>
  */
 export type SuccessPayload<P> = {
   readonly result: P
-  readonly time: PayloadTime
+  /**
+   * Optional, because a success does not always carry one and the SDK does not
+   * invent it. `rest.documentation.openapi` answers with the OpenAPI document at
+   * the top level: `getData()` hands that whole body back as `result`, and there
+   * is no `time` to report alongside it. Guard before reading a field off it —
+   * the type says `undefined` is possible precisely so the compiler makes you.
+   */
+  readonly time?: PayloadTime
 }

--- a/test/0_setup/hooks-under-load-jssdk.ts
+++ b/test/0_setup/hooks-under-load-jssdk.ts
@@ -234,11 +234,12 @@ export class LoadTesterV2 extends AbstractLoadTester {
       return (new Result<TestResult>()).setData({
         requestId,
         duration,
-        // `?? 0` because the counters are optional: a portal with its operating
-        // limiter off sends no `operating` at all. Zero is what this harness's
-        // own catch branch already reports for "nothing measured", so the two
-        // paths stay comparable.
-        operating: response.getData()!.time.operating ?? 0
+        // `?.` and `?? 0` because both levels are optional: a body may carry no
+        // `time` block at all, and a portal with its operating limiter off sends
+        // a block with no `operating` in it. Zero is what this harness's own
+        // catch branch already reports for "nothing measured", so the two paths
+        // stay comparable.
+        operating: response.getData()!.time?.operating ?? 0
       })
     } catch (error) {
       return (new Result<TestResult>())
@@ -387,11 +388,12 @@ export class LoadTesterV3 extends AbstractLoadTester {
       return (new Result<TestResult>()).setData({
         requestId,
         duration,
-        // `?? 0` because the counters are optional: a portal with its operating
-        // limiter off sends no `operating` at all. Zero is what this harness's
-        // own catch branch already reports for "nothing measured", so the two
-        // paths stay comparable.
-        operating: response.getData()!.time.operating ?? 0
+        // `?.` and `?? 0` because both levels are optional: a body may carry no
+        // `time` block at all, and a portal with its operating limiter off sends
+        // a block with no `operating` in it. Zero is what this harness's own
+        // catch branch already reports for "nothing measured", so the two paths
+        // stay comparable.
+        operating: response.getData()!.time?.operating ?? 0
       })
     } catch (error) {
       return (new Result<TestResult>())

--- a/test/integration/core/actions-v2-batch.spec.ts
+++ b/test/integration/core/actions-v2-batch.spec.ts
@@ -41,7 +41,7 @@ describe('core callBatch @apiV2', () => {
       expect(result).toHaveProperty('items')
       expect(result.items.length).toBeGreaterThan(0)
 
-      const time = rowData.time
+      const time = rowData.time!
       expect(time).toHaveProperty('operating')
       expect(time.operating).toBeGreaterThanOrEqual(0)
       expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -76,7 +76,7 @@ describe('core callBatch @apiV2', () => {
       expect(result).toHaveProperty('items')
       expect(result.items.length).toBeGreaterThan(0)
 
-      const time = rowData.time
+      const time = rowData.time!
       expect(time).toHaveProperty('operating')
       expect(time.operating).toBeGreaterThanOrEqual(0)
       expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -126,7 +126,7 @@ describe('core callBatch @apiV2', () => {
       expect(result).toHaveProperty('items')
       expect(result.items.length).toBeGreaterThan(0)
 
-      const time = rowData.time
+      const time = rowData.time!
       expect(time).toHaveProperty('operating')
       expect(time.operating).toBeGreaterThanOrEqual(0)
       expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -198,7 +198,7 @@ describe('core callBatch @apiV2', () => {
         expect(result).toHaveProperty('items')
         expect(result.items.length).toBeGreaterThan(0)
 
-        const time = rowData.time
+        const time = rowData.time!
         expect(time).toHaveProperty('operating')
         expect(time.operating).toBeGreaterThanOrEqual(0)
         expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -247,7 +247,7 @@ describe('core callBatch @apiV2', () => {
         expect(result).toHaveProperty('items')
         expect(result.items.length).toBeGreaterThan(0)
 
-        const time = rowData.time
+        const time = rowData.time!
         expect(time).toHaveProperty('operating')
         expect(time.operating).toBeGreaterThanOrEqual(0)
         expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -325,7 +325,7 @@ describe('core callBatch @apiV2', () => {
         expect(result).toHaveProperty('items')
         expect(result.items.length).toBeGreaterThan(0)
 
-        const time = rowData.time
+        const time = rowData.time!
         expect(time).toHaveProperty('operating')
         expect(time.operating).toBeGreaterThanOrEqual(0)
         expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -410,7 +410,7 @@ describe('core callBatch @apiV2', () => {
         expect(result).toHaveProperty('items')
         expect(result.items.length).toBeGreaterThan(0)
 
-        const time = rowData.time
+        const time = rowData.time!
         expect(time).toHaveProperty('operating')
         expect(time.operating).toBeGreaterThanOrEqual(0)
         expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -458,7 +458,7 @@ describe('core callBatch @apiV2', () => {
         expect(result).toHaveProperty('items')
         expect(result.items.length).toBeGreaterThan(0)
 
-        const time = rowData.time
+        const time = rowData.time!
         expect(time).toHaveProperty('operating')
         expect(time.operating).toBeGreaterThanOrEqual(0)
         expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -535,7 +535,7 @@ describe('core callBatch @apiV2', () => {
         expect(result).toHaveProperty('items')
         expect(result.items.length).toBeGreaterThan(0)
 
-        const time = rowData.time
+        const time = rowData.time!
         expect(time).toHaveProperty('operating')
         expect(time.operating).toBeGreaterThanOrEqual(0)
         expect(time.operating_reset_at).toBeGreaterThan(0)

--- a/test/integration/core/actions-v2-call.spec.ts
+++ b/test/integration/core/actions-v2-call.spec.ts
@@ -36,7 +36,7 @@ describe('core.actions.call @apiV2', () => {
     expect(result.task).toHaveProperty('id')
     expect(result.task).toHaveProperty('title')
 
-    const time = response.getData()!.time
+    const time = response.getData()!.time!
     expect(time).toHaveProperty('operating')
     expect(time.operating).toBeGreaterThanOrEqual(0)
     expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -81,7 +81,7 @@ describe('core.actions.call @apiV2', () => {
 
     expect(result).not.toHaveProperty('task')
 
-    const time = response.getData()!.time
+    const time = response.getData()!.time!
     expect(time).toHaveProperty('operating')
   })
 })

--- a/test/integration/core/actions-v3-batch.spec.ts
+++ b/test/integration/core/actions-v3-batch.spec.ts
@@ -46,7 +46,7 @@ describe('core callBatch @apiV3', () => {
         expect(result.item.id).toBeDefined()
       }
 
-      const time = rowData.time
+      const time = rowData.time!
       expect(time).toHaveProperty('operating')
       // @todo waite apiV3 fix docs
       expect(time.operating).toEqual(0)
@@ -90,7 +90,7 @@ describe('core callBatch @apiV3', () => {
         expect(result.item.id).toBeDefined()
       }
 
-      const time = rowData.time
+      const time = rowData.time!
       expect(time).toHaveProperty('operating')
       // @todo waite apiV3 fix docs
       expect(time.operating).toEqual(0)
@@ -144,7 +144,7 @@ describe('core callBatch @apiV3', () => {
         expect(result.item.id).toBeDefined()
       }
 
-      const time = rowData.time
+      const time = rowData.time!
       expect(time).toHaveProperty('operating')
       // @todo waite apiV3 fix docs
       expect(time.operating).toEqual(0)
@@ -638,7 +638,7 @@ describe('core callBatch @apiV3', () => {
     //   const rowData = resultData.FirstEventLogMessage!.getData()!
     //   expect(rowData.result).toHaveProperty('item')
     //   expect(rowData.result.item.id).toBe(getMapId().eventLogMessageSuccessV1)
-    //   const time = rowData.time
+    //   const time = rowData.time!
     //   expect(time).toHaveProperty('operating')
     //   // @todo waite apiV3 fix docs
     //   expect(time.operating).toEqual(0)
@@ -659,7 +659,7 @@ describe('core callBatch @apiV3', () => {
       const rowData = resultData.EventLogMessagesList1!.getData()!
       expect(rowData.result).toHaveProperty('items')
       // expect(rowData.result.items.length).toBe(2)
-      const time = rowData.time
+      const time = rowData.time!
       expect(time).toHaveProperty('operating')
       // @todo waite apiV3 fix docs
       expect(time.operating).toEqual(0)

--- a/test/integration/core/actions-v3-call.spec.ts
+++ b/test/integration/core/actions-v3-call.spec.ts
@@ -44,7 +44,7 @@ describe('core.actions.call @apiV3', () => {
     expect(result.item.id).toBeDefined()
     expect(result.item.title).toBeDefined()
 
-    const time = response.getData()!.time
+    const time = response.getData()!.time!
     expect(time).toHaveProperty('operating')
     expect(time.operating).toBeGreaterThanOrEqual(0)
     expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -112,7 +112,7 @@ describe('core.actions.call @apiV3', () => {
   //   expect(response.isSuccess).toBe(true)
   //
   //   const result = response.getData()!.result
-  //   const time = response.getData()!.time
+  //   const time = response.getData()!.time!
   //
   //   expect(result).toBeDefined()
   //   expect(result).toHaveProperty('result')

--- a/test/integration/core/actions-v3-modules.spec.ts
+++ b/test/integration/core/actions-v3-modules.spec.ts
@@ -58,7 +58,7 @@ async function smokeList(
   expect(data.result, `${method} returned no result envelope`).toBeDefined()
   expect(data.result, `${method} returned an empty result envelope`).not.toBeNull()
 
-  const time = data.time
+  const time = data.time!
   expect(time).toHaveProperty('operating')
   expect(time.operating).toBeGreaterThanOrEqual(0)
   expect(time.operating_reset_at).toBeGreaterThan(0)

--- a/test/integration/core/deprecated-call.spec.ts
+++ b/test/integration/core/deprecated-call.spec.ts
@@ -15,7 +15,7 @@ describe('core.deprecated @apiV2', () => {
 
     expect(response.isSuccess).toBe(true)
     const result = response.getData()!.result
-    const time = response.getData()!.time
+    const time = response.getData()!.time!
     expect(result).toBeDefined()
     expect(time).toHaveProperty('operating')
     expect(time.operating).toBeGreaterThanOrEqual(0)
@@ -39,7 +39,7 @@ describe('core.deprecated @apiV2', () => {
     expect(result.task).toHaveProperty('id')
     expect(result.task).toHaveProperty('title')
 
-    const time = response.getData()!.time
+    const time = response.getData()!.time!
     expect(time).toHaveProperty('operating')
     expect(time.operating).toBeGreaterThanOrEqual(0)
     expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -190,7 +190,7 @@ describe('core.deprecated @apiV2', () => {
       const rowData = resultData.Company!.getData()!
       expect(rowData.result).toHaveProperty('item')
       expect(rowData.result.item.id).toBe(getMapId().crmCompanySuccessMin)
-      const time = rowData.time
+      const time = rowData.time!
       expect(time).toHaveProperty('operating')
       expect(time.operating).toBeGreaterThanOrEqual(0)
       expect(time.operating_reset_at).toBeGreaterThan(0)
@@ -202,7 +202,7 @@ describe('core.deprecated @apiV2', () => {
       const rowData = resultData.Contact!.getData()!
       expect(rowData.result).toHaveProperty('item')
       expect(rowData.result.item.id).toBe(getMapId().crmContactSuccessMin)
-      const time = rowData.time
+      const time = rowData.time!
       expect(time).toHaveProperty('operating')
       expect(time.operating).toBeGreaterThanOrEqual(0)
       expect(time.operating_reset_at).toBeGreaterThan(0)

--- a/test/integration/core/envelope-less-response.unit.spec.ts
+++ b/test/integration/core/envelope-less-response.unit.spec.ts
@@ -75,6 +75,84 @@ describe('a response body with no `result` key', () => {
     expect(response.getData()!.time).toBeUndefined()
   })
 
+  it('@apiV3 wraps a body that is not an object either — array, primitive', async () => {
+    // The predicate asks "is this an envelope?", not "does it lack `result`?",
+    // so everything that is not one takes the same route rather than being
+    // projected away.
+    const bodies: unknown[] = [
+      [{ id: 1 }, { id: 2 }],
+      true,
+      'plain text'
+    ]
+
+    for (const body of bodies) {
+      b24?.destroy()
+      b24 = buildHook()
+      vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post').mockResolvedValue({
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+        data: body
+      })
+
+      const response = await b24.actions.v3.call.make({ method: 'some.method' })
+
+      expect(response.isSuccess, JSON.stringify(body)).toBe(true)
+      expect(response.getData()!.result, JSON.stringify(body)).toEqual(body)
+      expect(response.getData()!.time, JSON.stringify(body)).toBeUndefined()
+    }
+  })
+
+  it('@apiV3 a `null` body comes back empty rather than throwing', async () => {
+    // Two `.result` reads on the raw body stood between an HTTP 200 with a
+    // `null` body and its caller: the success-path log line and `getData()`'s
+    // own fallback. Both threw a `TypeError`, which the request path then
+    // re-wrapped as `JSSDK_UNKNOWN_ERROR` — a fine response arriving as an
+    // unrecognisable failure, the same shape as #338 and #456 one field over.
+    //
+    // There is genuinely nothing to hand back, so `result` is `undefined`. The
+    // assertion that matters is that the call succeeds and nothing is thrown.
+    b24 = buildHook()
+    vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post').mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as never,
+      data: null
+    })
+
+    const response = await b24.actions.v3.call.make({ method: 'some.method' })
+
+    expect(response.isSuccess).toBe(true)
+    expect(response.getData()).toBeDefined()
+    expect(response.getData()!.result).toBeUndefined()
+  })
+
+  it('@apiV3 reads `time` off an envelope-less body that happens to carry one', async () => {
+    // Never invented, but not thrown away either when the portal did send it.
+    b24 = buildHook()
+    const time = {
+      start: 0, finish: 0, duration: 0, processing: 0,
+      date_start: '1970-01-01T00:00:00+00:00',
+      date_finish: '1970-01-01T00:00:00+00:00'
+    }
+    vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post').mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as never,
+      data: { openapi: '3.0.0', time }
+    })
+
+    const response = await b24.actions.v3.call.make<{ openapi: string }>({
+      method: 'rest.documentation.openapi'
+    })
+
+    expect(response.getData()!.result.openapi).toBe('3.0.0')
+    expect(response.getData()!.time).toEqual(time)
+  })
+
   it('@apiV3 an error body is NOT wrapped — it stays an error', async () => {
     b24 = buildHook()
     vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
@@ -91,7 +169,7 @@ describe('a response body with no `result` key', () => {
 
     expect(response.isSuccess).toBe(false)
     expect(response.getData()).toBeUndefined()
-    expect([...response.errors].map(([, e]) => (e as { code?: string }).code))
+    expect([...response.getErrors()].map(e => (e as { code?: string }).code))
       .toContain('BITRIX_REST_V3_EXCEPTION_METHODNOTFOUNDEXCEPTION')
   })
 })

--- a/test/integration/core/envelope-less-response.unit.spec.ts
+++ b/test/integration/core/envelope-less-response.unit.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression: a body that carries **no `result` key at all** must reach the
+ * caller, not be projected away.
+ *
+ * `AjaxResult.getData()` rebuilds the payload from two named keys, `result` and
+ * `time`. A body carrying neither therefore came back as
+ * `{ result: undefined, time: undefined }` — the response was "successful" and
+ * empty at the same time.
+ *
+ * That is the shape `rest.documentation.openapi` actually answers with: the
+ * OpenAPI document at the top level, measured on an on-premise build
+ * (SM_VERSION 26.700.0), a cloud portal and a cloud sandbox. It is the method
+ * the docs call the source of truth for v3 discovery, and the snippet on that
+ * page reads `getData()?.result` — so the page documented something the
+ * transport quietly broke.
+ *
+ * The wrap lives in `getData()` and not in the constructor on purpose:
+ * `#processErrors()` runs against the raw body and detects an error by its
+ * `error` key. Wrapping earlier would hide `error` one level down and turn every
+ * error response into a successful one — which the second case here pins down.
+ *
+ * `b24phpsdk` resolves the same problem the same way, naming this same endpoint.
+ *
+ * `*.unit.spec.ts` — no real Bitrix24 portal required (axios is mocked).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { ApiVersion, B24Hook, ParamsFactory } from '../../../packages/jssdk/src/'
+
+/** What `rest.documentation.openapi` actually answers: no envelope, no `time`. */
+const OPENAPI_DOCUMENT_RESPONSE = {
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: {} as never,
+  data: {
+    openapi: '3.0.0',
+    info: { title: 'Bitrix24 REST V3 API', version: '1.0.0' },
+    servers: [],
+    tags: [{ name: 'main', description: 'main module methods' }],
+    paths: { '/main.eventlog.list': {} },
+    components: {}
+  }
+}
+
+function buildHook(): B24Hook {
+  return B24Hook.fromWebhookUrl('https://example.bitrix24.com/rest/1/SECRET', {
+    restrictionParams: { ...ParamsFactory.getDefault(), retryDelay: 1 }
+  })
+}
+
+describe('a response body with no `result` key', () => {
+  let b24: B24Hook | null = null
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    b24?.destroy()
+    b24 = null
+  })
+
+  it('@apiV3 is wrapped, so `getData().result` is the document', async () => {
+    b24 = buildHook()
+    vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue(OPENAPI_DOCUMENT_RESPONSE)
+
+    const response = await b24.actions.v3.call.make<{ openapi: string, paths: Record<string, unknown> }>({
+      method: 'rest.documentation.openapi'
+    })
+
+    const document = response.getData()!.result
+    expect(document.openapi).toBe('3.0.0')
+    expect(Object.keys(document.paths)).toEqual(['/main.eventlog.list'])
+
+    // Nothing to report as elapsed time — the body had no `time` block, and the
+    // SDK does not invent one.
+    expect(response.getData()!.time).toBeUndefined()
+  })
+
+  it('@apiV3 an error body is NOT wrapped — it stays an error', async () => {
+    b24 = buildHook()
+    vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue({
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+        // No `result` key here either — but this one must not become a payload.
+        data: { error: { code: 'BITRIX_REST_V3_EXCEPTION_METHODNOTFOUNDEXCEPTION', message: 'not found' } }
+      })
+
+    const response = await b24.actions.v3.call.make({ method: 'no.such.method' })
+
+    expect(response.isSuccess).toBe(false)
+    expect(response.getData()).toBeUndefined()
+    expect([...response.errors].map(([, e]) => (e as { code?: string }).code))
+      .toContain('BITRIX_REST_V3_EXCEPTION_METHODNOTFOUNDEXCEPTION')
+  })
+})

--- a/test/integration/core/response-without-time.unit.spec.ts
+++ b/test/integration/core/response-without-time.unit.spec.ts
@@ -146,7 +146,7 @@ describe('a response without a `time` block', () => {
     })
 
     expect(response.isSuccess).toBe(true)
-    expect(response.getData()!.time.operating).toBe(0.5)
+    expect(response.getData()!.time!.operating).toBe(0.5)
   })
 
   it('updateStats tolerates an absent time block from any caller', async () => {


### PR DESCRIPTION
Follows #456. That one stopped the crash; this one is why the response still could not be
used afterwards.

## What breaks

`AjaxResult.getData()` rebuilds the success payload from two named keys:

```ts
return Object.freeze({ result: payload.result, time: payload.time })
```

A body carrying **neither** is therefore projected away entirely, and a successful call hands
the caller `{ result: undefined, time: undefined }` — `isSuccess` true, nothing in it.

That is the shape `rest.documentation.openapi` actually answers with: the OpenAPI document at
the top level, no envelope. Measured on an on-premise build (`SM_VERSION 26.700.0`), a cloud
portal, and a disposable cloud sandbox.

It matters because that method is what
`docs/content/docs/2.working-with-the-rest-api/7.discovering-v3-methods.md` calls the source
of truth for v3 discovery, and every snippet on the page reads `getData()?.result`. The page
documented something the transport could not deliver.

## The change

A body with no `result` key is wrapped: the whole body becomes `result`, and `time` is read
off it if present. `b24phpsdk` resolves the same problem the same way, naming this same
endpoint in its comment.

**Why `getData()` and not the constructor.** `#processErrors()` runs against the raw body and
recognises a failure by its `error` key. Wrapping earlier would push `error` one level down
and turn every error response into a successful one. By the time `getData()` runs, `isSuccess`
has already been decided, so the wrap cannot reinterpret a failure.

The second test case pins exactly that: an error body — which also has no `result` — must
**not** be wrapped.

## Tests

`test/integration/core/envelope-less-response.unit.spec.ts`, project `jsSdk:unit` — axios
mocked, no portal needed. Two cases:

1. an envelope-less body reaches the caller as `result`, with `time` left `undefined` rather
   than invented;
2. an error body with no `result` stays an error — `isSuccess` false, `getData()` undefined,
   the portal's code preserved.

## Docs

The discovery page gets a `::warning` stating that this method answers without the envelope,
so a reader driving it from a raw HTTP client is not surprised by a response body that is the
document itself.

## Checks

- `pnpm typecheck` — clean
- `pnpm docs:lint` — 0 errors, 0 broken links
- `pnpm lint` — clean on the changed files
- `pnpm vitest run --project jsSdk:unit` — 597 passed, 0 failed

Run on this branch alone, with the remaining audit changes stashed, so the numbers describe
this change and not a pile.

## Scope

Second of five separate changes from a v3 audit against live portals. The next one is
unrelated to this path: the `restApi:v2` object filter dialect, which the portal rejects on
the tail walkers too.
