### PR TITLE
fix(recipes): make the v3 `tasks.task.add` calls in recipes 03 and 08 actually work

### DIFF
--- a/scripts/__tests__/check-v3-method-refs.test.mjs
+++ b/scripts/__tests__/check-v3-method-refs.test.mjs
@@ -492,3 +492,27 @@ test('recipes: .ts under skills/ is walked, not just .md', () => {
     assert.match(out.stdout + out.stderr, /notAnAction/)
   })
 })
+
+test('result key: a v2 sample later on the page is not attributed to a v3 call above it', () => {
+  // A page routinely shows both. The v2 sample may name no action of its own —
+  // only the response shape — so without a fence bound its correct
+  // `result.task` would inherit the v3 call further up and be reported.
+  withFixture({
+    'docs/content/docs/both.md': [
+      '# Both',
+      '',
+      '```ts',
+      'const res = await $b24.actions.v3.call.make({ method: \'tasks.task.get\', params: {} })',
+      'const task = res.getData().result.item',
+      '```',
+      '',
+      'The same call on v2:',
+      '',
+      '```ts [v2]',
+      'const id = res.getData().result.task.id',
+      '```'
+    ].join('\n')
+  }, (root) => {
+    assert.equal(runCheck(root).status, 0)
+  })
+})

--- a/scripts/__tests__/check-v3-method-refs.test.mjs
+++ b/scripts/__tests__/check-v3-method-refs.test.mjs
@@ -398,3 +398,97 @@ test('reduceDocument keeps what the check needs and drops the rest', () => {
     assert.doesNotMatch(serialised, new RegExp(forbidden), `${forbidden} must not survive the reduction`)
   }
 })
+
+// --- the v3 result key (#476) -------------------------------------------
+//
+// v3 returns a single entity under `result.item`, tasks included. TypeScript
+// cannot catch the v2 spelling because the response type is the caller's own
+// generic argument, so the gate has to.
+
+test('result key: `result.task` on a v3 call is an error', () => {
+  withFixture({
+    'skills/recipe.ts': [
+      'const res = await $b24.actions.v3.call.make({ method: \'tasks.task.add\', params: {} })',
+      'const id = res.getData().result.task.id'
+    ].join('\n')
+  }, (root) => {
+    const out = runCheck(root)
+    assert.equal(out.status, 1)
+    assert.match(out.stdout + out.stderr, /result\.task.*restApi:v3/s)
+  })
+})
+
+test('result key: the generic argument `<{ task: … }>` is an error too', () => {
+  withFixture({
+    'skills/recipe.ts': [
+      'const res = await $b24.actions.v3.call.make<{ task: { id: number } }>({',
+      '  method: \'tasks.task.add\', params: {} })'
+    ].join('\n')
+  }, (root) => {
+    assert.equal(runCheck(root).status, 1)
+  })
+})
+
+test('result key: a long call still attributes the read to the v3 above it', () => {
+  // `versionContextAt` looks +/-8 lines; a call with a big `fields` object puts
+  // `actions.v3.` further away than that, which is how the recipes escaped.
+  withFixture({
+    'skills/recipe.ts': [
+      'const res = await $b24.actions.v3.call.make({',
+      '  method: \'tasks.task.add\',',
+      '  params: { fields: {',
+      ...Array.from({ length: 14 }, (_, i) => `    field${i}: ${i},`),
+      '  } }',
+      '})',
+      'const id = res.getData().result.task.id'
+    ].join('\n')
+  }, (root) => {
+    assert.equal(runCheck(root).status, 1)
+  })
+})
+
+test('result key: `result.task` on a v2 call is correct and stays silent', () => {
+  withFixture({
+    'skills/recipe.ts': [
+      'const res = await $b24.actions.v2.call.make({ method: \'tasks.task.get\', params: {} })',
+      'const id = res.getData().result.task.id'
+    ].join('\n')
+  }, (root) => {
+    assert.equal(runCheck(root).status, 0)
+  })
+})
+
+test('result key: naming `result.task` in prose is not making the mistake', () => {
+  withFixture({
+    'docs/content/docs/note.md': [
+      '# Note',
+      '',
+      'A `actions.v3.call.make` returns `result.item` — the v2 method answered `result.task`.'
+    ].join('\n')
+  }, (root) => {
+    assert.equal(runCheck(root).status, 0)
+  })
+})
+
+test('result key: a marked anti-example is exempt', () => {
+  withFixture({
+    'skills/recipe.ts': [
+      'const res = await $b24.actions.v3.call.make({ method: \'tasks.task.add\', params: {} })',
+      '// @check-ignore: showing the wrong result.task spelling on purpose',
+      'const id = res.getData().result.task.id'
+    ].join('\n')
+  }, (root) => {
+    assert.equal(runCheck(root).status, 0)
+  })
+})
+
+test('recipes: .ts under skills/ is walked, not just .md', () => {
+  // The recipes were invisible to every v3 gate while only `.md` was walked.
+  withFixture({
+    'skills/b24jssdk-recipes/examples/03.ts': 'await $b24.actions.v3.notAnAction.make({})'
+  }, (root) => {
+    const out = runCheck(root)
+    assert.equal(out.status, 1)
+    assert.match(out.stdout + out.stderr, /notAnAction/)
+  })
+})

--- a/scripts/check-v3-method-refs.mjs
+++ b/scripts/check-v3-method-refs.mjs
@@ -240,15 +240,24 @@ const V2_RESULT_KEY = /\bresult\.task\b|<\{\s*task\s*:/g
 /**
  * Is this line prose rather than code?
  *
- * In markdown, anything outside a fenced block. In TypeScript, a comment line —
- * `//`, or a `*` continuing a JSDoc block.
+ * A comment either way — `//`, or a `*` continuing a JSDoc block — plus, in
+ * markdown, anything outside a fenced block.
+ *
+ * Indented (four-space) code blocks are read as prose by this test. That is a
+ * known gap rather than an oversight: every code sample in this repository is
+ * fenced, because the typecheck gates find blocks by fence and an indented one
+ * would already be invisible to them.
  */
+function isComment(line) {
+  return line.startsWith('//') || line.startsWith('*') || line.startsWith('/*')
+}
+
 function isProse(file, lines, index) {
   const line = (lines[index] ?? '').trim()
-  if (file.endsWith('.md')) {
-    return enclosingFenceStart(lines, index) === -1 || line.startsWith('//') || line.startsWith('*')
+  if (file.endsWith('.md') && enclosingFenceStart(lines, index) === -1) {
+    return true
   }
-  return line.startsWith('//') || line.startsWith('*') || line.startsWith('/*')
+  return isComment(line)
 }
 
 /**
@@ -260,10 +269,18 @@ function isProse(file, lines, index) {
  * window — recipe 03 spans some twenty lines between the two. So walk back to
  * the nearest preceding `actions.vN.` instead, with no distance limit: a result
  * read belongs to the last call opened above it. Falls back to the shared
- * context when the file names no action at all, and `null` stays a real answer.
+ * context when nothing is found, and `null` stays a real answer.
+ *
+ * In markdown the walk stops at the enclosing fence. A page routinely shows a
+ * v3 sample and then a v2 one, and the v2 sample may name no action of its own
+ * — only the response shape. Without the bound, its correct `result.task`
+ * would be attributed to the v3 call further up the page and reported as an
+ * error. A fenced sample is its own scope; `versionContextAt` then decides,
+ * which is what reads the `[v2]` / `[v3]` fence tag.
  */
 function callSurfaceAbove(file, lines, index) {
-  for (let i = index; i >= 0; i--) {
+  const floor = file.endsWith('.md') ? Math.max(0, enclosingFenceStart(lines, index)) : 0
+  for (let i = index; i >= floor; i--) {
     const found = /actions\.v([23])\./.exec(lines[i] ?? '')
     if (found !== null) {
       return `v${found[1]}`

--- a/scripts/check-v3-method-refs.mjs
+++ b/scripts/check-v3-method-refs.mjs
@@ -74,6 +74,12 @@ function filesToCheck() {
     // READMEs that are not ours to check.
     files.push(...walkFiles(join(ROOT, ...base.split('/')), { skipDirs: ['node_modules'] }))
   }
+  // The recipes are runnable TypeScript, not prose, and were invisible to every
+  // v3 gate while only `.md` was walked here — which is how two of them shipped
+  // calling `tasks.task.add` on v3 with v2 field names and reading the v2
+  // result key (#476). They are the files most likely to carry the mistake,
+  // because they are the ones people copy.
+  files.push(...walkFiles(join(ROOT, 'skills'), { extension: '.ts', skipDirs: ['node_modules'] }))
   // Tolerated as absent so a fixture root can populate only what it is testing;
   // `pullClient` is skipped because its vendored protobuf modules are not ours.
   const sdkSource = join(ROOT, 'packages', 'jssdk', 'src')
@@ -210,6 +216,84 @@ function checkPhantomActions(file, body) {
         report.error(file, `references non-existent v3 action "${name}" in actions.v3.{${m[1]}}`)
       }
     }
+  }
+}
+
+/**
+ * The v3 endpoint returns a single entity under `result.item`, always — tasks
+ * included, where the v2 method answered `result.task`.
+ *
+ * Worth a rule of its own because TypeScript cannot catch it: the response type
+ * is supplied by the caller as a generic argument, so `<{ task: … }>` compiles
+ * happily against a body that has no `task` key. The read then yields
+ * `undefined`, and `Number(undefined)` is `NaN` — so the caller reports a
+ * created entity with an id of `NaN` rather than failing. Two recipes shipped
+ * that way (#476).
+ *
+ * Only fires where the version context says v3, so the v2 spelling — which is
+ * correct there — stays silent. Prose is skipped too: explaining the mistake
+ * is not making it, and the sentence naming `result.task` as the v2 spelling
+ * is exactly the documentation this rule wants to keep.
+ */
+const V2_RESULT_KEY = /\bresult\.task\b|<\{\s*task\s*:/g
+
+/**
+ * Is this line prose rather than code?
+ *
+ * In markdown, anything outside a fenced block. In TypeScript, a comment line —
+ * `//`, or a `*` continuing a JSDoc block.
+ */
+function isProse(file, lines, index) {
+  const line = (lines[index] ?? '').trim()
+  if (file.endsWith('.md')) {
+    return enclosingFenceStart(lines, index) === -1 || line.startsWith('//') || line.startsWith('*')
+  }
+  return line.startsWith('//') || line.startsWith('*') || line.startsWith('/*')
+}
+
+/**
+ * Which surface does a result read belong to?
+ *
+ * `versionContextAt` looks ±8 lines, which is right for a `method:` literal
+ * sitting inside its call but too narrow here: a read comes *after* the call,
+ * and a call with a long `fields` object puts `actions.v3.` well out of that
+ * window — recipe 03 spans some twenty lines between the two. So walk back to
+ * the nearest preceding `actions.vN.` instead, with no distance limit: a result
+ * read belongs to the last call opened above it. Falls back to the shared
+ * context when the file names no action at all, and `null` stays a real answer.
+ */
+function callSurfaceAbove(file, lines, index) {
+  for (let i = index; i >= 0; i--) {
+    const found = /actions\.v([23])\./.exec(lines[i] ?? '')
+    if (found !== null) {
+      return `v${found[1]}`
+    }
+  }
+  return versionContextAt(file, lines, index)
+}
+
+function checkResultKey(file, body) {
+  const lines = body.split(/\r\n?|\n/)
+  for (const m of body.matchAll(V2_RESULT_KEY)) {
+    const line = body.slice(0, m.index).split(/\r\n?|\n/).length
+    if (callSurfaceAbove(file, lines, line - 1) !== 'v3') {
+      continue
+    }
+    if (isProse(file, lines, line - 1)) {
+      continue
+    }
+    if (isMarkedIgnored(lines, line - 1, 'result.task')) {
+      continue
+    }
+    report.error(
+      file,
+      `reads "${m[0]}" on a restApi:v3 call — v3 returns a single entity under \`result.item\`, `
+      + `including tasks (the v2 method answered \`result.task\`). TypeScript cannot catch this: `
+      + `the response type is the caller's own generic argument, so the read silently yields `
+      + `undefined. Use \`result.item\`, or mark the line `
+      + `"@check-ignore: <reason naming result.task>" if it is a deliberate anti-example`,
+      { line }
+    )
   }
 }
 
@@ -411,6 +495,7 @@ if (!isEntryPoint) {
   for (const file of filesToCheck()) {
     const body = readFileSync(file, 'utf8')
     checkPhantomActions(file, body)
+    checkResultKey(file, body)
     checkMethodNames(file, body, snapshots, documented)
   }
 

--- a/skills/b24jssdk-recipes/examples/03-task-automation.ts
+++ b/skills/b24jssdk-recipes/examples/03-task-automation.ts
@@ -29,11 +29,18 @@ function bootB24(): TypeB24 {
   return $b24
 }
 
+/**
+ * `priority` is a v3 enum, not the numeric v2 scale. Measured against a portal:
+ * only `high` and `average` exist — `low`, `normal` and any number are accepted
+ * without an error and stored as `average`, so a wrong value is silent.
+ */
+type TaskPriority = 'high' | 'average'
+
 interface TaskTemplate {
   title: string
   description: string
   deadlineDays: number
-  priority: 0 | 1 | 2
+  priority: TaskPriority
 }
 
 const STAGE_TASKS: Record<string, TaskTemplate> = {
@@ -41,19 +48,19 @@ const STAGE_TASKS: Record<string, TaskTemplate> = {
     title: 'Prepare documents and start execution',
     description: 'Deal moved into execution. Prepare all paperwork and kick off delivery.',
     deadlineDays: 5,
-    priority: 2
+    priority: 'high'
   },
   PREPAYMENT_INVOICE: {
     title: 'Send the invoice and chase payment',
     description: 'Issue the prepayment invoice and follow up until paid.',
     deadlineDays: 3,
-    priority: 2
+    priority: 'high'
   },
   FINAL_INVOICE: {
     title: 'Final reconciliation and closing',
     description: 'Final stage of the deal. Prepare closing documents.',
     deadlineDays: 7,
-    priority: 1
+    priority: 'average'
   }
 }
 
@@ -96,32 +103,52 @@ async function fetchOpenDeals($b24: TypeB24): Promise<DealRow[]> {
 }
 
 interface TasksTaskAddResponse {
-  task: { id: number }
+  item: { id: number }
+}
+
+/**
+ * `deadline` wants a DateTime *without* milliseconds. `Date.toISOString()`
+ * emits `.000Z`, which the portal rejects outright with "требуется тип данных
+ * `DateTime`" — so trim them rather than passing the ISO string straight in.
+ */
+function toPortalDateTime(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
 }
 
 async function createTask($b24: TypeB24, deal: DealRow, t: TaskTemplate): Promise<number> {
   const deadline = new Date()
   deadline.setDate(deadline.getDate() + t.deadlineDays)
 
-  // tasks.task.add is called on v3 (camelCase fields, result.item).
+  // tasks.task.add is on v3: camelCase fields, and the created entity comes
+  // back under `result.item`. Ask the portal itself with `tasks.task.field.list`
+  // rather than translating the v2 names by eye.
+  const responsibleId = deal.assignedById || 1
   const res = await $b24.actions.v3.call.make<TasksTaskAddResponse>({
     method: 'tasks.task.add',
     params: {
       fields: {
-        TITLE: `${t.title} — ${deal.title}`,
-        DESCRIPTION: `${t.description}\n\nDeal: ${deal.title} (ID: ${deal.id})`,
-        RESPONSIBLE_ID: deal.assignedById || 1,
-        PRIORITY: t.priority,
-        DEADLINE: deadline.toISOString(),
-        UF_CRM_TASK: [`D_${deal.id}`]
+        title: `${t.title} — ${deal.title}`,
+        description: `${t.description}\n\nDeal: ${deal.title} (ID: ${deal.id})`,
+        // Both are required — a fields object without them fails validation.
+        creatorId: responsibleId,
+        responsibleId,
+        priority: t.priority,
+        deadline: toPortalDateTime(deadline),
+        // The v2 `UF_CRM_TASK` field is `crmItemIds` on v3. The `D_<id>` value
+        // shape carries over; a bare number or an object is accepted and then
+        // silently dropped.
+        crmItemIds: [`D_${deal.id}`]
       }
     },
-    requestId: `task-add-${deal.id}`
+    // Names this attempt in the logs. It does NOT deduplicate — for that,
+    // `idempotencyKey` makes the retry of one operation write only once.
+    requestId: `task-add-${deal.id}`,
+    idempotencyKey: `stage-task-${deal.id}-${t.title}`
   })
 
   if (!res.isSuccess) throw new Error(res.getErrorMessages().join('; '))
 
-  const id = Number(res.getData()!.result.task.id)
+  const id = Number(res.getData()!.result.item.id)
   logger.info(`  task #${id} created — ${t.title}`)
   return id
 }

--- a/skills/b24jssdk-recipes/examples/03-task-automation.ts
+++ b/skills/b24jssdk-recipes/examples/03-task-automation.ts
@@ -18,6 +18,7 @@ import {
   type TypeB24
 } from '@bitrix24/b24jssdk'
 import { baseStage } from '../lib/funnel'
+import { toPortalDateTime } from '../lib/portal-datetime'
 
 const logger = Logger.create('TaskAuto')
 logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO, { useStyles: false }))
@@ -104,15 +105,6 @@ async function fetchOpenDeals($b24: TypeB24): Promise<DealRow[]> {
 
 interface TasksTaskAddResponse {
   item: { id: number }
-}
-
-/**
- * `deadline` wants a DateTime *without* milliseconds. `Date.toISOString()`
- * emits `.000Z`, which the portal rejects outright with "требуется тип данных
- * `DateTime`" — so trim them rather than passing the ISO string straight in.
- */
-function toPortalDateTime(date: Date): string {
-  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
 }
 
 async function createTask($b24: TypeB24, deal: DealRow, t: TaskTemplate): Promise<number> {

--- a/skills/b24jssdk-recipes/examples/08-ai-assistant.ts
+++ b/skills/b24jssdk-recipes/examples/08-ai-assistant.ts
@@ -24,6 +24,7 @@ import {
   type TypeB24
 } from '@bitrix24/b24jssdk'
 import OpenAI from 'openai'
+import { toPortalDateTime } from '../lib/portal-datetime'
 
 const logger = Logger.create('AiAssistant')
 logger.pushHandler(new ConsoleV2Handler(LogLevel.INFO, { useStyles: false }))
@@ -167,9 +168,7 @@ async function createTask($b24: TypeB24, r: Recommendation, deal: DealItem): Pro
         creatorId: responsibleId,
         responsibleId,
         priority: priorityMap[r.priority],
-        // `deadline` wants a DateTime *without* milliseconds; `toISOString()`
-        // emits `.000Z`, which the portal rejects outright.
-        deadline: deadline.toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        deadline: toPortalDateTime(deadline),
         // v2's `UF_CRM_TASK` is `crmItemIds` here; the `D_<id>` value shape
         // carries over, while a bare number is silently dropped.
         crmItemIds: [`D_${deal.id}`]

--- a/skills/b24jssdk-recipes/examples/08-ai-assistant.ts
+++ b/skills/b24jssdk-recipes/examples/08-ai-assistant.ts
@@ -141,31 +141,47 @@ Reply as JSON:
 async function createTask($b24: TypeB24, r: Recommendation, deal: DealItem): Promise<number> {
   const deadline = new Date()
   deadline.setDate(deadline.getDate() + Math.max(1, r.deadlineDays))
-  const priorityMap = { high: 2, medium: 1, low: 0 } as const
+  // v3 `priority` is an enum, not the numeric v2 scale. Measured against a
+  // portal: only `high` and `average` exist, and anything else — `low`, a
+  // number — is accepted without an error and stored as `average`. Mapping the
+  // model's three levels onto the two that exist keeps that explicit.
+  const priorityMap = { high: 'high', medium: 'average', low: 'average' } as const
 
-  // tasks.task.add is called on v3 (camelCase fields, result.item).
-  const res = await $b24.actions.v3.call.make<{ task: { id: number } }>({
+  // tasks.task.add is on v3: camelCase fields, and the created entity comes
+  // back under `result.item`. Ask `tasks.task.field.list` rather than
+  // translating the v2 names by eye.
+  const responsibleId = Number(deal.assignedById ?? 1)
+  const res = await $b24.actions.v3.call.make<{ item: { id: number } }>({
     method: 'tasks.task.add',
     params: {
       fields: {
-        TITLE: `[AI] ${r.taskTitle}`,
-        DESCRIPTION: [
+        title: `[AI] ${r.taskTitle}`,
+        description: [
           r.taskDescription,
           '',
           '---',
           `AI analysis: ${r.analysis}`,
           `Deal: ${deal.title} (ID: ${deal.id})`
         ].join('\n'),
-        RESPONSIBLE_ID: Number(deal.assignedById ?? 1),
-        PRIORITY: priorityMap[r.priority],
-        DEADLINE: deadline.toISOString(),
-        UF_CRM_TASK: [`D_${deal.id}`]
+        // Both are required — a fields object without them fails validation.
+        creatorId: responsibleId,
+        responsibleId,
+        priority: priorityMap[r.priority],
+        // `deadline` wants a DateTime *without* milliseconds; `toISOString()`
+        // emits `.000Z`, which the portal rejects outright.
+        deadline: deadline.toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        // v2's `UF_CRM_TASK` is `crmItemIds` here; the `D_<id>` value shape
+        // carries over, while a bare number is silently dropped.
+        crmItemIds: [`D_${deal.id}`]
       }
     },
-    requestId: `task-add-${deal.id}`
+    requestId: `task-add-${deal.id}`,
+    // The model can be asked twice about the same deal; the key makes the
+    // second run replay the first task instead of creating another.
+    idempotencyKey: `ai-task-${deal.id}-${r.taskTitle}`
   })
   if (!res.isSuccess) throw new Error(res.getErrorMessages().join('; '))
-  return Number(res.getData()!.result.task.id)
+  return Number(res.getData()!.result.item.id)
 }
 
 async function main() {

--- a/skills/b24jssdk-recipes/examples/10-error-handling.ts
+++ b/skills/b24jssdk-recipes/examples/10-error-handling.ts
@@ -191,6 +191,9 @@ async function intentionallyWrongCall($b24: TypeB24) {
   // it as a SOFT error — the call does NOT throw, it returns a failed
   // AjaxResult. Check `isSuccess` rather than catching.
   const response = await $b24.actions.v3.call.make({
+    // v3 publishes no `crm.item.*`; the point of this section is that the
+    // server rejects it, not the SDK.
+    // @check-ignore: `crm.item.get` is the deliberate anti-example here
     method: 'crm.item.get',
     params: { entityTypeId: EnumCrmEntityTypeId.deal, id: 1 }
   })

--- a/skills/b24jssdk-recipes/lib/portal-datetime.ts
+++ b/skills/b24jssdk-recipes/lib/portal-datetime.ts
@@ -1,0 +1,23 @@
+/**
+ * Date formatting for `restApi:v3` fields.
+ *
+ * Shared rather than copied: two recipes write task deadlines, and a format
+ * rule that drifts in one of two forks is a bug that reads like a refactor.
+ */
+
+/**
+ * Format a `Date` for a v3 `DateTime` field.
+ *
+ * `Date.toISOString()` alone does not work: it emits milliseconds (`.000Z`),
+ * and the portal rejects the value outright with "требуется тип данных
+ * `DateTime`". Measured against a portal — the identical value without the
+ * milliseconds is accepted, and reads back in the portal's own timezone.
+ *
+ * @example
+ * const deadline = new Date()
+ * deadline.setDate(deadline.getDate() + 5)
+ * toPortalDateTime(deadline) // '2026-09-10T05:53:22Z'
+ */
+export function toPortalDateTime(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+}


### PR DESCRIPTION
Closes #476.

Both recipes called `tasks.task.add` through `actions.v3.call.make` while sending v2 field names and reading the v2 result key, so neither could work as written. Recipe 08 carried a comment stating the rule — *"camelCase fields, result.item"* — directly above three lines that did neither.

## The field names came from the portal, not from guessing

Asked `tasks.task.field.list` (the method the [field-discovery guide](https://bitrix24.github.io/b24jssdk/docs/working-with-the-rest-api/discovering-entity-fields/) exists for) rather than translating the v2 spellings by eye. Three fields needed measuring, not renaming — which is why #476 was kept out of #475 instead of half-fixed there:

| Field | What was there | Measured |
|---|---|---|
| `deadline` | `DEADLINE: deadline.toISOString()` | **A rename alone still fails.** `toISOString()` emits `.000Z`, and the portal answers `требуется тип данных DateTime`. The same value without milliseconds is accepted. |
| `priority` | `PRIORITY: 2` (v2 numeric scale) | An **enum**, and only `high` and `average` exist. `low`, `normal`, `'2'`, `'1'`, `'0'` are all accepted with no error and stored as `average` — a wrong value is silent. |
| `crmItemIds` | `UF_CRM_TASK: ['D_1']` | The `D_<id>` value shape carries over; the field name does not. A bare number or `{ entityTypeId, id }` is accepted and then silently dropped. |

Plus `creatorId` / `responsibleId`, which are required — a `fields` object without them fails validation.

Both recipes also gained an `idempotencyKey` (from #462): a stage transition and an AI re-run are exactly the repeatable operations it exists for.

**Verified live.** The call as it now stands in recipe 03 creates a task whose `deadline`, `priority` and `crmItemIds` all read back as sent. Everything created was deleted afterwards.

## Why no gate caught it

`check-v3-method-refs.mjs` walked `skills/` for **`.md` only**. The recipes are runnable TypeScript — the code people actually copy — and were invisible to every v3 check. Now walked, which immediately surfaced one genuine anti-example in recipe 10 (`crm.item.get` on the v3 surface, the thing that section is *about*); it is marked with `@check-ignore` rather than silenced.

## The rule itself

Reading `result.task` from a v3 call is always wrong, and **TypeScript cannot catch it**: the response type is the caller's own generic argument, so `<{ task: … }>` compiles happily against a body with no `task` key. The read yields `undefined`, `Number(undefined)` is `NaN`, and the recipe reports a created task with an id of `NaN` rather than failing.

Two details that took a couple of passes:

- **Attribution is by nearest call above, not by a line window.** `versionContextAt` looks ±8 lines, which is right for a `method:` literal inside its call but too narrow for a result read: recipe 03 has ~20 lines of `fields` between the two, so the first version of the rule silently missed the very bug it was written for.
- **Prose is skipped.** The first version flagged the sentence added in #475 explaining that `result.task` is the v2 spelling — explaining the mistake is not making it.

Seven tests cover it: both spellings, the long-call case, the v2 spelling staying silent, prose staying silent, a marked exemption, and `.ts` under `skills/` being walked at all. Each was confirmed to redden by reverting the corresponding fix.

## Gates

`lint`, `lint:md`, `docs-lint --strict`, `check-v3-method-refs`, `lint:md-links`, the recipes' own `tsc`, and `docs:lint:test` (169 tests, run three times) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_