### PR TITLE
docs(skills): point the filtering and recipes skills at the field-list guide

### DIFF
--- a/skills/b24jssdk-filtering/SKILL.md
+++ b/skills/b24jssdk-filtering/SKILL.md
@@ -175,6 +175,9 @@ The same logical field has different names depending on the method:
 
 > Both shapes are v2-API, and neither is "v3-style": the casing here is per-method, not per-API-version. `crm.item.*` is camelCase for reasons of its own and is **not** a v3 method — v3 publishes no `crm.item.*` at all. Under `restApi:v3` camelCase *is* the rule, without exception across the 108 field descriptors measured; ask `<entity>.field.list` when unsure. Use the same casing across `filter`, `select`, and (where applicable) `order`. Mixing styles silently breaks paging.
 
+Full guide: [Discovering entity fields](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/discovering-entity-fields/) — how to ask an entity for its own field
+list, and why a `filterable: false` field is refused rather than ignored.
+
 ## Select
 
 Always pass `select` to limit response size:

--- a/skills/b24jssdk-recipes/SKILL.md
+++ b/skills/b24jssdk-recipes/SKILL.md
@@ -129,6 +129,9 @@ Inside the recipes the split is:
 
 The newer CRM methods (`crm.item.list`) use camelCase fields: `stageId`, `assignedById`, `opportunity`, `createdTime`. The classic ones (`tasks.task.add`, `crm.activity.list`, `crm.timeline.comment.add`) use uppercase: `TITLE`, `DESCRIPTION`, `OWNER_TYPE_ID`. Recipes follow this split. Both are `restApi:v2` — `crm.item.*` is camelCase for reasons of its own, not because it is v3; the v3 endpoint publishes no `crm.item.*`. Under `restApi:v3` camelCase is the rule everywhere, and `<entity>.field.list` answers it per entity.
 
+Under `restApi:v3` camelCase is the rule everywhere, and `<entity>.field.list` answers it per
+entity — see [Discovering entity fields](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/discovering-entity-fields/).
+
 ## Running
 
 ```bash

--- a/skills/b24jssdk-recipes/SKILL.md
+++ b/skills/b24jssdk-recipes/SKILL.md
@@ -127,10 +127,7 @@ Inside the recipes the split is:
 
 ## Field-naming choice
 
-The newer CRM methods (`crm.item.list`) use camelCase fields: `stageId`, `assignedById`, `opportunity`, `createdTime`. The classic ones (`tasks.task.add`, `crm.activity.list`, `crm.timeline.comment.add`) use uppercase: `TITLE`, `DESCRIPTION`, `OWNER_TYPE_ID`. Recipes follow this split. Both are `restApi:v2` — `crm.item.*` is camelCase for reasons of its own, not because it is v3; the v3 endpoint publishes no `crm.item.*`. Under `restApi:v3` camelCase is the rule everywhere, and `<entity>.field.list` answers it per entity.
-
-Under `restApi:v3` camelCase is the rule everywhere, and `<entity>.field.list` answers it per
-entity — see [Discovering entity fields](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/discovering-entity-fields/).
+The newer CRM methods (`crm.item.list`) use camelCase fields: `stageId`, `assignedById`, `opportunity`, `createdTime`. The classic ones (`tasks.task.add`, `crm.activity.list`, `crm.timeline.comment.add`) use uppercase: `TITLE`, `DESCRIPTION`, `OWNER_TYPE_ID`. Recipes follow this split. Both are `restApi:v2` — `crm.item.*` is camelCase for reasons of its own, not because it is v3; the v3 endpoint publishes no `crm.item.*`. Under `restApi:v3` camelCase is the rule everywhere, and `<entity>.field.list` answers it per entity — see [Discovering entity fields](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/discovering-entity-fields/).
 
 ## Running
 

--- a/skills/b24jssdk-rest/SKILL.md
+++ b/skills/b24jssdk-rest/SKILL.md
@@ -402,6 +402,7 @@ const hasNotes = Boolean(doc?.paths?.['/note.collection.list'])
 - The document is **portal-specific** (reflects installed modules + token scopes) and **large** (100 KB+). Fetch it **once and cache it** — it's response-only and stable within a session; don't re-request per interaction.
 - Each `paths['/method.name'].post.requestBody` schema lists the accepted parameters (often with an `example` of real field names) — read those instead of inventing `select` fields.
 - Full guide: [Discovering v3 methods](https://github.com/bitrix24/b24jssdk/blob/main/docs/content/docs/2.working-with-the-rest-api/7.discovering-v3-methods.md).
+- For one entity's fields and their flags, the cheaper half of the same question: [Discovering entity fields](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/discovering-entity-fields/).
 
 ## Anti-patterns
 


### PR DESCRIPTION
Follow-up to #473. That PR added the [Discovering entity fields](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/discovering-entity-fields/) guide but only the `b24jssdk-rest` skill pointed at it, so the two skills where the question actually comes up had no way to reach it.

One pointer added to each of three skills:

- **`b24jssdk-filtering`** — before `## Select`: how to ask an entity for its own field list, and why a `filterable: false` field is refused rather than ignored.
- **`b24jssdk-recipes`** — before `## Running`: under `restApi:v3` camelCase is the rule everywhere, and `<entity>.field.list` answers it per entity.
- **`b24jssdk-rest`** — next to the existing "Discovering v3 methods" link.

Documentation only; no runtime change.

Gates: `lint:md` 0 issues, `skills:typecheck-blocks` 83 blocks, `lint:md-links` 0 broken / 138 checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_