### PR TITLE
feat(scripts): hold v3 method names against a portal's own OpenAPI document

### DIFF
--- a/.github/contributing/documentation.md
+++ b/.github/contributing/documentation.md
@@ -1,6 +1,6 @@
 # Documentation
 
-<sub>Last reviewed: 2026-08-26.</sub>
+<sub>Last reviewed: 2026-09-05.</sub>
 
 > **Agent-facing mirror:** the same surface, condensed for agents generating usage code, lives in [`skills/`](../../skills/README.md). The skill set has its own maintenance playbook ([`maintenance.md`](../../.github/contributing/maintenance.md)). When the public docs change here, the matching skill files usually need a refresh in the same PR.
 
@@ -159,7 +159,33 @@ console.log(result.getData().result)
 
 > Compile-checked example: [`documentation-b24hook-example.ts`](../../test/some-code-from-docs/contributing/documentation-b24hook-example.ts)
 >
-> **CI guard:** the `docs-lint` job runs [`scripts/check-v3-method-refs.mjs`](../../scripts/check-v3-method-refs.mjs), which blocks examples that call a non-existent `actions.v3.*` action (real actions: `call` / `callList` / `fetchList` / `callTail` / `fetchTail` / `batch` / `batchByChunk`). It no longer validates v3 *method* names against a whitelist — the SDK dropped its hardcoded v3 allowlist, so any method may be called on v3 and the server validates it. (Separate from `// @check-ignore`, which skips the `docs:typecheck-blocks` TypeScript pass.)
+> **CI guard:** the `docs-lint` job runs [`scripts/check-v3-method-refs.mjs`](../../scripts/check-v3-method-refs.mjs) over docs, skills, `README-AI.md` **and `packages/jssdk/src/`**. Two layers: it blocks examples that call a non-existent `actions.v3.*` action (real actions: `call` / `callList` / `fetchList` / `callTail` / `fetchTail` / `batch` / `batchByChunk`), and it holds every v3 **method name** against a committed snapshot of a portal's own OpenAPI document — see below.
+
+### Checking a v3 method name against a portal snapshot
+
+The docs call `rest.documentation.openapi` the source of truth for what exists on v3, and now something compares against it. `scripts/data/openapi-<kind>-<date>.json` is a reduction of that document — method name, module, operations — carrying a portal **kind** and never a domain, a scope or a credential.
+
+A name is only judged in a **method position**: a `method: '…'` literal, a v3 batch tuple, a parameter-table row whose first cell is `method`, or a JSDoc bullet documenting the `method` option. A backticked name in ordinary prose is not one, because this project writes `result.items` the same way it writes `crm.item.list`.
+
+Two verdicts, and only one of them fails:
+
+- a name in a v3 position that **no** snapshot publishes → **failure**, with `file:line`;
+- a portal method the docs never mention → informational. Never a failure: 237 of 245 are undocumented today, and a check that is red by design gets switched off.
+
+A name published by **one** snapshot is accepted. Portals genuinely differ — two cloud portals measured a day apart disagreed on 28 methods, and every on-premise method exists in the cloud while 98 cloud ones do not exist on the box. A snapshot is a baseline for prose, not a catalogue, and this must never gate runtime.
+
+**Deliberate anti-examples and placeholders** are marked with the same `// @check-ignore: <reason>` this repository already uses, on the line, the line above, or the nearest non-empty line before the fence. **The reason must name the method**, e.g. ``// @check-ignore: `some.method` is a placeholder, not a portal method``. That is deliberate: two fences already carried a marker written for the typecheck gate, and without the name an exemption granted for one reason would silently grant the other.
+
+**Refreshing a snapshot** is a local step — CI never calls a portal:
+
+```bash
+B24_HOOK='https://<portal>/rest/<userId>/<secret>/' V3_SNAPSHOT_KIND=cloud \
+  node scripts/check-v3-method-refs.mjs --refresh
+```
+
+`V3_SNAPSHOT_KIND` is the portal kind (`cloud`, `on-premise`), never a domain. Re-run it when a Bitrix24 release adds v3 methods, or when a name you know is real is rejected; commit the new file and delete the one it replaces if it is the same kind. `--coverage` prints the per-module table and always exits 0 — that is the number to quote in a PR.
+
+(Separate from `// @check-ignore` used alone, which skips the `docs:typecheck-blocks` TypeScript pass.)
 
 #### Runnable examples (`<CodeExample>`)
 

--- a/docs/content/docs/1.getting-started/2.installation/5.umd.md
+++ b/docs/content/docs/1.getting-started/2.installation/5.umd.md
@@ -182,7 +182,8 @@ The code is expected to run in the Bitrix24 user interface.
     try {
       logger.debug('Loading companies...');
 
-      const response = await b24.actions.v3.call.make({
+      // `crm.*` lives on restApi:v2 — the v3 endpoint publishes no `crm.item.*`.
+      const response = await b24.actions.v2.call.make({
         method: 'crm.item.list',
         params: {
           entityTypeId: B24Js.EnumCrmEntityTypeId.company,

--- a/docs/content/docs/1.getting-started/2.installation/5.umd.md
+++ b/docs/content/docs/1.getting-started/2.installation/5.umd.md
@@ -71,7 +71,7 @@ try {
 
 ### B24Frame :badge{label="client-side" class="align-text-top"}
 
-Here's a simple example demonstrating how to get a list of companies.
+Here's a simple example demonstrating how to get a list of records — companies under `restApi:v2`, tasks under `restApi:v3`, since `crm.*` is v2-only.
 
 ::note{color="air-secondary" icon-name="Bitrix24Icon" to="https://apidocs.bitrix24.com/local-integrations/serverside-local-app-with-ui.html"}
 The code is expected to run in the Bitrix24 user interface.
@@ -167,7 +167,7 @@ The code is expected to run in the Bitrix24 user interface.
   <title>Bitrix24 JS SDK Demo</title>
 </head>
 <body>
-<h1>Company Loader Example</h1>
+<h1>Task Loader Example</h1>
 <p>Check developer console for results</p>
 
 <script src="https://unpkg.com/@bitrix24/b24jssdk@latest/dist/umd/index.min.js"></script>
@@ -176,34 +176,31 @@ The code is expected to run in the Bitrix24 user interface.
   const logger = B24Js.LoggerFactory.createForBrowser('B24/jsSdk::umd', true);
 
   /**
-   * Load company list
+   * Load task list
    */
-  async function loadCompanies(b24) {
+  async function loadTasks(b24) {
     try {
-      logger.debug('Loading companies...');
+      logger.debug('Loading tasks...');
 
-      // `crm.*` lives on restApi:v2 — the v3 endpoint publishes no `crm.item.*`.
-      const response = await b24.actions.v2.call.make({
-        method: 'crm.item.list',
+      const response = await b24.actions.v3.call.make({
+        method: 'tasks.task.list',
         params: {
-          entityTypeId: B24Js.EnumCrmEntityTypeId.company,
-          order: { id: 'desc' },
-          select: ['id', 'title', 'createdTime']
+          select: ['id', 'title', 'created']
         }
       });
 
       const data = response.getData().result;
 
-      const companies = (data?.items || []).map((item) => {
+      const tasks = (data?.items || []).map((item) => {
         return {
           id: Number.parseInt(item.id),
           title: item.title,
-          createdTime: B24Js.Text.toDateTime(item.createdTime) // @memo this is luxon/DateTime
+          created: B24Js.Text.toDateTime(item.created) // @memo this is luxon/DateTime
         };
       });
 
-      logger.debug('Companies loaded successfully', { companies });
-      return companies;
+      logger.debug('Tasks loaded successfully', { tasks });
+      return tasks;
     } catch (error) {
       logger.error('Request failed', { error });
       throw error;
@@ -218,11 +215,11 @@ The code is expected to run in the Bitrix24 user interface.
       // Initialize B24Frame instance
       let b24 = await B24Js.initializeB24Frame();
 
-      // Load companies
-      const companies = await loadCompanies(b24);
+      // Load tasks
+      const tasks = await loadTasks(b24);
 
       // Further data processing...
-      logger.info('Loaded ' + companies.length + ' companies');
+      logger.info('Loaded ' + tasks.length + ' tasks');
     } catch (error) {
       logger.error('Some problems', { error })
     }

--- a/docs/content/docs/1.getting-started/3.migration/1.v1.md
+++ b/docs/content/docs/1.getting-started/3.migration/1.v1.md
@@ -153,6 +153,7 @@ For `restApi:v2`, you must use the [`b24.actions.v2.call.make(options)`{lang="ts
 
 For `restApi:v3`, you must use the [`b24.actions.v3.call.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-rest-api-ver3/) method.
 
+// @check-ignore: `some.method` is a placeholder, not a portal method
 ```diff
 - await b24.callMethod('some.method', { filter: { '>id': 123 } }, 100)
 + await b24.actions.v3.call.make({
@@ -198,6 +199,7 @@ For `restApi:v2`, you must use the [`b24.actions.v2.callList.make(options)`{lang
 
 For `restApi:v3`, you must use the [`b24.actions.v3.callList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/call-list-rest-api-ver3/) method.
 
+// @check-ignore: `some.method` is a placeholder, not a portal method
 ```diff
 - await b24.callListMethod('some.method', { filter: { '>id': 123 } }, null, 'items')
 + await b24.actions.v3.callList.make({
@@ -243,6 +245,7 @@ For `restApi:v2`, you must use the [`b24.actions.v2.fetchList.make(options)`{lan
 
 For `restApi:v3`, you must use the [`b24.actions.v3.fetchList.make(options)`{lang="ts-type"}](/docs/working-with-the-rest-api/fetch-list-rest-api-ver3/) method.
 
+// @check-ignore: `some.method` is a placeholder, not a portal method
 ```diff
 - b24.fetchListMethod('some.method', { filter: { '>id': 123 } }, 'id', 'items')
 + b24.actions.v3.fetchList.make({

--- a/docs/content/docs/2.working-with-the-rest-api/0.index.md
+++ b/docs/content/docs/2.working-with-the-rest-api/0.index.md
@@ -305,7 +305,7 @@ const data = response.getData()
 ```
 
 #rest-api-ver3
-// @check-ignore: top-level return in error-handling illustration
+// @check-ignore: top-level return in error-handling illustration; `some.method` is a placeholder, not a portal method
 ```typescript
 const response = await $b24.actions.v3.call.make({
   method: 'some.method',

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
@@ -74,7 +74,7 @@ The SDK does not keep a client-side list of v3 methods: `CallV3.make()`{lang="ts
 
 For successful requests, always check `isSuccess` and handle errors:
 
-// @check-ignore: top-level return in error-handling illustration
+// @check-ignore: top-level return in error-handling illustration; `some.method` is a placeholder, not a portal method
 ```ts
 const response = await $b24.actions.v3.call.make({
   method: 'some.method',

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallListV3.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 3.'
 category: 'actions'
-audited: 2026-08-29
+audited: 2026-09-05
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: CallList
@@ -71,7 +71,7 @@ The `options` object contains the following properties:
 
 | Parameter | Type | Required | Description |
 |----|----|----|----|
-| **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `crm.contact.list`, `tasks.task.list`). |
+| **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `tasks.task.list`, `main.eventlog.list`). |
 | **`params`** | `Omit<TypeCallParamsV3, 'pagination' \| 'order' \| 'filter'> & { filter?: TypeFilterV3 }`{lang="ts-type"} | No | Request parameters, excluding the `pagination` and `order` parameters, and with `filter` narrowed to the `restApi:v3` array form (see [Limitations](#limitations)). The `pagination` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `cursorIdKey` (which defaults to `idKey`) ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
 | **`idKey`** | `string`{lang="ts-type"} | No | Name of the id field **as it appears in each response item**; its value drives the cursor. Default: `'id'`. Set it to match the id field the method returns. |
 | **`cursorIdKey`** | `string`{lang="ts-type"} | No | Field name used in the **request** for `order` and the `[field, '>', n]` page filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs from the response field name (e.g. an uppercase request field but a lowercase response id): pass `idKey: 'id', cursorIdKey: 'ID'`. |
@@ -125,7 +125,7 @@ Some v3 list methods (e.g. `note.*`) also return a `nextCursor`{lang="ts-type"} 
 
 Always check the result using `isSuccess` and handle errors:
 
-// @check-ignore: top-level return in error-handling illustration
+// @check-ignore: top-level return in error-handling illustration; `some.method` is a placeholder, not a portal method
 ```ts
 const response = await $b24.actions.v3.callList.make({
   method: 'some.method',
@@ -210,6 +210,7 @@ try {
 
 Some methods sort / filter by one field name but return another (for example an uppercase `ID` in the request vs a lowercase `id` in the payload). Set `idKey` to the **response** field and `cursorIdKey` to the **request** field:
 
+// @check-ignore: `some.list` is a placeholder, not a portal method
 ```ts
 const response = await $b24.actions.v3.callList.make({
   method: 'some.list',

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: FetchListV3.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 3 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-08-29
+audited: 2026-09-05
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: FetchList
@@ -69,7 +69,7 @@ The `options` object contains the following properties:
 
 | Parameter | Type | Required | Description |
 |----|----|----|----|
-| **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `crm.contact.list`, `tasks.task.list`). |
+| **`method`** | `string`{lang="ts-type"} | Yes | REST API method name that returns a data list (e.g., `tasks.task.list`, `main.eventlog.list`). |
 | **`params`** | `Omit<TypeCallParamsV3, 'pagination' \| 'order' \| 'filter'> & { filter?: TypeFilterV3 }`{lang="ts-type"} | No | Request parameters, excluding the `pagination` and `order` parameters, and with `filter` narrowed to the `restApi:v3` array form (see [Limitations](#limitations)). The `pagination` parameter is reserved because the method retrieves all data in a single call. The `order` parameter is reserved because cursor-based pagination requires sorting strictly by `cursorIdKey` (which defaults to `idKey`) ascending — see [Limitations](#limitations). Use `filter` and `select` to control the selection. |
 | **`idKey`** | `string`{lang="ts-type"} | No | Name of the id field **as it appears in each response item**; its value drives the cursor. Default: `'id'`. Set it to match the id field the method returns. |
 | **`cursorIdKey`** | `string`{lang="ts-type"} | No | Field name used in the **request** for `order` and the `[field, '>', n]` page filter. Defaults to `idKey`. Set it only when the sortable / filterable field name differs from the response field name (e.g. an uppercase request field but a lowercase response id): pass `idKey: 'id', cursorIdKey: 'ID'`. |
@@ -134,6 +134,7 @@ Some v3 list methods (e.g. `note.*`) also return a `nextCursor`{lang="ts-type"} 
 
 Since the method returns an asynchronous generator, errors are handled differently than in `CallListV3.make()`{lang="ts-type"}:
 
+// @check-ignore: `some.method` is a placeholder, not a portal method
 ```ts
 import { SdkError } from '@bitrix24/b24jssdk'
 
@@ -259,6 +260,7 @@ try {
 
 Some methods sort / filter by one field name but return another (for example an uppercase `ID` in the request vs a lowercase `id` in the payload). Set `idKey` to the **response** field and `cursorIdKey` to the **request** field:
 
+// @check-ignore: `some.list` is a placeholder, not a portal method
 ```ts
 const generator = $b24.actions.v3.fetchList.make({
   method: 'some.list',

--- a/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
+++ b/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
@@ -141,10 +141,17 @@ but you almost always want to **filter more narrowly** instead. See the
 [CallList Limitations](/docs/working-with-the-rest-api/call-list-rest-api-ver2/#limitations)
 for details.
 
-## Side-by-side: the same query in v2 and v3
+## Side-by-side: the same filter in v2 and v3
 
-Open deals (`stageId` not in `WON` / `LOSE`) with an amount between 50 000 and
-200 000, created in the last six months:
+The dialect is the point here, not the entity — and the two halves below cannot
+use the same method, because **`crm.*` is `restApi:v2`-only**. The v3 endpoint
+publishes no `crm.item.*` on any portal measured; what `crm` it does publish is
+timeline email. So the v2 half asks for open deals, and the v3 half asks the
+same *shape* of question of tasks: a NOT-IN group, a `between`, and a lower bound
+on a date.
+
+v2 — open deals (`stageId` not in `WON` / `LOSE`) with an amount between 50 000
+and 200 000, created in the last six months:
 
 ```ts [v2]
 import { EnumCrmEntityTypeId, Text } from '@bitrix24/b24jssdk'
@@ -169,24 +176,28 @@ const response = await $b24.actions.v2.callList.make({
 })
 ```
 
+v3 — unfinished tasks (`status` not in *completed* / *deferred*) with a story-point
+estimate between 5 and 20, created in the last six months:
+
 ```ts [v3]
-import { EnumCrmEntityTypeId, Text } from '@bitrix24/b24jssdk'
+import { Text } from '@bitrix24/b24jssdk'
 
 const sixMonthsAgo = new Date()
 sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
 
 const response = await $b24.actions.v3.callList.make({
-  method: 'crm.item.list',
+  method: 'tasks.task.list',
   params: {
-    entityTypeId: EnumCrmEntityTypeId.deal,
     filter: [
       // v3 has no "not in" operator — wrap `in` in a NOT group (`negative: true`).
       // The `FilterV3.not(FilterV3.in(...))` helper builds the same shape.
-      { negative: true, conditions: [['stageId', 'in', ['WON', 'LOSE']]] },
-      ['opportunity', 'between', [50000, 200000]],
-      ['createdTime', '>=', Text.toB24Format(sixMonthsAgo)]
+      { negative: true, conditions: [['status', 'in', [5, 6]]] },
+      ['storyPoints', 'between', [5, 20]],
+      ['created', '>=', Text.toB24Format(sixMonthsAgo)]
     ],
-    select: ['id', 'title', 'stageId', 'opportunity']
+    // v3 field names are camelCase — `tasks.task.field.list` is how you ask the
+    // portal for the real ones rather than guessing.
+    select: ['id', 'title', 'status', 'storyPoints']
   },
   idKey: 'id',
   customKeyForResult: 'items'

--- a/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
+++ b/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
@@ -191,6 +191,7 @@ const response = await $b24.actions.v3.callList.make({
     filter: [
       // v3 has no "not in" operator — wrap `in` in a NOT group (`negative: true`).
       // The `FilterV3.not(FilterV3.in(...))` helper builds the same shape.
+      // 5 = completed, 6 = deferred
       { negative: true, conditions: [['status', 'in', [5, 6]]] },
       ['storyPoints', 'between', [5, 20]],
       ['created', '>=', Text.toB24Format(sixMonthsAgo)]

--- a/docs/server/api/ai.post.ts
+++ b/docs/server/api/ai.post.ts
@@ -117,7 +117,7 @@ export default defineEventHandler(async (event) => {
   const safeRestApiVersion = restApiVersion === 'vue' ? 'vue' : 'nuxt'
 
   const safePage = currentPage
-    ? currentPage.replace(/[^\w\-/. ]/gi, '').slice(0, 300)
+    ? currentPage.replace(/[^\w\-/. ]/g, '').slice(0, 300)
     : undefined
 
   const mcpTools = mcpToolsToAiTools()

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "lint:md-fix": "pnpm run lint:md -- --fix",
     "lint:md-links": "node scripts/md-internal-links.mjs",
     "lint:v3-refs": "node scripts/check-v3-method-refs.mjs",
+    "lint:v3-coverage": "node scripts/check-v3-method-refs.mjs --coverage",
     "docs:lint-pages": "node scripts/docs-lint.mjs",
     "docs:lint-pages:strict": "node scripts/docs-lint.mjs --strict",
     "docs:lint-links": "node scripts/docs-link-check.mjs",

--- a/packages/jssdk/src/core/actions/v3/aggregate.ts
+++ b/packages/jssdk/src/core/actions/v3/aggregate.ts
@@ -53,11 +53,12 @@ export class AggregateV3 extends AbstractAction {
    *
    * @returns {Promise<Result<AggregateResultV3>>} buckets keyed by function then field name.
    *
+   * @check-ignore: `some.entity.aggregate` is a placeholder, not a portal method
+   *
    * @example
    * import { FilterV3 } from '@bitrix24/b24jssdk'
    *
    * const response = await b24.actions.v3.aggregate.make({
-   *   // @check-ignore: `some.entity.aggregate` is a placeholder, not a portal method
    *   method: 'some.entity.aggregate',
    *   select: { sum: { amount: 'totalAmount' }, count: ['id'] },
    *   params: { filter: FilterV3.build(FilterV3.eq('status', 'NEW')) }

--- a/packages/jssdk/src/core/actions/v3/aggregate.ts
+++ b/packages/jssdk/src/core/actions/v3/aggregate.ts
@@ -57,6 +57,7 @@ export class AggregateV3 extends AbstractAction {
    * import { FilterV3 } from '@bitrix24/b24jssdk'
    *
    * const response = await b24.actions.v3.aggregate.make({
+   *   // @check-ignore: `some.entity.aggregate` is a placeholder, not a portal method
    *   method: 'some.entity.aggregate',
    *   select: { sum: { amount: 'totalAmount' }, count: ['id'] },
    *   params: { filter: FilterV3.build(FilterV3.eq('status', 'NEW')) }

--- a/packages/jssdk/src/core/actions/v3/batch.ts
+++ b/packages/jssdk/src/core/actions/v3/batch.ts
@@ -53,18 +53,18 @@ export class BatchV3 extends AbstractBatch {
    * @example
    * import type { AjaxResult } from '@bitrix24/b24jssdk'
    *
-   * interface Contact { id: number, name: string }
-   * const response = await b24.actions.v3.batch.make<{ item: Contact }>({
+   * interface Task { id: number, title: string }
+   * const response = await b24.actions.v3.batch.make<{ item: Task }>({
    *   calls: {
-   *     first: ['crm.item.get', { entityTypeId: 3, id: 1 }],
-   *     second: ['crm.item.get', { entityTypeId: 3, id: 2 }]
+   *     first: ['tasks.task.get', { taskId: 1 }],
+   *     second: ['tasks.task.get', { taskId: 2 }]
    *   },
    *   options: { isHaltOnError: false, returnAjaxResult: true, requestId: 'batch-123' }
    * })
    * if (!response.isSuccess) {
    *   throw new Error(`Problem: ${response.getErrorMessages().join('; ')}`)
    * }
-   * const data = response.getData()! as Record<string, AjaxResult<{ item: Contact }>>
+   * const data = response.getData()! as Record<string, AjaxResult<{ item: Task }>>
    * console.log(data['first']!.getData()!.result.item)
    *
    * @warning The maximum number of commands in one batch request is 50.

--- a/packages/jssdk/src/core/actions/v3/call-list.ts
+++ b/packages/jssdk/src/core/actions/v3/call-list.ts
@@ -38,7 +38,7 @@ export class CallListV3 extends AbstractAction {
    * @template T - The type of the elements of the returned array (default is `unknown`).
    *
    * @param {ActionCallListV3} options - parameters for executing the request.
-   *     - `method: string` - The name of the REST API method that returns a list of data (for example: `crm.item.list`, `tasks.task.list`)
+   *     - `method: string` - The name of the REST API method that returns a list of data (for example: `tasks.task.list`, `main.eventlog.list`)
    *     - `params?: Omit<TypeCallParamsV3, 'pagination' | 'order'>` - Request parameters, excluding the `pagination` and `order` parameters,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.

--- a/packages/jssdk/src/core/actions/v3/call.ts
+++ b/packages/jssdk/src/core/actions/v3/call.ts
@@ -24,7 +24,7 @@ export class CallV3 extends AbstractAction {
    * @template T - The expected data type in the response (default is `unknown`).
    *
    * @param {ActionCallV3} options - parameters for executing the request.
-   *     - `method: string` - REST API method name (eg: `crm.item.get`)
+   *     - `method: string` - REST API method name (eg: `tasks.task.get`)
    *     - `params?: TypeCallParamsV3` - Parameters for calling the method.
    *     - `requestId?: string` - Unique request identifier for tracking. Used for query deduplication and debugging.
    *

--- a/packages/jssdk/src/core/actions/v3/fetch-list.ts
+++ b/packages/jssdk/src/core/actions/v3/fetch-list.ts
@@ -40,7 +40,7 @@ export class FetchListV3 extends AbstractAction {
    * @template T - The type of items in the returned arrays (default is `unknown`).
    *
    * @param {ActionFetchListV3} options - parameters for executing the request.
-   *     - `method: string` - The name of the REST API method that returns a list of data (for example: `crm.item.list`, `tasks.task.list`)
+   *     - `method: string` - The name of the REST API method that returns a list of data (for example: `tasks.task.list`, `main.eventlog.list`)
    *     - `params?: Omit<TypeCallParamsV3, 'pagination' | 'order'>` - Request parameters, excluding the `pagination` and `order` parameters,
    *         since the method is designed to obtain all data in one call.
    *         Note: Use `filter`, `order`, and `select` to control the selection.

--- a/packages/jssdk/src/tools/batch-ref-v3.ts
+++ b/packages/jssdk/src/tools/batch-ref-v3.ts
@@ -46,7 +46,7 @@ function assertPath(path: string, who: string): void {
  *   calls: [
  *     { method: 'tasks.task.list', as: 'tasks', params: { select: ['id'] } },
  *     {
- *       method: 'tasks.task.comment.list',
+ *       method: 'tasks.task.result.list',
  *       // server substitutes the array of ids collected from the first command's items[]
  *       params: { filter: [['taskId', 'in', R.refArray('tasks.id')]] }
  *     }

--- a/scripts/__tests__/check-v3-method-refs.test.mjs
+++ b/scripts/__tests__/check-v3-method-refs.test.mjs
@@ -13,6 +13,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
+import { reduceDocument } from '../check-v3-method-refs.mjs'
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
@@ -252,4 +253,148 @@ test('the fence tag decides the dialect when nothing else in the block does', ()
     assert.match(r.stdout, /side-by-side\.md:6 "crm\.item\.list"/)
     assert.doesNotMatch(r.stdout, /side-by-side\.md:2 /)
   })
+})
+
+test('a method name with a camelCase segment is seen — the snapshot publishes such names', () => {
+  // `crm.activity.mail.getContent` is in the committed snapshot. An earlier
+  // `METHOD_NAME` demanded lower-case throughout and simply did not see it,
+  // which is worse than reporting it wrong: a gate blind to a class of real
+  // names cannot claim fidelity to the real surface.
+  withFixture({
+    'docs/content/docs/camel.md': [
+      '```ts',
+      'await $b24.actions.v3.call.make({ method: \'crm.activity.mail.getThread\' })',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const published = runCheck(root, { snapshots: { cloud: ['crm.activity.mail.getThread'] } })
+    assert.equal(published.status, 0, `stdout:\n${published.stdout}`)
+
+    const absent = runCheck(root, { snapshots: { cloud: ['tasks.task.get'] } })
+    assert.equal(absent.status, 1, `stdout:\n${absent.stdout}`)
+    assert.match(absent.stdout, /"crm\.activity\.mail\.getThread"/)
+  })
+})
+
+test('a `callMethod(...)` argument is a method position too', () => {
+  // v2 by definition, so the version rule rules it out — but it is collected,
+  // because a name read in four positions and not the fifth is a blind spot
+  // people find by accident.
+  withFixture({
+    'docs/content/docs/legacy.md': [
+      'Under v3 this becomes `actions.v3.call.make`:',
+      '',
+      '```ts',
+      'await b24.callMethod(\'no.such.method\', {})',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root, { snapshots: { cloud: ['tasks.task.get'] } })
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /"no\.such\.method" is used as a v3 method \(callMethod argument\)/)
+  })
+})
+
+test('a malformed snapshot names itself instead of crashing from inside a map', () => {
+  withFixture({ 'docs/content/docs/ok.md': '# ok\n' }, (root) => {
+    const dir = join(root, 'snapshots')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'openapi-truncated.json'), '{"methods": [{"modul', 'utf8')
+    const r = spawnSync(process.execPath, [SCRIPT], {
+      env: { ...process.env, V3_CHECK_ROOT: root, V3_SNAPSHOT_DIR: dir },
+      encoding: 'utf8'
+    })
+    assert.notEqual(r.status, 0)
+    assert.match(r.stderr, /openapi-truncated\.json is not valid JSON/)
+  })
+})
+
+test('the v3 batch tuple is a method position', () => {
+  // `calls: { first: ['x.y', {…}] }` — no `method:` key names it, which is why
+  // it needs a rule of its own.
+  withFixture({
+    'docs/content/docs/batch.md': [
+      '```ts',
+      'await $b24.actions.v3.batch.make({',
+      '  calls: { first: [\'no.such.method\', { id: 1 }] }',
+      '})',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root, { snapshots: { cloud: ['tasks.task.get'] } })
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /"no\.such\.method" is used as a v3 method \(batch tuple\)/)
+  })
+})
+
+test('a parameter-table row whose first cell is `method` is a method position', () => {
+  // The example inside that prose is the first thing a reader copies.
+  withFixture({
+    'docs/content/docs/table-ver3.md': [
+      '| Parameter | Type | Description |',
+      '| --- | --- | --- |',
+      '| **`method`** | `string` | REST API method name (e.g. `no.such.method`). |',
+      '| **`params`** | `object` | Passed through to the portal. |'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root, { snapshots: { cloud: ['tasks.task.get'] } })
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /table-ver3\.md:3 "no\.such\.method" is used as a v3 method \(method parameter row\)/)
+    // The `params` row is not about the method argument, and `string` is not a
+    // method name — neither may be picked up.
+    assert.doesNotMatch(r.stdout, /table-ver3\.md:4/)
+  })
+})
+
+test('the path decides when no fence tag and no nearby call do', () => {
+  // Far enough from any `actions.vN.` mention that only the directory answers.
+  // The earlier version of this rule matched `v3` as a *substring* of the path,
+  // so a directory named `v3-migration-notes/` forced v3 on content about v2 —
+  // hence the deliberately awkward directory names below.
+  const filler = Array.from({ length: 14 }, (_, i) => ` * filler line ${i}`).join('\n')
+  const block = [
+    '/**',
+    ' * Documentation for the call action.',
+    filler,
+    ' *     - `method: string` - REST API method name (eg: `no.such.method`)',
+    ' */',
+    'export class X {}'
+  ].join('\n')
+  withFixture({
+    'packages/jssdk/src/core/actions/v3/call.ts': block,
+    'packages/jssdk/src/core/actions/v2/call.ts': block,
+    'packages/jssdk/src/v3-migration-notes/legacy.ts': block
+  }, (root) => {
+    const r = runCheck(root, { snapshots: { cloud: ['tasks.task.get'] } })
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /v3\/call\.ts:\d+ "no\.such\.method"/)
+    assert.doesNotMatch(r.stdout, /v2\/call\.ts/)
+    // A directory that merely *contains* "v3" is not a version decision.
+    assert.doesNotMatch(r.stdout, /v3-migration-notes/)
+  })
+})
+
+test('reduceDocument keeps what the check needs and drops the rest', () => {
+  // Exercised here because `--refresh` is a manual step the suite never runs,
+  // and this is the function that decides what a committed snapshot contains.
+  const reduced = reduceDocument({
+    openapi: '3.0.0',
+    info: { title: 'Bitrix24 REST V3 API' },
+    paths: {
+      '/tasks.task.list': { post: {} },
+      '/crm.activity.mail.getContent': { post: {}, get: {} },
+      '/': {}
+    }
+  }, 'cloud', new Date('2026-09-05T00:00:00Z'))
+
+  assert.equal(reduced.portalKind, 'cloud')
+  assert.equal(reduced.snapshotDate, '2026-09-05')
+  assert.equal(reduced.totals.methods, 2)
+  assert.deepEqual(reduced.methods.map(m => m.method), ['crm.activity.mail.getContent', 'tasks.task.list'])
+  assert.deepEqual(reduced.methods[0].operations, ['get', 'post'])
+  // Nothing that could name the portal or its rights comes through.
+  const serialised = JSON.stringify(reduced)
+  for (const forbidden of ['info', 'title', 'scopes', 'summary', 'servers']) {
+    assert.doesNotMatch(serialised, new RegExp(forbidden), `${forbidden} must not survive the reduction`)
+  }
 })

--- a/scripts/__tests__/check-v3-method-refs.test.mjs
+++ b/scripts/__tests__/check-v3-method-refs.test.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 // Fixture tests for scripts/check-v3-method-refs.mjs.
 //
-// The script guards docs/skills against referencing a non-existent
-// `actions.v3.<x>` action. (It used to also validate v3 *method* names against a
-// hardcoded allowlist; that allowlist was removed — the server is the source of
-// truth — so the method-check tests went with it.)
+// Two layers. The first guards docs/skills against referencing a non-existent
+// `actions.v3.<x>` action. The second (#463) holds v3 *method* names against a
+// committed snapshot of a portal's own OpenAPI document — the layer that
+// replaced the hardcoded allowlist removed in 2.0.0, this time without a list.
 //
 // Run with: node --test scripts/__tests__/check-v3-method-refs.test.mjs
 
@@ -42,11 +42,23 @@ function withFixture(files, run) {
   }
 }
 
-function runCheck(root) {
-  return spawnSync(process.execPath, [SCRIPT], {
-    env: { ...process.env, V3_CHECK_ROOT: root },
-    encoding: 'utf8'
-  })
+function runCheck(root, { snapshots, args = [] } = {}) {
+  const env = { ...process.env, V3_CHECK_ROOT: root }
+  if (snapshots !== undefined) {
+    const dir = join(root, 'snapshots')
+    mkdirSync(dir, { recursive: true })
+    for (const [name, methods] of Object.entries(snapshots)) {
+      writeFileSync(join(dir, `openapi-${name}.json`), JSON.stringify({
+        portalKind: name,
+        snapshotDate: '2026-01-01',
+        totals: { methods: methods.length, modules: 1 },
+        methodsPerModule: {},
+        methods: methods.map(method => ({ method, module: method.split('.')[0], operations: ['post'] }))
+      }), 'utf8')
+    }
+    env.V3_SNAPSHOT_DIR = dir
+  }
+  return spawnSync(process.execPath, [SCRIPT, ...args], { env, encoding: 'utf8' })
 }
 
 test('clean: real actions (including callTail/fetchTail) and any method pass', () => {
@@ -100,5 +112,144 @@ test('a method passed to v2 (not v3) is never flagged', () => {
   }, (root) => {
     const r = runCheck(root)
     assert.equal(r.status, 0, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The method-name layer (#463).
+// ---------------------------------------------------------------------------
+
+test('a v3 method no snapshot publishes is flagged, with the line', () => {
+  withFixture({
+    'docs/content/docs/v3.md': [
+      '```ts',
+      'await $b24.actions.v3.call.make({ method: \'crm.item.get\' })',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root, { snapshots: { cloud: ['tasks.task.get'] } })
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /v3\.md:2 "crm\.item\.get" is used as a v3 method/)
+  })
+})
+
+test('without a snapshot the layer is inert, and says so rather than passing quietly', () => {
+  withFixture({
+    'docs/content/docs/v3.md': [
+      '```ts',
+      'await $b24.actions.v3.call.make({ method: \'crm.item.get\' })',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root)
+    assert.equal(r.status, 0, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /no portal snapshot/)
+  })
+})
+
+test('a name published by one snapshot only is accepted — portals differ', () => {
+  // Measured: two cloud portals a day apart disagreed on 28 methods, and every
+  // on-premise method exists in the cloud while 98 cloud ones do not exist on
+  // the box. A name has to clear the union, not every snapshot.
+  withFixture({
+    'docs/content/docs/v3.md': [
+      '```ts',
+      'await $b24.actions.v3.call.make({ method: \'note.collection.list\' })',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root, { snapshots: { 'cloud': ['note.collection.list'], 'on-premise': ['tasks.task.get'] } })
+    assert.equal(r.status, 0, `stdout:\n${r.stdout}`)
+  })
+})
+
+test('a marker naming the method silences it; one naming something else does not', () => {
+  const block = [
+    '```ts',
+    'await $b24.actions.v3.call.make({ method: \'some.method\' })',
+    '```'
+  ]
+  withFixture({
+    'docs/content/docs/marked.md': ['// @check-ignore: `some.method` is a placeholder', ...block].join('\n'),
+    'docs/content/docs/other.md': ['// @check-ignore: top-level return in an illustration', ...block].join('\n')
+  }, (root) => {
+    const r = runCheck(root, { snapshots: { cloud: ['tasks.task.get'] } })
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    // The marker written for a different gate must not silence this one: an
+    // exemption granted for one reason cannot acquire a second by proximity.
+    assert.match(r.stdout, /other\.md:\d+ "some\.method"/)
+    assert.doesNotMatch(r.stdout, /marked\.md/)
+  })
+})
+
+test('a backticked name in ordinary prose is not a method position', () => {
+  // This repository writes `result.items` and `crm.item.list` in backticks with
+  // the same syntax; only the position tells them apart.
+  withFixture({
+    'docs/content/docs/prose.md': [
+      'Under `actions.v3.call.make` the payload key is `result.items`, not',
+      '`crm.item.list` — the latter is a v2 method name mentioned in passing.'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root, { snapshots: { cloud: ['tasks.task.get'] } })
+    assert.equal(r.status, 0, `stdout:\n${r.stdout}`)
+  })
+})
+
+test('a JSDoc method-option bullet in v3 source is a method position; its v2 twin is not', () => {
+  const bullet = version => [
+    '/**',
+    ` * @param options - parameters for actions.${version}.call.`,
+    ' *     - `method: string` - REST API method name (eg: `crm.item.get`)',
+    ' */',
+    'export class X {}'
+  ].join('\n')
+  withFixture({
+    'packages/jssdk/src/core/actions/v3/call.ts': bullet('v3'),
+    'packages/jssdk/src/core/actions/v2/call.ts': bullet('v2')
+  }, (root) => {
+    const r = runCheck(root, { snapshots: { cloud: ['tasks.task.get'] } })
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /v3\/call\.ts:3 "crm\.item\.get"/)
+    assert.doesNotMatch(r.stdout, /v2\/call\.ts/)
+  })
+})
+
+test('--coverage reports and always exits 0, even with an unpublished name', () => {
+  withFixture({
+    'docs/content/docs/v3.md': [
+      '```ts',
+      'await $b24.actions.v3.call.make({ method: \'crm.item.get\' })',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root, { snapshots: { cloud: ['tasks.task.get'] }, args: ['--coverage'] })
+    assert.equal(r.status, 0, `stdout:\n${r.stdout}`)
+    assert.match(r.stdout, /publishes 1, documented here 0/)
+    assert.match(r.stdout, /published by no snapshot: 1 — crm\.item\.get/)
+  })
+})
+
+test('the fence tag decides the dialect when nothing else in the block does', () => {
+  // The `[v2]` / `[v3]` tag is the only thing separating the two halves of a
+  // side-by-side page, and a snippet that shows just the options object has no
+  // `actions.vN.` call for the fallback to read. Without this rule the block
+  // below is unattributed and silently skipped.
+  withFixture({
+    'docs/content/docs/side-by-side.md': [
+      '```ts [v2]',
+      'const options = { method: \'crm.item.list\', params: {} }',
+      '```',
+      '',
+      '```ts [v3]',
+      'const options = { method: \'crm.item.list\', params: {} }',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    const r = runCheck(root, { snapshots: { cloud: ['tasks.task.get'] } })
+    assert.equal(r.status, 1, `stdout:\n${r.stdout}`)
+    // Line 6 is the v3 half; line 2 is the v2 half and must stay silent.
+    assert.match(r.stdout, /side-by-side\.md:6 "crm\.item\.list"/)
+    assert.doesNotMatch(r.stdout, /side-by-side\.md:2 /)
   })
 })

--- a/scripts/_v3-method-positions.mjs
+++ b/scripts/_v3-method-positions.mjs
@@ -1,0 +1,183 @@
+/**
+ * Where a Bitrix24 REST **method name** genuinely appears, as opposed to where a
+ * dotted token merely looks like one.
+ *
+ * Shared by `check-v3-method-refs.mjs` and its tests, so the rule that decides
+ * "this is a method" is stated once. It has to be narrow: this repository writes
+ * `result.items`, `response.isSuccess` and `crm.item.list` in backticks with the
+ * same syntax, and only the position tells them apart (#463).
+ *
+ * Four positions, every one of them taken from a real occurrence rather than
+ * imagined:
+ *
+ *  1. **A code literal** — `method: 'crm.item.list'`. The plain case.
+ *  2. **A v3 batch tuple** — `first: ['crm.item.get', { … }]`, the shape
+ *     `actions.v3.batch.make({ calls })` takes. The name is the first element of
+ *     an array literal, so no `method:` key names it.
+ *  3. **A parameter-table row** whose first cell is `method` — the docs describe
+ *     the argument in prose there, and the example inside that prose is what a
+ *     reader copies first.
+ *  4. **A JSDoc bullet for the `method` option** — `` - `method: string` - … ``
+ *     followed by an example in backticks. Five of the eight known defect sites
+ *     were of this shape, which is why `packages/jssdk/src/` has to be walked at
+ *     all.
+ *
+ * Everything else — a backticked name in ordinary prose, a heading, a link — is
+ * deliberately **not** a method position. That is the difference between a check
+ * that can be left on and one that gets disabled.
+ */
+
+/**
+ * A Bitrix24 method name: lower-case segments separated by dots, at least two.
+ *
+ * Anchored at both ends by the caller so `tasks.task.list` matches but the
+ * `list` of `crm.item.list` inside a longer identifier does not.
+ */
+const METHOD_NAME = /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]+)+$/
+
+/** Every backticked span on a line, unwrapped. */
+function backtickedSpans(line) {
+  return [...line.matchAll(/`([^`]+)`/g)].map(m => m[1].trim())
+}
+
+function isMethodName(token) {
+  return METHOD_NAME.test(token)
+}
+
+/**
+ * The cells of a markdown table row, by position.
+ *
+ * Split rather than filtered, for the reason `check-api-reference-index.mjs`
+ * learned the hard way: dropping empty cells shifts every later column left, so
+ * an empty first cell would make the second look like the first.
+ */
+function tableCells(line) {
+  const trimmed = line.trim()
+  if (!trimmed.startsWith('|') || !trimmed.endsWith('|')) {
+    return null
+  }
+  return trimmed.split('|').slice(1, -1).map(cell => cell.trim())
+}
+
+/** Is this row's first cell the `method` parameter? */
+function isMethodParamRow(cells) {
+  if (cells === null || cells.length < 2) {
+    return false
+  }
+  // `| **`method`** | ... |` — strip the emphasis and the backticks.
+  const first = cells[0].replaceAll('*', '').replaceAll('`', '').trim()
+  return first === 'method'
+}
+
+/** Is this line a JSDoc bullet documenting the `method` option? */
+function isMethodOptionBullet(line) {
+  return /^[\s*]*-\s*`method\s*:/.test(line)
+}
+
+/**
+ * Collect every method-name occurrence in `body`, with its 1-based line.
+ *
+ * @param {string} body File contents.
+ * @returns {{ name: string, line: number, position: string }[]}
+ */
+export function collectMethodPositions(body) {
+  const found = []
+  const lines = body.split(/\r\n?|\n/)
+
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1
+    const add = (name, position) => {
+      if (isMethodName(name)) {
+        found.push({ name, line: lineNumber, position })
+      }
+    }
+
+    // 1. `method: 'x.y'` — in a fence, in a snippet, in source.
+    for (const m of line.matchAll(/\bmethod\s*:\s*['"]([^'"]+)['"]/g)) {
+      add(m[1], 'method literal')
+    }
+
+    // 2. `['x.y', { … }]` — the v3 batch tuple.
+    for (const m of line.matchAll(/\[\s*['"]([^'"]+)['"]\s*,/g)) {
+      add(m[1], 'batch tuple')
+    }
+
+    // 3 and 4 read the same way: backticked examples inside a line that is
+    // *about* the `method` argument.
+    const cells = tableCells(line)
+    if (isMethodParamRow(cells) || isMethodOptionBullet(line)) {
+      for (const span of backtickedSpans(line)) {
+        add(span, isMethodParamRow(cells) ? 'method parameter row' : 'method option bullet')
+      }
+    }
+  })
+
+  return found
+}
+
+export const __testing = { isMethodName, tableCells, isMethodParamRow, isMethodOptionBullet }
+
+/**
+ * Which API version a line is talking about, or `null` when nothing says.
+ *
+ * Order matters, most specific first, and each rule exists because a real line
+ * needed it:
+ *
+ *  1. **The enclosing fence tag** — the docs mark a snippet ```` ```ts [v3] ````,
+ *     and `5.filtering.md` shows the same `crm.item.list` call twice on one
+ *     page, once under `[v2]` where it is correct and once under `[v3]` where it
+ *     is the defect. Nothing but the tag separates them.
+ *  2. **A nearby `actions.vN.`** — looked for both above and below, because the
+ *     `method:` line sits *inside* the call it belongs to.
+ *  3. **The path** — `src/core/actions/v3/`, or a `v3` in the basename
+ *     (`batch-ref-v3.ts`), or a `-ver3.md` docs page. This is what keeps the v2
+ *     JSDoc twins silent: their prose is identical, only the directory differs.
+ *
+ * Returning `null` is a real answer and the safe one: an unattributed line is
+ * left alone rather than guessed at.
+ */
+const NEARBY_LINES = 8
+
+export function versionContextAt(file, lines, index) {
+  // 1. The fence that encloses this line, if any.
+  let fenceTag = null
+  let open = false
+  for (let i = 0; i <= index; i++) {
+    const fence = /^\s*`{3,}([^`].*)?$/.exec(lines[i])
+    if (fence === null) {
+      continue
+    }
+    if (open) {
+      open = false
+      fenceTag = null
+    } else {
+      open = true
+      const info = (fence[1] ?? '').trim()
+      fenceTag = /\[v3\]/.test(info) ? 'v3' : /\[v2\]/.test(info) ? 'v2' : null
+    }
+  }
+  if (open && fenceTag !== null) {
+    return fenceTag
+  }
+
+  // 2. An `actions.vN.` in the neighbourhood, either side.
+  const from = Math.max(0, index - NEARBY_LINES)
+  const to = Math.min(lines.length - 1, index + NEARBY_LINES)
+  const window = lines.slice(from, to + 1).join('\n')
+  const v3Near = /actions\.v3\./.test(window)
+  const v2Near = /actions\.v2\./.test(window)
+  if (v3Near !== v2Near) {
+    return v3Near ? 'v3' : 'v2'
+  }
+
+  // 3. The path.
+  const path = file.replaceAll('\\', '/')
+  if (/\/v3\/|v3[.-]|-ver3\./.test(path)) {
+    return 'v3'
+  }
+  if (/\/v2\/|v2[.-]|-ver2\./.test(path)) {
+    return 'v2'
+  }
+
+  return null
+}

--- a/scripts/_v3-method-positions.mjs
+++ b/scripts/_v3-method-positions.mjs
@@ -7,20 +7,28 @@
  * `result.items`, `response.isSuccess` and `crm.item.list` in backticks with the
  * same syntax, and only the position tells them apart (#463).
  *
- * Four positions, every one of them taken from a real occurrence rather than
+ * Five positions, every one of them taken from a real occurrence rather than
  * imagined:
  *
  *  1. **A code literal** — `method: 'crm.item.list'`. The plain case.
  *  2. **A v3 batch tuple** — `first: ['crm.item.get', { … }]`, the shape
  *     `actions.v3.batch.make({ calls })` takes. The name is the first element of
  *     an array literal, so no `method:` key names it.
- *  3. **A parameter-table row** whose first cell is `method` — the docs describe
+ *  3. **A `callMethod('x.y', …)` argument** — the deprecated entry point, which
+ *     the migration pages use throughout.
+ *  4. **A parameter-table row** whose first cell is `method` — the docs describe
  *     the argument in prose there, and the example inside that prose is what a
  *     reader copies first.
- *  4. **A JSDoc bullet for the `method` option** — `` - `method: string` - … ``
+ *  5. **A JSDoc bullet for the `method` option** — `` - `method: string` - … ``
  *     followed by an example in backticks. Five of the eight known defect sites
  *     were of this shape, which is why `packages/jssdk/src/` has to be walked at
  *     all.
+ *
+ * One shape is knowingly missed: a `method:` whose value sits on the *next*
+ * line. The scan is line-by-line, no occurrence in this repository is written
+ * that way, and reading across lines would mean tracking string state through
+ * fences for a case that does not exist. If one ever appears it is a false
+ * negative — silence, not a wrong answer.
  *
  * Everything else — a backticked name in ordinary prose, a heading, a link — is
  * deliberately **not** a method position. That is the difference between a check
@@ -28,12 +36,20 @@
  */
 
 /**
- * A Bitrix24 method name: lower-case segments separated by dots, at least two.
+ * A Bitrix24 method name: dot-separated segments, each starting lower-case, at
+ * least two of them.
+ *
+ * **A segment may be camelCase.** An earlier version demanded lower-case
+ * throughout, which rejected `crm.activity.mail.getContent` and
+ * `crm.activity.mail.getThread` — both published by the very snapshot this
+ * check validates against. A name it cannot recognise is not reported as wrong;
+ * it is silently not seen at all, which is the worse failure for a gate whose
+ * whole claim is fidelity to the real surface.
  *
  * Anchored at both ends by the caller so `tasks.task.list` matches but the
  * `list` of `crm.item.list` inside a longer identifier does not.
  */
-const METHOD_NAME = /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]+)+$/
+const METHOD_NAME = /^[a-z][a-zA-Z0-9]*(?:\.[a-z][a-zA-Z0-9]*)+$/
 
 /** Every backticked span on a line, unwrapped. */
 function backtickedSpans(line) {
@@ -102,7 +118,16 @@ export function collectMethodPositions(body) {
       add(m[1], 'batch tuple')
     }
 
-    // 3 and 4 read the same way: backticked examples inside a line that is
+    // 3. `callMethod('x.y', …)` — the deprecated entry point, which the
+    // migration pages are full of. It is v2 by definition, so `versionContextAt`
+    // will almost always rule it out; it is collected anyway because a name is
+    // either read in every position or the gate has a blind spot people find by
+    // accident.
+    for (const m of line.matchAll(/\bcall(?:List|Tail)?Method\s*\(\s*['"]([^'"]+)['"]/g)) {
+      add(m[1], 'callMethod argument')
+    }
+
+    // 4 and 5 read the same way: backticked examples inside a line that is
     // *about* the `method` argument.
     const cells = tableCells(line)
     if (isMethodParamRow(cells) || isMethodOptionBullet(line)) {
@@ -119,6 +144,10 @@ export const __testing = { isMethodName, tableCells, isMethodParamRow, isMethodO
 
 /**
  * Which API version a line is talking about, or `null` when nothing says.
+ *
+ * Rescanned from the top of the file per call rather than indexed once: the
+ * files here are documentation pages, the cost is invisible at their size, and
+ * a shared index would be one more thing to keep in step with the walk.
  *
  * Order matters, most specific first, and each rule exists because a real line
  * needed it:
@@ -143,7 +172,7 @@ export function versionContextAt(file, lines, index) {
   let fenceTag = null
   let open = false
   for (let i = 0; i <= index; i++) {
-    const fence = /^\s*`{3,}([^`].*)?$/.exec(lines[i])
+    const fence = /^\s*(?:`{3,}([^`].*)?|~{3,}([^~].*)?)$/.exec(lines[i])
     if (fence === null) {
       continue
     }
@@ -152,7 +181,7 @@ export function versionContextAt(file, lines, index) {
       fenceTag = null
     } else {
       open = true
-      const info = (fence[1] ?? '').trim()
+      const info = (fence[1] ?? fence[2] ?? '').trim()
       fenceTag = /\[v3\]/.test(info) ? 'v3' : /\[v2\]/.test(info) ? 'v2' : null
     }
   }
@@ -170,12 +199,21 @@ export function versionContextAt(file, lines, index) {
     return v3Near ? 'v3' : 'v2'
   }
 
-  // 3. The path.
-  const path = file.replaceAll('\\', '/')
-  if (/\/v3\/|v3[.-]|-ver3\./.test(path)) {
+  // 3. The path — by segment, never by substring. `v3[.-]` matched anywhere in
+  // the path, so a directory called `v3-migration-notes/` would have forced v3
+  // on a page about v2. It surfaced because the test harness's own temporary
+  // directory is named `v3-refs-…`, which is a fair warning about how easily an
+  // unanchored path rule fires on something that is not a path decision.
+  const segments = file.replaceAll('\\', '/').split('/').filter(Boolean)
+  const version = (n) => {
+    const dir = segments.slice(0, -1).includes(`v${n}`)
+    const base = new RegExp(`(^|[-.])(v|ver)${n}([-.]|$)`).test(segments.at(-1) ?? '')
+    return dir || base
+  }
+  if (version(3)) {
     return 'v3'
   }
-  if (/\/v2\/|v2[.-]|-ver2\./.test(path)) {
+  if (version(2)) {
     return 'v2'
   }
 

--- a/scripts/check-v3-method-refs.mjs
+++ b/scripts/check-v3-method-refs.mjs
@@ -1,35 +1,72 @@
 #!/usr/bin/env node
 
 /**
- * Guards docs / skills / README-AI against drifting from the SDK's real v3 surface (#216).
+ * Guards docs / skills / README-AI / SDK source against drifting from the
+ * portal's real v3 surface. Two layers, both pure static text analysis.
  *
- * Pure static text analysis (no build or portal needed): **phantom v3 actions**.
- * `ActionsManagerV3` exposes only call / callList / fetchList / callTail /
- * fetchTail / batch / batchByChunk. Any other `actions.v3.<x>` — e.g. the
- * `actions.v3.aggregate` that #164 had to walk back — resolves to `undefined` at
- * runtime, so it is flagged wherever it appears (dotted or in a `{a,b,c}` list),
- * in prose or code.
+ * **Phantom v3 actions** (#216). `ActionsManagerV3` exposes only call /
+ * callList / fetchList / callTail / fetchTail / batch / batchByChunk. Any other
+ * `actions.v3.<x>` — e.g. the `actions.v3.aggregate` that #164 had to walk back
+ * — resolves to `undefined` at runtime, so it is flagged wherever it appears.
  *
- * NOTE: this script used to also check that v3 method names were on a hardcoded
- * `version-manager` allowlist. That allowlist was removed — the SDK no longer
- * gates v3 by a static list (the server validates method support), so there is
- * nothing to conform to and that layer was dropped.
+ * **Phantom v3 method names** (#463). This is the layer the old NOTE here said
+ * had been dropped with the hardcoded `version-manager` allowlist. It is back,
+ * and deliberately not as a list: the names are held against a **snapshot of a
+ * portal's own OpenAPI document**, committed under `scripts/data/`. A name used
+ * in a v3 method position and published by no snapshot fails with `file:line`.
+ *
+ * Three properties of that design are load-bearing, and each is a decision:
+ *
+ *  - **A snapshot is a baseline, not a catalogue.** No two measured portals
+ *    publish the same surface — 147 on-premise, 245 and 220 on two cloud
+ *    portals, which disagree with each other. So a name present in *one*
+ *    snapshot is accepted, and a portal method we never document is never a
+ *    failure. A check that is red by design gets switched off.
+ *  - **It audits prose, never runtime.** `b24pysdk` keeps a 70-name list and
+ *    silently downgrades an unlisted v3 call to v2; the on-premise build
+ *    publishes 81 names it does not know, and 4 of its own exist on no portal
+ *    at all. That is the mistake this must not repeat.
+ *  - **It never calls a portal.** Refreshing a snapshot is a local step
+ *    (`--refresh`), like the rest of this repository's portal work.
+ *
+ * Deliberate anti-examples are marked, not special-cased: `@check-ignore` on the
+ * line or the line before, the same escape hatch the fence gates use.
+ *
+ * `--coverage` prints what the snapshots hold against what the repository
+ * documents, and always exits 0. That is the number a docs PR cites.
  */
 
-import { readFileSync } from 'node:fs'
-import { join, resolve, dirname } from 'node:path'
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from 'node:fs'
+import { join, resolve, dirname, basename } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { walkFiles } from './_docs-utils.mjs'
 import { createReporter } from './_reporter.mjs'
+import { collectMethodPositions, versionContextAt } from './_v3-method-positions.mjs'
 
 const ROOT = process.env.V3_CHECK_ROOT
   ? resolve(process.env.V3_CHECK_ROOT)
   : resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
+const SNAPSHOT_DIR = process.env.V3_SNAPSHOT_DIR
+  ? resolve(process.env.V3_SNAPSHOT_DIR)
+  : join(ROOT, 'scripts', 'data')
+
 const V3_ACTIONS = new Set(['call', 'callList', 'fetchList', 'callTail', 'fetchTail', 'aggregate', 'batch', 'batchByChunk'])
 const REAL_ACTIONS = [...V3_ACTIONS].join(' / ')
 
-function markdownFiles() {
+const args = new Set(process.argv.slice(2))
+const wantCoverage = args.has('--coverage')
+const wantRefresh = args.has('--refresh')
+
+/**
+ * The files worth walking, and why each is in the list.
+ *
+ * `packages/jssdk/src/` joined the walk for #463: five of the eight method-name
+ * defects found by the v3 audit were JSDoc, not documentation. `.md` and `.ts`
+ * are read the same way — the positions that count are syntactic, not
+ * per-language.
+ */
+function filesToCheck() {
   const files = [join(ROOT, 'packages', 'jssdk', 'README-AI.md')]
   for (const base of ['docs/content/docs', 'skills']) {
     // `skills/b24jssdk-recipes` is its own npm package (#65), so its
@@ -37,7 +74,86 @@ function markdownFiles() {
     // READMEs that are not ours to check.
     files.push(...walkFiles(join(ROOT, ...base.split('/')), { skipDirs: ['node_modules'] }))
   }
+  // Tolerated as absent so a fixture root can populate only what it is testing;
+  // `pullClient` is skipped because its vendored protobuf modules are not ours.
+  const sdkSource = join(ROOT, 'packages', 'jssdk', 'src')
+  if (existsSync(sdkSource)) {
+    files.push(...walkFiles(sdkSource, { extension: '.ts', skipDirs: ['node_modules', 'pullClient'] }))
+  }
   return files
+}
+
+/**
+ * Load every committed snapshot.
+ *
+ * Returns `[]` when the directory is empty, and the caller treats that as
+ * "cannot judge" rather than "nothing is published" — the difference between a
+ * check that is quiet because everything is fine and one that is quiet because
+ * it has nothing to compare against. The second must say so out loud.
+ */
+export function loadSnapshots(dir = SNAPSHOT_DIR) {
+  if (!existsSync(dir)) {
+    return []
+  }
+  return readdirSync(dir)
+    .filter(name => name.startsWith('openapi-') && name.endsWith('.json'))
+    .sort()
+    .map((name) => {
+      const parsed = JSON.parse(readFileSync(join(dir, name), 'utf8'))
+      return { name, methods: new Set(parsed.methods.map(m => m.method)), raw: parsed }
+    })
+}
+
+/**
+ * The opening fence enclosing `index`, or `-1`.
+ *
+ * Same walk `versionContextAt` does, kept here because the marker convention and
+ * the version convention answer different questions about the same fence.
+ */
+function enclosingFenceStart(lines, index) {
+  let open = -1
+  for (let i = 0; i <= index; i++) {
+    if (/^\s*`{3,}/.test(lines[i])) {
+      open = open === -1 ? i : -1
+    }
+  }
+  return open
+}
+
+/**
+ * Is this occurrence deliberately exempt?
+ *
+ * The marker is the repository's existing `// @check-ignore: <reason>` rather
+ * than a new vocabulary — on the line, the line above, or the nearest non-empty
+ * line *before the enclosing fence*, which is where the typecheck gates look
+ * (`_typecheck-blocks.mjs`). One marker per example beats one per line.
+ *
+ * **The reason must name the method.** That is not decoration. Two fences in
+ * the docs already carried `// @check-ignore: top-level return in
+ * error-handling illustration` — written for the typecheck gate, about
+ * something else entirely — and a marker shared between checks would have let
+ * an exemption granted for one silently grant the other. Naming the method
+ * makes every exemption specific to the thing it excuses, so a marker cannot
+ * acquire a second meaning by sitting in the right place.
+ */
+function isMarkedIgnored(lines, index, name) {
+  const names = line => line.includes('@check-ignore') && line.includes(name)
+
+  const here = lines[index] ?? ''
+  const above = index > 0 ? lines[index - 1] : ''
+  if (names(here) || names(above)) {
+    return true
+  }
+
+  const fence = enclosingFenceStart(lines, index)
+  if (fence === -1) {
+    return false
+  }
+  let prev = fence - 1
+  while (prev >= 0 && lines[prev].trim() === '') {
+    prev--
+  }
+  return prev >= 0 && lines[prev].trim().startsWith('// @check-ignore') && lines[prev].includes(name)
 }
 
 const report = createReporter({
@@ -46,27 +162,198 @@ const report = createReporter({
   errorNoun: 'problem'
 })
 
-const fail = (file, message) => report.error(file, message)
-
 function checkPhantomActions(file, body) {
   for (const m of body.matchAll(/actions\.v3\.([a-zA-Z]\w*)/g)) {
     if (!V3_ACTIONS.has(m[1])) {
-      fail(file, `references non-existent v3 action "actions.v3.${m[1]}" — real actions are ${REAL_ACTIONS}`)
+      report.error(file, `references non-existent v3 action "actions.v3.${m[1]}" — real actions are ${REAL_ACTIONS}`)
     }
   }
   for (const m of body.matchAll(/actions\.v3\.\{([^}]*)\}/g)) {
     for (const name of m[1].split(',').map(s => s.trim()).filter(Boolean)) {
       if (!V3_ACTIONS.has(name)) {
-        fail(file, `references non-existent v3 action "${name}" in actions.v3.{${m[1]}}`)
+        report.error(file, `references non-existent v3 action "${name}" in actions.v3.{${m[1]}}`)
       }
     }
   }
 }
 
-for (const file of markdownFiles()) {
-  const body = readFileSync(file, 'utf8')
-  checkPhantomActions(file, body)
+/**
+ * Hold every v3 method position against the snapshots.
+ *
+ * Every name seen in a v3 position is added to `documented`, whether or not a
+ * snapshot publishes it — that set is what the coverage report joins against.
+ */
+function checkMethodNames(file, body, snapshots, documented) {
+  const lines = body.split(/\r\n?|\n/)
+  for (const hit of collectMethodPositions(body)) {
+    if (versionContextAt(file, lines, hit.line - 1) !== 'v3') {
+      continue
+    }
+    documented.add(hit.name)
+    if (snapshots.length === 0 || isMarkedIgnored(lines, hit.line - 1, hit.name)) {
+      continue
+    }
+    const publishedBy = snapshots.filter(s => s.methods.has(hit.name))
+    if (publishedBy.length === 0) {
+      report.error(
+        file,
+        `"${hit.name}" is used as a v3 method (${hit.position}) but no portal snapshot publishes it — `
+        + `fix the name, or mark the line "@check-ignore: <reason>" if it is a deliberate anti-example`,
+        { line: hit.line }
+      )
+    }
+  }
 }
 
-report.note('across docs, skills, README-AI')
-process.exit(report.finish())
+async function refresh() {
+  const hook = process.env.B24_HOOK
+  if (!hook) {
+    console.error('--refresh needs B24_HOOK (a webhook URL) in the environment. It is never read in CI and never committed.')
+    process.exit(2)
+  }
+  const kind = process.env.V3_SNAPSHOT_KIND
+  if (!kind || !/^[a-z0-9-]+$/.test(kind)) {
+    console.error('--refresh needs V3_SNAPSHOT_KIND — the portal *kind* (e.g. "cloud", "on-premise"), never a domain.')
+    process.exit(2)
+  }
+
+  // A plain POST rather than the SDK. Every other script in `scripts/` is
+  // dependency-free node, and importing the package source here would pull the
+  // Pull client's protobuf modules into a lint script that has no use for them.
+  // The endpoint is one unauthenticated-by-header call: the webhook URL *is* the
+  // credential, which is exactly why it never leaves this local step.
+  // `restApi:v3` puts the hook at /rest/api/<userId>/<secret>/, not
+  // /rest/<userId>/<secret>/ — the `api/` segment goes *before* the user id, and
+  // appending it after the secret answers 404. Same shape the log redactor
+  // masks, read from `hook/auth.ts`.
+  const v3Base = hook.replace(/\/rest\/(\d+\/)/, '/rest/api/$1')
+  if (v3Base === hook && !hook.includes('/rest/api/')) {
+    console.error('B24_HOOK does not look like a Bitrix24 webhook URL (/rest/<userId>/<secret>/)')
+    process.exit(2)
+  }
+  const base = v3Base.endsWith('/') ? v3Base : `${v3Base}/`
+  const response = await fetch(`${base}rest.documentation.openapi`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}'
+  })
+  if (!response.ok) {
+    // Deliberately without the body or the URL: both can carry the secret.
+    console.error(`portal refused with HTTP ${response.status}`)
+    process.exit(1)
+  }
+
+  const document = await response.json()
+  if (typeof document?.paths !== 'object') {
+    console.error('the response carried no `paths` — not an OpenAPI document')
+    process.exit(1)
+  }
+
+  const written = writeSnapshot(document, kind)
+  console.log(`wrote ${written.file} — ${written.totals.methods} methods across ${written.totals.modules} modules`)
+}
+
+/**
+ * Reduce the portal document to what the check needs, and nothing else.
+ *
+ * The document on the wire is ~140 KB on-premise and ~215 KB in the cloud, its
+ * `summary` fields are Russian, and it is not ours to republish. What is kept is
+ * the method name, its module and its operations — enough to answer "does this
+ * portal publish this name" and to print coverage per module.
+ *
+ * What is deliberately dropped: `summary` (the Russian half), the scopes the
+ * token held, and anything naming the portal. A snapshot carries a portal
+ * kind*, never an identity and never a credential.
+ */
+export function reduceDocument(document, kind, today = new Date()) {
+  const methods = []
+  for (const [path, operations] of Object.entries(document.paths ?? {})) {
+    const method = path.replace(/^\//, '')
+    if (method === '') {
+      continue
+    }
+    methods.push({
+      method,
+      module: method.split('.')[0],
+      operations: Object.keys(operations ?? {}).sort()
+    })
+  }
+  methods.sort((a, b) => a.method.localeCompare(b.method))
+
+  const methodsPerModule = {}
+  for (const { module } of methods) {
+    methodsPerModule[module] = (methodsPerModule[module] ?? 0) + 1
+  }
+
+  return {
+    portalKind: kind,
+    snapshotDate: today.toISOString().slice(0, 10),
+    openapi: document.openapi ?? null,
+    totals: { methods: methods.length, modules: Object.keys(methodsPerModule).length },
+    methodsPerModule,
+    methods
+  }
+}
+
+function writeSnapshot(document, kind) {
+  const reduced = reduceDocument(document, kind)
+  mkdirSync(SNAPSHOT_DIR, { recursive: true })
+  const file = join(SNAPSHOT_DIR, `openapi-${kind}-${reduced.snapshotDate}.json`)
+  writeFileSync(file, `${JSON.stringify(reduced, null, 2)}\n`)
+  return { file: basename(file), totals: reduced.totals }
+}
+
+function printCoverage(snapshots, documented) {
+  if (snapshots.length === 0) {
+    console.log('coverage: no snapshot committed under scripts/data/ — run with --refresh against a portal.')
+    return
+  }
+  console.log('v3 method coverage — portal snapshots against what this repository documents\n')
+  for (const snapshot of snapshots) {
+    const published = snapshot.raw.methods
+    const covered = published.filter(m => documented.has(m.method))
+    console.log(`${snapshot.name}  (${snapshot.raw.portalKind}, ${snapshot.raw.snapshotDate})`)
+    console.log(`  publishes ${published.length}, documented here ${covered.length}, never named ${published.length - covered.length}`)
+    const perModule = {}
+    for (const m of published) {
+      perModule[m.module] ??= { total: 0, covered: 0 }
+      perModule[m.module].total++
+      if (documented.has(m.method)) {
+        perModule[m.module].covered++
+      }
+    }
+    for (const [module, { total, covered: hit }] of Object.entries(perModule).sort()) {
+      console.log(`    ${module.padEnd(18)} ${String(hit).padStart(3)} / ${total}`)
+    }
+    console.log('')
+  }
+  const unpublished = [...documented].filter(name => !snapshots.some(s => s.methods.has(name))).sort()
+  console.log(`named here in a v3 position: ${documented.size}`)
+  if (unpublished.length > 0) {
+    console.log(`named here but published by no snapshot: ${unpublished.length} — ${unpublished.join(', ')}`)
+  }
+}
+
+if (wantRefresh) {
+  await refresh()
+} else {
+  const snapshots = loadSnapshots()
+  const documented = new Set()
+
+  for (const file of filesToCheck()) {
+    const body = readFileSync(file, 'utf8')
+    checkPhantomActions(file, body)
+    checkMethodNames(file, body, snapshots, documented)
+  }
+
+  if (wantCoverage) {
+    printCoverage(snapshots, documented)
+    process.exit(0)
+  }
+
+  if (snapshots.length === 0) {
+    report.note('no portal snapshot under scripts/data/ — method names unchecked; run --refresh locally')
+  }
+  report.note(`across docs, skills, README-AI, packages/jssdk/src (${snapshots.length} snapshot(s))`)
+  process.exit(report.finish())
+}

--- a/scripts/check-v3-method-refs.mjs
+++ b/scripts/check-v3-method-refs.mjs
@@ -38,7 +38,7 @@
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from 'node:fs'
 import { join, resolve, dirname, basename } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { walkFiles } from './_docs-utils.mjs'
 import { createReporter } from './_reporter.mjs'
 import { collectMethodPositions, versionContextAt } from './_v3-method-positions.mjs'
@@ -99,7 +99,19 @@ export function loadSnapshots(dir = SNAPSHOT_DIR) {
     .filter(name => name.startsWith('openapi-') && name.endsWith('.json'))
     .sort()
     .map((name) => {
-      const parsed = JSON.parse(readFileSync(join(dir, name), 'utf8'))
+      // Validated rather than trusted: `--refresh` is the only writer, but a run
+      // interrupted mid-write leaves a truncated file, and the failure that
+      // produced was an undefined `.map` deep inside module load with nothing
+      // naming the file.
+      let parsed
+      try {
+        parsed = JSON.parse(readFileSync(join(dir, name), 'utf8'))
+      } catch (error) {
+        throw new Error(`snapshot ${name} is not valid JSON — re-run --refresh`, { cause: error })
+      }
+      if (!Array.isArray(parsed.methods) || parsed.methods.some(m => typeof m?.method !== 'string')) {
+        throw new Error(`snapshot ${name} has no usable "methods" array — re-run --refresh`)
+      }
       return { name, methods: new Set(parsed.methods.map(m => m.method)), raw: parsed }
     })
 }
@@ -113,7 +125,7 @@ export function loadSnapshots(dir = SNAPSHOT_DIR) {
 function enclosingFenceStart(lines, index) {
   let open = -1
   for (let i = 0; i <= index; i++) {
-    if (/^\s*`{3,}/.test(lines[i])) {
+    if (/^\s*(?:`{3,}|~{3,})/.test(lines[i])) {
       open = open === -1 ? i : -1
     }
   }
@@ -145,15 +157,39 @@ function isMarkedIgnored(lines, index, name) {
     return true
   }
 
+  // In a source file there is no fence, and the marker cannot sit next to the
+  // line either: inside a JSDoc `@example` it would render on hover as if it
+  // were part of the example an SDK consumer is meant to copy. So a marker
+  // anywhere in the enclosing JSDoc block exempts that block, which is also how
+  // a reader would expect a block annotation to behave.
   const fence = enclosingFenceStart(lines, index)
   if (fence === -1) {
+    for (let i = index - 1; i >= 0; i--) {
+      const text = lines[i].trim()
+      if (names(text)) {
+        return true
+      }
+      if (text.startsWith('/**')) {
+        return false
+      }
+      if (!text.startsWith('*')) {
+        return false
+      }
+    }
     return false
   }
   let prev = fence - 1
   while (prev >= 0 && lines[prev].trim() === '') {
     prev--
   }
-  return prev >= 0 && lines[prev].trim().startsWith('// @check-ignore') && lines[prev].includes(name)
+  if (prev < 0) {
+    return false
+  }
+  // `.replace(/^\*\s*/, '')` because inside a JSDoc block the marker line reads
+  // `* // @check-ignore: …` — without it the fence form silently never matched
+  // in TypeScript, and only the line-above form worked there.
+  const marker = lines[prev].trim().replace(/^\*\s*/, '')
+  return marker.startsWith('// @check-ignore') && marker.includes(name)
 }
 
 const report = createReporter({
@@ -189,16 +225,24 @@ function checkMethodNames(file, body, snapshots, documented) {
     if (versionContextAt(file, lines, hit.line - 1) !== 'v3') {
       continue
     }
+    if (isMarkedIgnored(lines, hit.line - 1, hit.name)) {
+      // Not counted as documented either: a marked placeholder is not a method
+      // this repository describes, and counting it inflated the very number
+      // `--coverage` exists to report.
+      continue
+    }
     documented.add(hit.name)
-    if (snapshots.length === 0 || isMarkedIgnored(lines, hit.line - 1, hit.name)) {
+    if (snapshots.length === 0) {
       continue
     }
     const publishedBy = snapshots.filter(s => s.methods.has(hit.name))
     if (publishedBy.length === 0) {
       report.error(
         file,
-        `"${hit.name}" is used as a v3 method (${hit.position}) but no portal snapshot publishes it — `
-        + `fix the name, or mark the line "@check-ignore: <reason>" if it is a deliberate anti-example`,
+        `"${hit.name}" is used as a v3 method (${hit.position}) but no committed portal snapshot `
+        + `publishes it — fix the name; or, if the method is real and new, refresh a snapshot `
+        + `(\`--refresh\`, see .github/contributing/documentation.md); or mark the line `
+        + `"@check-ignore: <reason naming ${hit.name}>" if it is a deliberate anti-example`,
         { line: hit.line }
       )
     }
@@ -232,18 +276,34 @@ async function refresh() {
     process.exit(2)
   }
   const base = v3Base.endsWith('/') ? v3Base : `${v3Base}/`
-  const response = await fetch(`${base}rest.documentation.openapi`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: '{}'
-  })
+  // Wrapped, and the caught error deliberately discarded: Node's `fetch failed`
+  // carries a `cause` of `getaddrinfo ENOTFOUND <hostname>`, so an uncaught
+  // network error prints the portal's host. The secret is in the path rather
+  // than the host, but neither belongs in a terminal someone may paste from.
+  let response
+  try {
+    response = await fetch(`${base}rest.documentation.openapi`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}'
+    })
+  } catch {
+    console.error('could not reach the portal (network error)')
+    process.exit(1)
+  }
   if (!response.ok) {
     // Deliberately without the body or the URL: both can carry the secret.
     console.error(`portal refused with HTTP ${response.status}`)
     process.exit(1)
   }
 
-  const document = await response.json()
+  let document
+  try {
+    document = await response.json()
+  } catch {
+    console.error('the portal did not answer with JSON')
+    process.exit(1)
+  }
   if (typeof document?.paths !== 'object') {
     console.error('the response carried no `paths` — not an OpenAPI document')
     process.exit(1)
@@ -334,7 +394,15 @@ function printCoverage(snapshots, documented) {
   }
 }
 
-if (wantRefresh) {
+// Only when run, never when imported: the tests import `reduceDocument` to
+// exercise the part `--refresh` owns, and a module body that calls
+// `process.exit` on import ends the test run instead.
+const isEntryPoint = process.argv[1] !== undefined
+  && import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (!isEntryPoint) {
+  // nothing to do — the exports above are the whole point of an import
+} else if (wantRefresh) {
   await refresh()
 } else {
   const snapshots = loadSnapshots()

--- a/scripts/data/openapi-cloud-2026-09-05.json
+++ b/scripts/data/openapi-cloud-2026-09-05.json
@@ -1,0 +1,1775 @@
+{
+  "portalKind": "cloud",
+  "snapshotDate": "2026-09-05",
+  "openapi": "3.0.0",
+  "totals": {
+    "methods": 245,
+    "modules": 14
+  },
+  "methodsPerModule": {
+    "batch": 1,
+    "bizprocdesigner": 16,
+    "call": 4,
+    "crm": 11,
+    "documentation": 1,
+    "humanresources": 33,
+    "mail": 24,
+    "main": 37,
+    "note": 25,
+    "rest": 55,
+    "scopes": 1,
+    "tasks": 22,
+    "timeman": 3,
+    "vibecodeconnector": 12
+  },
+  "methods": [
+    {
+      "method": "batch",
+      "module": "batch",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.agent.connect",
+      "module": "bizprocdesigner",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.catalog.block.field.get",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.catalog.block.field.list",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.catalog.block.get",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.catalog.block.list",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.document.field.field.get",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.document.field.field.list",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.document.field.list",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.template.draft.add",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.template.draft.field.get",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.template.draft.field.list",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.template.field.get",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.template.field.list",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.template.get",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.template.list",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "bizprocdesigner.template.validate",
+      "module": "bizprocdesigner",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "call.followup.field.get",
+      "module": "call",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "call.followup.field.list",
+      "module": "call",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "call.followup.get",
+      "module": "call",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "call.followup.list",
+      "module": "call",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "crm.activity.mail.getContent",
+      "module": "crm",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "crm.activity.mail.getThread",
+      "module": "crm",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "crm.activity.mail.reply",
+      "module": "crm",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "crm.company.timeline.activity.email.list",
+      "module": "crm",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "crm.company.timeline.activity.email.send",
+      "module": "crm",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "crm.contact.timeline.activity.email.list",
+      "module": "crm",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "crm.contact.timeline.activity.email.send",
+      "module": "crm",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "crm.deal.timeline.activity.email.list",
+      "module": "crm",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "crm.deal.timeline.activity.email.send",
+      "module": "crm",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "crm.lead.timeline.activity.email.list",
+      "module": "crm",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "crm.lead.timeline.activity.email.send",
+      "module": "crm",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "documentation",
+      "module": "documentation",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.access.permission.list",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.access.role.add",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.access.role.delete",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.access.role.field.get",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.access.role.field.list",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.access.role.get",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.access.role.list",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.access.role.update",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.access.user.permissions",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.employee.count",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.employee.field.get",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.employee.field.list",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.employee.multidepartment",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.employee.search",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.employee.subordinates",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.add",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.children",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.communication.edit",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.communication.list",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.count",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.edit",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.field.get",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.field.list",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.get",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.list",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.member.add",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.member.field.get",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.member.field.list",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.member.move",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.member.remove",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.member.set",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.move",
+      "module": "humanresources",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "humanresources.node.search",
+      "module": "humanresources",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.mailbox.field.get",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.mailbox.field.list",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.mailbox.get",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.mailbox.list",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.mailbox.senders",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.createcalendarevent",
+      "module": "mail",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.createchat",
+      "module": "mail",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.createcrmactivity",
+      "module": "mail",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.createfeedpost",
+      "module": "mail",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.createtask",
+      "module": "mail",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.field.get",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.field.list",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.forward",
+      "module": "mail",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.get",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.list",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.movetofolder",
+      "module": "mail",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.removecrmactivity",
+      "module": "mail",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.reply",
+      "module": "mail",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.send",
+      "module": "mail",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "mail.message.thread",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.recipient.field.get",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.recipient.field.list",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.recipient.listcontacts",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "mail.recipient.listemployees",
+      "module": "mail",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.eventlog.field.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.eventlog.field.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.eventlog.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.eventlog.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.eventlog.tail",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.like.field.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.like.field.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.like.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.like.reactions",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.smile.field.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.smile.field.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.smile.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.smileset.field.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.smileset.field.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.smileset.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.agreement.field.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.agreement.field.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.agreement.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.agreement.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.consent.add",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.consent.field.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.consent.field.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.history.field.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.history.field.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.history.fields.field.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.history.fields.field.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.history.fields.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.history.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.user.history.tail",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.userfieldconfig.add",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.userfieldconfig.delete",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.userfieldconfig.field.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.userfieldconfig.field.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.userfieldconfig.get",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.userfieldconfig.gettypes",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.userfieldconfig.list",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "main.userfieldconfig.update",
+      "module": "main",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.collection.add",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.collection.archive",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.collection.delete",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.collection.field.get",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.collection.field.list",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.collection.get",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.collection.list",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.collection.update",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.add",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.archive",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.delete",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.field.get",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.field.list",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.get",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.search.field.get",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.search.field.list",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.search.list",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.tree.field.get",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.tree.field.list",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.tree.list",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.document.update",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.file.add",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.file.field.get",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.file.field.list",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "note.file.get",
+      "module": "note",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.app.scoperequest.add",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.app.scoperequest.field.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.app.scoperequest.field.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.app.scoperequest.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.app.scoperequest.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.access.delete",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.access.field.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.access.field.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.access.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.access.reset",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.access.set",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.embedding.add",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.embedding.delete",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.embedding.field.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.embedding.field.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.embedding.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.field.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.field.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.getbyclientid",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.local.field.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.local.field.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.local.install",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.local.uninstall",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.personal.field.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.personal.field.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.personal.install",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.personal.uninstall",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.placement.field.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.placement.field.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.application.placement.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.deferredbatch.add",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.deferredbatch.delete",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.deferredbatch.downloadresult",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.deferredbatch.field.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.deferredbatch.field.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.deferredbatch.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.deferredbatch.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.documentation.openapi",
+      "module": "rest",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "rest.event.field.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.event.field.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.event.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.event.online.bind",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.event.online.field.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.event.online.field.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.event.online.unbind",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.incomingwebhook.add",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.incomingwebhook.delete",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.incomingwebhook.field.get",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.incomingwebhook.field.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.incomingwebhook.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.incomingwebhook.prolong",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.incomingwebhook.update",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "rest.portal.license.get",
+      "module": "rest",
+      "operations": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "method": "rest.scope.list",
+      "module": "rest",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "scopes",
+      "module": "scopes",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.access.get",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.add",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.chat.message.field.get",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.chat.message.field.list",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.chat.message.send",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.delete",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.field.get",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.field.list",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.file.attach",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.gantt.link.field.get",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.gantt.link.field.list",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.gantt.link.list",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.get",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.list",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.result.add",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.result.addfromchatmessage",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.result.delete",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.result.field.get",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.result.field.list",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.result.list",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.result.update",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "tasks.task.update",
+      "module": "tasks",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "timeman.record.field.get",
+      "module": "timeman",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "timeman.record.field.list",
+      "module": "timeman",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "timeman.record.list",
+      "module": "timeman",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.access.field.get",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.access.field.list",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.access.set",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.add",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.delete",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.field.get",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.field.list",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.pin.delete",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.pin.field.get",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.pin.field.list",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.pin.set",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    },
+    {
+      "method": "vibecodeconnector.catalog.item.update",
+      "module": "vibecodeconnector",
+      "operations": [
+        "post"
+      ]
+    }
+  ]
+}

--- a/scripts/docs-lint.mjs
+++ b/scripts/docs-lint.mjs
@@ -229,7 +229,14 @@ export function checkFrontmatterLinkTargets(file, frontmatter, deps = {}) {
 // It is built from Nuxt auto-imports and two app-level helpers, none of which
 // exist in the isolated context this check compiles in — un-checkable rather
 // than unfixed, which is what the marker is for.
-const CHECK_IGNORE_WARN_THRESHOLD = 51
+//
+// 51 -> 57 (#463): six placeholders — `some.method`, `some.list` — in migration
+// and error-handling snippets, now that the v3 method-name gate reads the same
+// marker. They are deliberately not portal methods, which is the whole point of
+// the snippet, and the ten *real* wrong names that gate found were fixed rather
+// than marked. Two of the six extended a marker that already existed for the
+// typecheck pass, so the marker count rose by four, not six.
+const CHECK_IGNORE_WARN_THRESHOLD = 57
 
 function countCheckIgnoreMarkers(files) {
   let total = 0

--- a/skills/b24jssdk-rest/SKILL.md
+++ b/skills/b24jssdk-rest/SKILL.md
@@ -404,6 +404,7 @@ const hasNotes = Boolean(doc?.paths?.['/note.collection.list'])
 - ❌ `$b24.callMethod(...)`, `$b24.callBatch(...)`, etc. — `@deprecated`, removed in 3.0.0. Use the actions API.
 - ❌ `res.getNext()` / `res.fetchNext()` against a **v3** client — they throw `JSSDK_CORE_METHOD_NOT_SUPPORT_IN_API_V3`. Under v2 they work and are supported; for new code prefer `callList` / `fetchList`, which work under both versions.
 - ❌ Reading `res.getTotal()` or `res.isMore()` on a **v3** response — not an error, but they always answer `0` / `false` there because v3 sends no `total` / `next`. Under v2 they are correct and supported. For a v3 count use `actions.v3.aggregate.make` (`count`/`countDistinct`) on a method that exposes an `*.aggregate` action, and treat it as unverified.
+<!-- @check-ignore: `crm.item.get` is the deliberate anti-example this bullet is about — v3 publishes no `crm.item.*` -->
 - ❌ Calling `$b24.actions.v3.call.make({ method: 'crm.item.get', ... })` — `crm.*` is v2-only, so the v3 server returns a `METHODNOTFOUNDEXCEPTION` soft error (`response.isSuccess === false`); use `actions.v2.*` for CRM. (The SDK no longer pre-flight-throws here.)
 - ❌ Passing `order` to `callList.make` — silently ignored with a warning. Narrow with `filter` instead.
 - ❌ `customKeyForResult: 'result'` for `crm.item.list` — wrong, use `'items'`. Otherwise you'll get an empty list silently.


### PR DESCRIPTION
Closes #463. Closes #464 — see *Why both* below.

## The gap

The discovery page calls `rest.documentation.openapi` "the source of truth the SDK relies on
instead of a hardcoded allowlist", and nothing compared anything to it. The one gate that
looks at v3 drift said so in its own NOTE: the method layer went out with the allowlist in
2.0.0, and #206 was closed without the snapshot it asked for.

## The check

`scripts/data/openapi-cloud-2026-09-05.json` is a reduction of a real portal's document —
method name, module, operations. A name used in a **v3 method position** that no snapshot
publishes fails with `file:line`.

Three properties are load-bearing, each a decision rather than a default:

- **A snapshot is a baseline, not a catalogue.** Portals differ — two cloud portals measured a
  day apart disagreed on 28 methods; every on-premise method exists in the cloud, 98 cloud
  ones do not exist on the box. So *one* snapshot publishing a name is enough, and a portal
  method we never document is informational (237 of 245 today). A check that is red by design
  gets switched off.
- **It audits prose, never runtime.** `b24pysdk` keeps a 70-name list and silently downgrades
  an unlisted v3 call to v2. Not repeating that.
- **It never calls a portal.** `--refresh` is local, and a plain POST rather than an SDK
  import — every other script here is dependency-free node, and importing the package would
  drag the Pull client's protobuf modules into a lint script.

**What counts as a method position** is the whole difficulty, because this repo writes
`result.items` and `crm.item.list` in backticks identically. Four positions, each taken from a
real occurrence: a `method:` literal, a v3 batch tuple, a parameter-table row whose first cell
is `method`, and a JSDoc bullet documenting the `method` option. The last is why
`packages/jssdk/src/` joined the walk — five of the defects were JSDoc, not docs.

## What it found

The eight sites #463 predicted, at the predicted lines — **and a ninth it did not**:
`5.umd.md` offers a newcomer `actions.v3.call.make({ method: 'crm.item.list' })` as their
first copy-paste, and v3 publishes no `crm.item.*` on any portal.

### Why both issues

All ten occurrences are fixed here rather than marked, because a check that cannot be switched
on is not a deliverable. That is #464's scope, so it closes too. The substantive one was
`5.filtering.md`'s "same query in v2 and v3" section: it *cannot* be the same method, so the
v3 half now asks the same **shape** of question of `tasks.task.list`, with field names read
from `tasks.task.field.list` rather than guessed.

## Two findings from building it

**A shared escape hatch is not an escape hatch.** Two fences already carried
`// @check-ignore: top-level return in error-handling illustration`, written for the typecheck
gate about something else — and my first version let them silence this gate too. The marker's
reason must now **name the method** it excuses, so an exemption granted for one reason cannot
acquire a second by sitting in the right place.

**The anti-example in `b24jssdk-rest/SKILL.md` was silent by accident**, not intent: its
neighbourhood mentions both `actions.v2.` and `actions.v3.`, so the dialect is ambiguous and
the line is skipped. Defensible as a rule; not something to rely on. Marked.

## Tests

Eight new cases in `scripts/__tests__/check-v3-method-refs.test.mjs` (12 total), one per arm.
Confirmed by mutation, including the fence-tag rule — which at first **no test could
distinguish from its own fallback**, so a case was added where it is the only signal.

| mutation | red |
|---|---|
| marker no longer has to name the method | 1 |
| fence `[v2]`/`[v3]` tag ignored | 1 |

## Coverage

`pnpm run lint:v3-coverage`, always exit 0 — the number a docs PR quotes:

```
publishes 245, documented here 8, never named 237
  humanresources  0 / 33      mail  0 / 24      bizprocdesigner  0 / 16
  tasks           4 / 22      main  2 / 37      rest             1 / 55
```

## The snapshot

33 KB of the 215 KB on the wire. Carries a portal **kind**, never a domain, a scope or a
credential; the Russian `summary` fields are dropped. Verified: no host, no token, no URL in
the file. Refresh is documented in `.github/contributing/documentation.md`.

## Checks

- `pnpm typecheck`, `pnpm lint`, `pnpm lint:md` — clean
- `docs-lint --strict` — 0/0 (the `@check-ignore` threshold is raised 51 → 57 with the reason
  written where the previous raises are)
- `docs:lint:test` — 155 pass
- all four block gates, `docs:lint-api-index` — clean
- `pnpm vitest run --project jsSdk:unit` — 609 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_