### PR TITLE
docs: the OpenAPI document follows installed modules, not granted scopes

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/7.discovering-v3-methods.md
+++ b/docs/content/docs/2.working-with-the-rest-api/7.discovering-v3-methods.md
@@ -42,7 +42,7 @@ for methods present on both.
 `BITRIX_REST_V3_EXCEPTION_INSUFFICIENTSCOPEEXCEPTION` (403) when the token lacks
 the scope — so the document cannot be used as a permission check. It is not
 filtered by your rights either: widening a webhook from 10 scopes to 15 did not
-change it at all. To find the scope a method needs, use `rest.scope.list`.
+change it at all. Scopes are published separately, by `rest.scope.list`.
 ::
 
 ::warning
@@ -116,8 +116,8 @@ portal **without guessing**:
   wrappers, or narrow `$b24.actions.v3.call.make<T>()` with the right `T`.
 - **Portal-aware** — because the answer is per-portal, an agent can adapt to the
   modules actually installed rather than to a generic assumption. Scopes are a
-  separate question the document does not answer; pair it with `rest.scope.list`
-  when the agent also needs to know what the token may call.
+  separate question the document does not answer; pair it with `rest.scope.list`,
+  which is where the portal publishes them.
 
 ::tip
 The document is large (often **100 KB+**) and **response-only** — it does not

--- a/docs/content/docs/2.working-with-the-rest-api/7.discovering-v3-methods.md
+++ b/docs/content/docs/2.working-with-the-rest-api/7.discovering-v3-methods.md
@@ -1,7 +1,7 @@
 ---
 title: Discovering v3 methods (OpenAPI)
 description: 'Use rest.documentation.openapi to fetch the portal''s own machine-readable list of every available REST API v3 method — the source of truth the SDK relies on instead of a hardcoded allowlist. Especially useful for AI agents and codegen.'
-audited: 2026-09-05
+audited: 2026-09-07
 navigation:
   title: Discovering v3 methods
 links:
@@ -31,9 +31,18 @@ to the server and lets it decide. When you need to know *what's actually there*
 — which methods, which fields — you ask the portal itself with this call.
 
 ::note
-The document reflects the **modules installed on this portal** and the **scopes
-your token holds**, so two portals can return different method sets. Always treat
-it as portal-specific, not a global catalogue.
+The document lists the methods **this portal has**. Its contents follow the
+installed modules and the build, so two portals answer differently — always treat
+it as portal-specific, not a global catalogue. Measured: an on-premise build
+published **147** methods across 8 modules, a cloud portal **245**, and a second
+cloud portal **220** with a different set again, including changed request fields
+for methods present on both.
+
+**Listing is not permission.** A method present in the document still fails with
+`BITRIX_REST_V3_EXCEPTION_INSUFFICIENTSCOPEEXCEPTION` (403) when the token lacks
+the scope — so the document cannot be used as a permission check. It is not
+filtered by your rights either: widening a webhook from 10 scopes to 15 did not
+change it at all. To find the scope a method needs, use `rest.scope.list`.
 ::
 
 ::warning
@@ -106,7 +115,9 @@ portal **without guessing**:
 - **Typing / codegen** — feed the schema into a generator to produce typed
   wrappers, or narrow `$b24.actions.v3.call.make<T>()` with the right `T`.
 - **Portal-aware** — because the answer is per-portal, an agent can adapt to the
-  modules and scopes actually present rather than to a generic assumption.
+  modules actually installed rather than to a generic assumption. Scopes are a
+  separate question the document does not answer; pair it with `rest.scope.list`
+  when the agent also needs to know what the token may call.
 
 ::tip
 The document is large (often **100 KB+**) and **response-only** — it does not


### PR DESCRIPTION
Docs only.

## What the page said

`docs/content/docs/2.working-with-the-rest-api/7.discovering-v3-methods.md`:

> The document reflects the **modules installed on this portal** and the **scopes your token
> holds**, so two portals can return different method sets.

The second half is wrong, and it is the half a reader would act on: it invites treating the
document as a permission list.

## What is true

**Scopes do not filter it.** Widening a webhook from 10 scopes to 15 — adding `call`, `mail`,
`humanresources`, `timeman`, `humanresources.hcmlink` — did not change the document at all.
Same 147 methods across 8 modules before and after; re-counted today against the same
on-premise build (`SM_VERSION 26.700.0`) before writing the number into the page.

**Listing is not permission the other way either.** A method present in the document still
answers `BITRIX_REST_V3_EXCEPTION_INSUFFICIENTSCOPEEXCEPTION` (403) when the token lacks the
scope. So the document answers "what exists here", never "what may I call" — and a reader who
assumes otherwise ships code that discovers the 403 in production. The note now points at
`rest.scope.list` as where the portal publishes its scopes.

The full wire code is spelled out rather than abbreviated, since a caller matches on that
string.

**The spread is larger than "can differ".** Measured on three portals: an on-premise build
published **147** methods, a cloud portal **245**, and a second cloud portal **220** — with a
different set again, including changed request fields for methods present on both. That is not
a footnote; it is the argument for the design this page already describes (no hardcoded method
list, ask the portal), which is why it now sits on the page.

## Second occurrence

The same assumption appeared once more, in the AI-agents list — "adapt to the modules **and
scopes** actually present". Corrected there too, with the pointer to `rest.scope.list` so an
agent that does need permissions knows where to look.

Found by reading the page end to end rather than only the paragraph being changed. Worth
saying because the `audited:` stamp is a claim about the whole page, and the previous stamp on
this page had been moved without that.

## Review correction

The first version of this branch said `rest.scope.list` answers "the scope a method needs".
Toned down to what is established.

The method does exist on v3 — it is in the committed cloud snapshot,
`scripts/data/openapi-cloud-2026-09-05.json`, and worth checking because the v2 documentation
has no such name (there the method is `scope`, and per-method availability is `method.get`).
But nothing here establishes that it maps a method to its scope rather than simply listing the
portal's scopes, and this page belongs to a series being corrected for exactly that kind of
unmeasured claim. It now says scopes are published there, which is what the evidence supports.

## Checks

- `pnpm docs:lint-pages:strict` — 0 errors, 0 warnings
- `docs-link-check`, `docs-typecheck` (172 blocks), `check-v3-method-refs` — clean
- `main` merged in; CI green on the merge

## Scope

One of several separate changes from a v3 audit against live portals — #456, #469, #489, #493
and #494 are the others. Independent of all of them: different file, different claim, different
evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr