### PR TITLE
fix(http): walk a top-level array or string in the redactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Bug Fixes
 
+* **The log redactor no longer skips a response whose `result` is an array.** `redactSensitiveParams` began `if (!isPlainObject(params)) return params`, and that excludes arrays — so a credential key was masked inside an object and printed verbatim when it arrived on its own. `post/response` logs `response.data?.result`, and a `restApi:v3` batch answers with an array there, so every successful v3 batch wrote its response to the log unmasked. A bare string was skipped for the same reason, which meant a webhook secret in a URL path — the case v2.2.0 taught the redactor to mask — was missed whenever the URL was the whole value rather than a field inside one.
+
+    The walker underneath always handled both shapes; only the entry point refused them. Nothing about which keys are masked, or how deep the walk goes, has changed.
+
 * **`setRestrictionManagerParams` no longer wipes the parameters you did not mention.** It replaced the whole configuration, so `setRestrictionManagerParams({ maxRetries: 5 })` after a deliberate setup left `hardErrorCodes`, `retryOnNetworkError` and `classifyV3ErrorsByCategory` at `undefined` — and `rateLimit` too, which then reached the rate limiter as `undefined` behind a non-null assertion. No error, nothing in the log; the next call simply ran under a policy nobody had chosen. It now replaces what you name and leaves the rest alone.
 
     The nested blocks — `rateLimit`, `operatingLimit`, `adaptiveConfig` — are replaced **whole** rather than merged field by field; their types have no optional fields, and a partial block arriving from JavaScript is now refused with `JSSDK_LIMITER_INVALID_CONFIG_BLOCK` instead of switching rate limiting off on a `NaN` interval. `getRestrictionManagerParams()` returns a copy, so reading the policy no longer hands out the limiter's live state.

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -2,7 +2,7 @@
 title: Logging & Credential Redaction
 description: 'What the SDK redacts automatically before any request information enters the logger or an AjaxError, what it does not redact, and how to wire a custom logger via setLogger(...) without re-introducing credential leaks.'
 category: 'logging'
-audited: 2026-09-06
+audited: 2026-09-07
 navigation.title: Logging & Redaction
 links:
   - label: redact.ts (canonical key list)
@@ -79,6 +79,12 @@ where the credential lives at `cmd[i].params.<key>`, plus flat one-level
 shapes like `{ data: { token } }`. Anything deeper than that is **not**
 walked — keep secrets close to the top of the payload if you want them
 caught, or redact at the callsite.
+
+The value handed in does not have to be an object. An **array** or a bare
+**string** at the top level is walked on the same terms — which matters
+because `post/response` logs `response.data?.result`, and a `restApi:v3`
+batch answers with an array there. Until v2.3.0 the redactor returned any
+non-object input untouched, so those responses were logged unmasked (#487).
 
 The redactor also scans **string values** for query-string credential
 pairs (`<key>=<value>`) and masks the value in place. This covers the

--- a/packages/jssdk/src/core/http/redact.ts
+++ b/packages/jssdk/src/core/http/redact.ts
@@ -196,19 +196,35 @@ const DEFAULT_REDACT_DEPTH = 2
 
 /**
  * Returns a copy of `params` with any known credential-bearing key replaced by
- * `REDACTED_PLACEHOLDER`, and any credential value embedded in a query-string
- * value masked in place. Walks up to two levels into nested objects/arrays so
- * batch-shaped payloads (`cmd[i].params.<key>` and `cmd[i]` query strings) are
- * covered. Non-object inputs are returned as-is so callers don't have to
- * pre-check.
+ * `REDACTED_PLACEHOLDER`, and any credential embedded in a string — a query
+ * value or a webhook secret in a URL path — masked in place. Walks up to two
+ * levels into nested objects/arrays so batch-shaped payloads
+ * (`cmd[i].params.<key>` and `cmd[i]` query strings) are covered.
+ *
+ * **An array or a string at the top level is walked too.** It used to be
+ * returned untouched: this function began `if (!isPlainObject(params)) return
+ * params`, and `isPlainObject` excludes arrays. The walker underneath has
+ * always handled both — only the door was shut. So the same content was masked
+ * inside an object and printed verbatim when it arrived on its own, and #468
+ * widened that gap rather than closing it, by teaching the string pass to mask
+ * a webhook secret in a URL path that a top-level string never reached.
+ *
+ * That is not a corner: `_makeAxiosRequest` logs `response.data?.result`, and a
+ * `restApi:v3` batch answers with an array there, so every successful v3 batch
+ * wrote its response to the log unmasked.
+ *
+ * The plain-object branch is kept rather than folded into `redactValue`,
+ * because entering through the value walker would spend a depth level on the
+ * object itself and leave one for its contents — half the reach that
+ * batch-shaped payloads need.
  */
 export function redactSensitiveParams(
   params: Record<string, unknown>
 ): Record<string, unknown>
 export function redactSensitiveParams<T>(params: T): T
 export function redactSensitiveParams(params: unknown): unknown {
-  if (!isPlainObject(params)) return params
-  return redactObject(params, DEFAULT_REDACT_DEPTH)
+  if (isPlainObject(params)) return redactObject(params, DEFAULT_REDACT_DEPTH)
+  return redactValue(params, DEFAULT_REDACT_DEPTH)
 }
 
 /**

--- a/test/integration/core/redact-top-level-value.unit.spec.ts
+++ b/test/integration/core/redact-top-level-value.unit.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * The redactor used to refuse anything that was not a plain object.
+ *
+ * `redactSensitiveParams` began `if (!isPlainObject(params)) return params`,
+ * and `isPlainObject` excludes arrays — so an array or a bare string handed in
+ * at the top level came back untouched. The walker underneath (`redactValue`)
+ * had always handled both; only the door was shut. The same content was
+ * therefore masked inside an object and printed verbatim when it arrived on its
+ * own.
+ *
+ * That is reached on an ordinary path, not a corner: `_makeAxiosRequest` logs
+ * `response.data?.result`, and a `restApi:v3` batch answers with an **array**
+ * there — so every successful v3 batch wrote its response to the log unmasked.
+ *
+ * #468 widened the gap rather than closing it: it taught the string pass to
+ * mask a webhook secret in a URL *path*, a capability a top-level string never
+ * reached.
+ *
+ * One `it` per surface: a compound case lets one mutation hide behind a
+ * neighbouring assertion.
+ *
+ * `*.unit.spec.ts` — no portal, no network.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { ApiVersion, B24Hook, ParamsFactory } from '../../../packages/jssdk/src/'
+import { redactSensitiveParams } from '../../../packages/jssdk/src/core/http/redact'
+
+const SECRET_URL = 'https://example.bitrix24.com/rest/1/abcdefgh12345678/user.get'
+const REDACTED = '***REDACTED***'
+
+describe('redacting a top-level array or string', () => {
+  it('masks a credential key inside a top-level array', () => {
+    // No cast on the way in: the generic overload carries the array type
+    // through, which is itself part of the contract this pins.
+    const redacted = redactSensitiveParams([{ id: 1, auth: 'SECRET' }])
+    expect(redacted[0]?.auth).toBe(REDACTED)
+  })
+
+  it('masks a webhook secret in a URL inside a top-level array', () => {
+    const redacted = redactSensitiveParams([{ url: SECRET_URL }])
+    expect(redacted[0]?.url).not.toContain('abcdefgh12345678')
+    expect(redacted[0]?.url).toContain(REDACTED)
+  })
+
+  it('masks a webhook secret in a bare top-level string', () => {
+    // The #468 capability, on the shape #468 never reached.
+    const redacted = redactSensitiveParams(SECRET_URL)
+    expect(redacted).not.toContain('abcdefgh12345678')
+    expect(redacted).toContain(REDACTED)
+  })
+
+  it('masks a query-string credential in a bare top-level string', () => {
+    const redacted = redactSensitiveParams('https://example.com/?auth=SECRET&x=1')
+    expect(redacted).not.toContain('SECRET')
+  })
+
+  it('walks an array nested in a top-level array', () => {
+    const redacted = redactSensitiveParams([[{ auth: 'SECRET' }]])
+    expect(redacted[0]?.[0]?.auth).toBe(REDACTED)
+  })
+
+  it('leaves a value with nothing to mask alone', () => {
+    expect(redactSensitiveParams(['plain', 42])).toEqual(['plain', 42])
+    expect(redactSensitiveParams(null)).toBeNull()
+    expect(redactSensitiveParams(undefined)).toBeUndefined()
+    expect(redactSensitiveParams(42)).toBe(42)
+  })
+
+  it('does not mutate the array it was given', () => {
+    const source = [{ auth: 'SECRET' }]
+    redactSensitiveParams(source)
+    expect(source[0]?.auth).toBe('SECRET')
+  })
+
+  it('keeps the full two-level reach for a plain object', () => {
+    // Entering through the value walker would spend a depth level on the object
+    // itself, halving the reach batch-shaped payloads need.
+    const redacted = redactSensitiveParams({ cmd: [{ params: { auth: 'SECRET' } }] }) as {
+      cmd: Array<{ params: { auth: string } }>
+    }
+    expect(redacted.cmd[0]?.params.auth).toBe(REDACTED)
+  })
+})
+
+describe('the response log of a call whose result is an array', () => {
+  let b24: B24Hook | null = null
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    b24?.destroy()
+    b24 = null
+  })
+
+  it('masks the credentials a v3 batch returns', async () => {
+    b24 = B24Hook.fromWebhookUrl('https://example.bitrix24.com/rest/1/SECRET', {
+      restrictionParams: { ...ParamsFactory.getDefault(), maxRetries: 1, retryDelay: 1 }
+    })
+    const client = b24.getHttpClient(ApiVersion.v3)
+
+    vi.spyOn(client.ajaxClient, 'post').mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as never,
+      data: {
+        result: [{ id: 1, auth: 'SECRET-IN-BATCH', url: SECRET_URL }],
+        time: {
+          start: 0, finish: 0, duration: 0, processing: 0,
+          date_start: '1970-01-01T00:00:00+00:00', date_finish: '1970-01-01T00:00:00+00:00'
+        }
+      }
+    })
+
+    const logged: string[] = []
+    vi.spyOn(client.getLogger(), 'info').mockImplementation(async (message: string, context?: unknown) => {
+      if (message === 'post/response') {
+        logged.push(JSON.stringify(context))
+      }
+    })
+
+    await client.call('main.eventlog.list', {})
+
+    // End to end, because the unit-level cases above cannot show that this is
+    // the shape the transport actually hands the redactor.
+    expect(logged).toHaveLength(1)
+    expect(logged[0]).not.toContain('SECRET-IN-BATCH')
+    expect(logged[0]).not.toContain('abcdefgh12345678')
+  })
+})


### PR DESCRIPTION
Closes #487. Reported as a follow-up to #468.

## What was wrong

`redactSensitiveParams` opened with `if (!isPlainObject(params)) return params`, and `isPlainObject` excludes arrays. Everything that was not a plain object came back untouched — while the walker underneath (`redactValue`) had always handled arrays *and* strings. Only the entry point refused them, and the doc comment recorded it as intended behaviour: *"Non-object inputs are returned as-is so callers don't have to pre-check."*

Measured:

| Input | Before |
|---|---|
| `{ auth: 'SECRET-TOKEN' }` | `{"auth":"***REDACTED***"}` |
| `[{ auth: 'SECRET-TOKEN' }]` | `[{"auth":"SECRET-TOKEN"}]` — **not masked** |
| `{ items: [{ auth: 'SECRET-TOKEN' }] }` | masked |
| `'…/rest/1/abcdefgh12345678/user.get'` | unchanged — **not masked** |
| `{ url: '…/rest/1/abcdefgh12345678/user.get' }` | masked |

The same content, masked in one shape and printed in the other.

## Why it reached real traffic

`_makeAxiosRequest` logs `response.data?.result`, and a `restApi:v3` batch answers with an **array** there (`BatchResponsePayload<T> = BatchResponseData<T> | T[] | Record<…>`). So every successful v3 batch wrote its response to the log unmasked. Confirmed end to end — a mocked v3 response with `result: [{ id: 1, auth: 'SECRET-TOKEN-IN-BATCH', url: '…/rest/1/abcdefgh12345678/…' }]` put both credentials verbatim into the `post/response` context at `info` level.

**The report named arrays; strings are affected too**, and that half is sharper. Masking a webhook secret in a URL *path* is precisely the capability #468 added — and a top-level string never reached it. #468 therefore widened the asymmetry rather than closing it, which is how it became visible.

## The change

One branch at the entry point:

```ts
if (isPlainObject(params)) return redactObject(params, DEFAULT_REDACT_DEPTH)
return redactValue(params, DEFAULT_REDACT_DEPTH)
```

The plain-object branch **stays** rather than folding into `redactValue`, and that is the one subtlety here: entering through the value walker spends a depth level on the object itself and leaves one for its contents — half the reach the batch shape `cmd[i].params.<key>` needs. Two tests pin it, because collapsing the two lines into one is the obvious-looking simplification.

Nothing about which keys are masked, or how deep the walk goes, changes.

## Tests

New `test/integration/core/redact-top-level-value.unit.spec.ts`, nine cases, one per surface: a top-level array; a webhook path inside one; a bare string with a webhook path; a bare string with a query credential; an array nested in an array; values with nothing to mask; non-mutation of the input; the retained two-level reach for objects; and one end-to-end case driving a v3-shaped array response through the transport and asserting the logged context carries neither credential.

Mutation-checked: restoring the bail reddens six of them, entering through `redactValue` reddens the two depth cases.

The 37 existing cases in `http-logger-redaction.unit.spec.ts` are untouched and green — which is the check that the key list and the walk depth were not altered.

The tests pass their inputs **without a cast**; the generic overload carries the array and string types through, which is itself part of the contract now.

## Docs

`78.logging.md` documents that a top-level array or string is walked, and why it matters for `post/response`. `CHANGELOG.md` carries the entry.

## Gates

`lint`, repo-level `typecheck`, `test:typecheck`, `docs-lint --strict`, `lint:md`, `lint:md-links`, `docs-typecheck`, and `jsSdk:unit` (678 passed) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_