### PR TITLE
feat(core): send a v3 batch as a bare array, with the OAuth token in a Bearer header

### DIFF
--- a/.github/contributing/transports-and-results.md
+++ b/.github/contributing/transports-and-results.md
@@ -1,6 +1,6 @@
 # Transports and Results
 
-<sub>Last reviewed: 2026-09-04.</sub>
+<sub>Last reviewed: 2026-09-08.</sub>
 
 > **Agent-facing mirror:** the same area, viewed from the angle of agents writing usage code, lives in [`skills/b24jssdk-rest/SKILL.md`](../../skills/b24jssdk-rest/SKILL.md), [`skills/b24jssdk-filtering/SKILL.md`](../../skills/b24jssdk-filtering/SKILL.md), and [`skills/b24jssdk-core/SKILL.md`](../../skills/b24jssdk-core/SKILL.md). Keep this guide and those skills in sync when the underlying API changes.
 
@@ -269,9 +269,38 @@ Every transport / limiter holds a `LoggerInterface` (the public abstraction from
   Context key is `removalVersion`, not `removeInVersion`. The canonical pattern lives in [packages/jssdk/src/core/abstract-b24.ts](../../packages/jssdk/src/core/abstract-b24.ts) (look for `@deprecated` + `@removed` + `forcedLog`).
 - New warnings or errors must be mentioned in the relevant docs page so users can recognise them.
 
-### Credential redaction (since v1.1.2)
+### A `restApi:v3` batch is the only bare array on the wire
+
+`HttpV3.batch` passes the commands as `params`, and `_makeAxiosRequest` sends
+them unwrapped instead of through `_prepareParams`, because on v3 the commands
+**are** the body. The portal reads every top-level entry as a command and
+requires `method` and `query` on each, so an `auth` entry fails the whole batch
+with `INVALIDSELECTEXCEPTION` before anything runs — and so does a command that
+carries no `query`, which is why `ParseRow` defaults it to `{}`.
+
+The credential therefore moves, per transport: a webhook keeps it in the URL, a
+non-hook transport **outside a CORS-enforcing runtime** sends
+`Authorization: Bearer`. A browser — and a Web Worker, which is a browser
+context without a `window` — keeps the old object body and stays broken: the
+portal's preflight allows only `origin, content-type, accept`, so asking for the
+header would replace a diagnosable 400 with an opaque network error. Do not
+"fix" that branch without a portal-side change.
+
+The branch is gated on the version **and** the method, not on the body being an
+array: `TypeCallParams` has an index signature, so a positional `restApi:v2`
+call such as `task.commentitem.getlist` also arrives here with an array, and
+none of the reasoning above applies to it.
+
+## Credential redaction (since v1.1.2)
 
 The transport layer redacts credentials from log lines and error messages before they reach the logger. The redaction module is [packages/jssdk/src/core/http/redact.ts](../../packages/jssdk/src/core/http/redact.ts); the full list of redacted keys is the **static** `SENSITIVE_PARAM_KEYS` array in that file (matched **case-insensitively**, and the scrub also masks `key=value` pairs embedded in string values, e.g. a batch `cmd[i]`, and the secret segment of a Bitrix24 webhook URL, which is neither a key nor a pair). The list is not extended automatically: when you introduce a new credential-bearing parameter on any code path, add its key to `SENSITIVE_PARAM_KEYS` in `redact.ts` in the same PR, or it will appear unredacted in logs and in `AjaxError`.
+
+**A header is not a parameter, and nothing redacts it.** The SDK sets
+`Authorization: Bearer` itself on a v3 batch outside a CORS-enforcing runtime.
+`redactSensitiveParams` walks `params` and never sees a header; the local
+`no-credential-in-logger` rule does not know the word either. So the invariant
+"no header reaches logger context" is held by a test, not by a guard — if you
+add a log line near the transport, do not put the request config in it.
 
 Rules for code under `packages/jssdk/src/`:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@
 
 ### Bug Fixes
 
+* **A `restApi:v3` batch no longer sends the OAuth token as one of its commands.**
+  On v3 the commands are the request body — a bare array, no envelope — but
+  `_prepareParams` spread that array into `{ '0': …, '1': … }` and then added the
+  access token as one more top-level entry. The portal reads every top-level entry
+  of a batch body as a command and requires `method` and `query` on each, so that
+  entry rejected the whole batch with `INVALIDSELECTEXCEPTION` before a single
+  command ran. Every `B24OAuth` v3 batch failed this way; a webhook survived only
+  because PHP cannot tell a list from a map with sequential integer keys.
+
+    The commands now go out as the array the portal's grammar describes, and
+    outside a CORS-enforcing runtime the token travels in `Authorization: Bearer`,
+    merged into the per-request config so a caller's own `Idempotency-Key` survives
+    beside it. A second victim of the same rule is fixed with it: a command written
+    without `params` went out with no `query` key at all, which is refused under the
+    same code and takes the rest of the batch with it.
+
+    **Worth knowing:** the request body changes shape for **every** transport,
+    `B24Hook` included, even though a webhook batch already worked. A proxy, a WAF
+    rule, a recorded HTTP fixture or a request-log assertion sees `[{…},{…}]` where
+    it saw `{"0":{…},"1":{…}}`, plus a header it has not seen before. The
+    `post/send` log line changes the same way. `AjaxError.requestInfo.params` does
+    not — it has always carried the commands array.
+
+    **A frame app still cannot batch on v3.** The portal's CORS preflight allows
+    only `origin, content-type, accept`, so a browser cannot send the header; that
+    path is left exactly as it was, failing visibly with a 400 rather than opaquely
+    at the preflight. That half needs a portal-side change.
+
+    Verified against two portals, and end to end rather than by hand-built request:
+    `b24.actions.v3.batch.make` on a real `B24OAuth` succeeds, while the same build
+    driven as a browser reproduces the old rejection verbatim.
+
 * **A list or tail walk whose cursor stops advancing now fails instead of running for ever.** When the server does not apply the page condition, the same full page keeps arriving and nothing in the loops noticed: the `restApi:v3` driver stops on a page *shorter* than the largest it has seen, the `restApi:v2` loops stop on `length < 50`, and a repeated full page is neither. The streaming helpers yielded the same rows for ever; the eager ones grew an array until the process died.
 
     Measured on `restApi:v2` `tasks.task.list` with `idKey: 'id'` and no `cursorIdKey`: three pages, 150 rows, 50 unique, the cursor reading 3 every time — the response spells the id lowercase while the filter accepts it uppercase, so `>id` matches nothing and is dropped. The two halves of that mistake fail in opposite ways: leave `idKey` at its default `'ID'` and the cursor cannot be read, so the walk warns and stops after 50 rows; set `idKey: 'id'` alone and the read works while the request condition is ignored. Only the second one used to hang.

--- a/docs/content/docs/1.getting-started/3.migration/3.within-2x.md
+++ b/docs/content/docs/1.getting-started/3.migration/3.within-2x.md
@@ -2,7 +2,7 @@
 title: Behaviour changes inside 2.x
 description: 'Changes within the 2.x line that need a change on your side even though no API was removed — what breaks, how to tell, and what to do.'
 navigation.title: Inside 2.x
-audited: 2026-09-07
+audited: 2026-09-08
 links:
   - label: CHANGELOG
     iconName: GitHubIcon
@@ -21,6 +21,73 @@ to be ignored now means something.
 Everything here ships inside the `2.x` line, so `pnpm up @bitrix24/b24jssdk`
 picks it up without a major-version step. That is exactly why it is worth
 reading — nothing about the upgrade signals that behaviour moved.
+::
+
+## 2.3.0 — a `restApi:v3` batch sends a different request body
+
+**What changed.** A v3 batch now puts its commands on the wire as a bare
+top-level JSON array. It used to send an object with numeric keys, and on an
+OAuth transport it added the access token as one more top-level entry:
+
+```
+before (B24Hook)   {"0":{…},"1":{…}}
+before (B24OAuth)  {"0":{…},"1":{…},"auth":"<access token>"}
+now                [{…},{…}]
+```
+
+On a server, `B24OAuth` sends the token in an `Authorization: Bearer` header
+instead of in the body.
+
+**What it fixes.** A v3 batch from `B24OAuth` never worked at all. The portal
+reads every top-level entry of a batch body as a command and requires `method`
+and `query` on each, so the `auth` entry failed the whole batch with
+`BITRIX_REST_V3_EXCEPTION_INVALIDSELECTEXCEPTION` before a single command ran. A
+webhook survived only because PHP cannot tell a JSON list from a map with
+sequential integer keys.
+
+The same rule had a second victim, invisible until the first was fixed: a command
+written without `params` — `{ method: 'rest.scope.list' }`, or the tuple
+`['rest.scope.list']` — went out with no `query` key, because `JSON.stringify`
+drops an `undefined` value. That is refused under the same code, and one such
+entry takes the whole batch down with it. Commands now always carry a `query`,
+empty if there is nothing to put in it.
+
+**Who is affected.**
+
+- **`B24OAuth` on a server** — `actions.v3.batch.make` and
+  `actions.v3.batchByChunk.make` start working. Any workaround that looped
+  single calls can go.
+- **Anything that inspects the request** — a reverse proxy, a WAF body rule, an
+  egress gateway, a recorded HTTP fixture (nock / msw / VCR), or a test that
+  asserts on the request body. The body is an array now for **every** transport,
+  `B24Hook` included, even though a webhook batch already worked; and a
+  server-side OAuth batch carries a header it did not carry before. Re-record
+  fixtures, and let `Authorization` through the proxy.
+- **Log readers** — the `post/send` line logs the body it sends, so a v3 batch
+  now writes `[{…},{…}]` where it wrote
+  `{"0":{…},…,"auth":"***REDACTED***"}`.
+
+**What to do.** Nothing in your own code. The action arguments and the return
+shape are unchanged, and so is `AjaxError.requestInfo.params` — that has always
+carried the commands array, not the formatted body.
+
+One thing to know if you sit behind a redirect. The header-carrying request is
+sent with `maxRedirects: 0`, so it will not follow a 301/302 while holding the
+token — `follow-redirects` keeps `Authorization` across a same-host or subdomain
+hop, and the credential in the body was never exposed that way because a
+redirect drops the body. Only that one request is constrained; see
+[configuring the axios instance](/docs/working-with-the-rest-api/core-http/#configuring-the-axios-instance)
+if you need to change it.
+
+::caution
+**A frame app still cannot batch on `restApi:v3`.** The portal answers the CORS
+preflight with `Access-Control-Allow-Headers: origin, content-type, accept`, so
+a browser cannot send `Authorization` — such a request would never leave. The
+SDK therefore leaves the browser path exactly as it was: the token stays in the
+body and the portal rejects the batch, visibly with a 400 rather than opaquely
+at the preflight. Until the portal allows the header, run v3 batches from your
+own backend (`B24OAuth` / `B24Hook`), use `actions.v2.batch.make`, or send the
+commands as individual `actions.v3.call.make` calls.
 ::
 
 ## 2.3.0 — a stalled pagination cursor now throws

--- a/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/3.batch-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3. Allows executing up to 50 commands in a single API call.'
 category: 'actions'
-audited: 2026-09-06
+audited: 2026-09-08
 restApiVersion: 'rest-api-ver3'
 navigation.title: Batch
 links:
@@ -139,6 +139,26 @@ type guards on the caller side (see [issue #23](https://github.com/bitrix24/b24j
 * If a successful v3 response is missing a result entry for a command (which
   indicates a malformed API response), the SDK throws
   `JSSDK_INTERACTION_BATCH_STRATEGY_V3_EMPTY_COMMAND_RESPONSE`{lang="ts-type"}.
+
+::caution
+**A `restApi:v3` batch does not work from the browser.** The commands *are* the
+request body on v3 — a bare JSON array — so there is no room in it for an OAuth
+credential: the portal reads every top-level entry as a command and requires
+`method` and `query` on each. On a server the SDK moves the token into an
+`Authorization: Bearer` header instead. A browser cannot follow: the portal
+answers the CORS preflight with `Access-Control-Allow-Headers: origin,
+content-type, accept`, so a request asking for that header would never leave at
+all. `B24Frame` therefore keeps the old body and the portal rejects it with
+`BITRIX_REST_V3_EXCEPTION_INVALIDSELECTEXCEPTION` — chosen deliberately, because
+a visible 400 is worth more than an opaque network error after the retry budget
+burns.
+
+Until the portal allows the header: use
+[`BatchV2.make()`](/docs/working-with-the-rest-api/batch-rest-api-ver2/) in the
+frame, send the commands as individual
+[`CallV3.make()`](/docs/working-with-the-rest-api/call-rest-api-ver3/) calls, or
+run the batch on your own backend with `B24OAuth` or `B24Hook`.
+::
 
 ## Passing data between commands (`$ref` / `$refArray`)
 
@@ -291,4 +311,4 @@ try {
 * **For working with lists**: Use [`CallList`](/docs/working-with-the-rest-api/call-list-rest-api-ver3/) for retrieving large volumes of data.
 * **For step-by-step processing**: Use [`FetchList`](/docs/working-with-the-rest-api/fetch-list-rest-api-ver3/) for processing data as it arrives.
 * **To run more commands (more than 50)**: Use [`BatchByChunk`](/docs/working-with-the-rest-api/batch-by-chunk-rest-api-ver3/), which automatically splits commands into chunks of 50.
-* **On the client-side (browser):** Use the built-in [`B24Frame`](/docs/getting-started/installation/vue/#init) object.
+* **On the client-side (browser):** `B24Frame` **cannot run a `restApi:v3` batch** — see [Limitations](#limitations). Use `actions.v2.batch.make` in the frame, or move the batch to your own backend (`B24OAuth` / `B24Hook`).

--- a/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/4.batch-by-chunk-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: BatchByChunkV3.make
 description: 'Method for executing batch requests to Bitrix24 REST API version 3 with automatic chunking for any number of commands. Automatically splits large command sets into batches of 50 and executes them sequentially. Use only arrays of tuples or arrays of objects.'
 category: 'actions'
-audited: 2026-09-06
+audited: 2026-09-08
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: BatchByChunk
@@ -228,4 +228,10 @@ try {
 * **For working with lists**: Use [`CallList`](/docs/working-with-the-rest-api/call-list-rest-api-ver3/) for retrieving large volumes of data.
 * **For step-by-step processing**: Use [`FetchList`](/docs/working-with-the-rest-api/fetch-list-rest-api-ver3/) for processing data as it arrives.
 * **For batch operations:** Use [`Batch`](/docs/working-with-the-rest-api/batch-rest-api-ver3/) to execute up to 50 commands in a single request.
-* **On the client-side (browser):** Use the built-in [`B24Frame`](/docs/getting-started/installation/vue/#init) object.
+* **On the client-side (browser):** `B24Frame` **cannot run a `restApi:v3` batch** — see [Limitations](#limitations). Use `actions.v2.batch.make` in the frame, or move the batch to your own backend (`B24OAuth` / `B24Hook`).
+
+::caution
+The browser limitation is inherited from `Batch` — a `restApi:v3` batch cannot
+carry an OAuth credential the portal's CORS policy allows a browser to send. See
+[BatchV3 Limitations](/docs/working-with-the-rest-api/batch-rest-api-ver3/#limitations).
+::

--- a/docs/content/docs/2.working-with-the-rest-api/70.core-http.md
+++ b/docs/content/docs/2.working-with-the-rest-api/70.core-http.md
@@ -76,7 +76,49 @@ Low-level batch call. Three input shapes are accepted:
 For most use cases call [`actions.v2.batch.make`](/docs/working-with-the-rest-api/batch-rest-api-ver2/) / [`actions.v3.batch.make`](/docs/working-with-the-rest-api/batch-rest-api-ver3/), which handle the response unwrapping and `returnAjaxResult`.
 
 ::note
-`BatchRequestEnvelopeV2`{lang="ts-type"} is exported alongside these types but is not something you construct. It names what the `restApi:v2` transport puts on the wire for a batch — `{ halt, cmd }` — which reaches `call` through a parameter typed `TypeCallParams`{lang="ts-type"} and type-checks only because of that type's permissive index signature. It is documented here so an exported symbol is not a mystery, not because a caller needs it. `restApi:v3` has no envelope: the commands are the request body.
+`BatchRequestEnvelopeV2`{lang="ts-type"} is exported alongside these types but is not something you construct. It names what the `restApi:v2` transport puts on the wire for a batch — `{ halt, cmd }` — which reaches `call` through a parameter typed `TypeCallParams`{lang="ts-type"} and type-checks only because of that type's permissive index signature. It is documented here so an exported symbol is not a mystery, not because a caller needs it. `restApi:v3` has no envelope: the commands **are** the request body, a bare top-level JSON array. That leaves nowhere in the body for a credential — the portal reads every top-level entry as a command — so a webhook keeps its secret in the URL and a server-side `B24OAuth` sends the token in an `Authorization: Bearer` header. A browser cannot send that header (the portal's CORS preflight does not allow it), which is why a v3 batch does not work from `B24Frame`; see [BatchV3 Limitations](/docs/working-with-the-rest-api/batch-rest-api-ver3/#limitations).
+::
+
+## Configuring the axios instance
+
+`ajaxClient` is the live axios instance the transport uses. There is no
+constructor option for axios settings today, so this is where you change them —
+after the client exists, through `defaults`:
+
+```ts
+import { ApiVersion } from '@bitrix24/b24jssdk'
+
+const http = $b24.getHttpClient(ApiVersion.v3)
+
+http.ajaxClient.defaults.timeout = 120_000
+http.ajaxClient.defaults.proxy = { host: '10.0.0.1', port: 3128 }
+```
+
+Two things the SDK sets and you should know before overriding them:
+
+- **`timeout: 30_000`** and a matching `timeoutErrorMessage`. Raise it for a
+  long-running report method rather than raising the retry count.
+- **`User-Agent`**, on server-side runtimes only — browsers forbid the header.
+
+::warning
+**`maxRedirects` is forced to `0` on one request, and only one.** A
+`restApi:v3` batch on a non-hook transport outside a browser carries the access
+token in an `Authorization: Bearer` header, and a redirect would take it along:
+`follow-redirects` strips the header when the host changes, but keeps it for the
+same host and for a **subdomain**. A credential in the body was safe here by
+accident — a 301/302 turns POST into GET and drops the body, so the token that
+used to sit in `auth` never travelled.
+
+The constraint is per-request, not on the instance: nothing else the SDK sends
+is affected, and a redirect elsewhere in your traffic still works. A portal that
+does redirect this one request gets a legible 301 instead of a silent hop with a
+bearer token attached.
+
+If you know your redirect target and want the hop anyway, a transport subclass
+can return `maxRedirects` from `_prepareRequestConfig` and it wins — the value
+is a default, applied before the per-request config is spread over it, not a
+lock. Setting `ajaxClient.defaults.maxRedirects` does **not** reach it: a
+per-request config outranks the instance default in axios.
 ::
 
 ## Limiter Configuration

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -2,7 +2,7 @@
 title: Logging & Credential Redaction
 description: 'What the SDK redacts automatically before any request information enters the logger or an AjaxError, what it does not redact, and how to wire a custom logger via setLogger(...) without re-introducing credential leaks.'
 category: 'logging'
-audited: 2026-09-07
+audited: 2026-09-08
 navigation.title: Logging & Redaction
 links:
   - label: redact.ts (canonical key list)
@@ -256,12 +256,15 @@ The SDK knows about the canonical keys listed above, matched
   `toJSON()` includes. `validation` is included in `toJSON()` as well, but only
   when the portal sent one, so an error without it serializes exactly as it did
   before the field existed.
-- **Custom request headers you set on the underlying axios client** —
-  e.g. an `Authorization: Bearer <token>` header configured via your
-  own axios interceptor. The redactor only touches `params`, not
-  headers, and headers are not part of the SDK's standard logger
-  context anyway — but they do live on `AxiosError.config.headers`, see
-  the next bullet.
+- **Request headers — including one the SDK sets itself.** On a server-side
+  `B24OAuth`, a `restApi:v3` batch carries the access token in an
+  `Authorization: Bearer <token>` header rather than in the body, and a header
+  you configure through your own axios options sits beside it. The redactor
+  touches `params` only; it never sees a header, and neither does the local
+  `no-credential-in-logger` ESLint rule. Nothing in the SDK puts a header into
+  logger context — that is a deliberate invariant with a test behind it, not an
+  accident — but the token does live on `AxiosError.config.headers`, so see the
+  next bullet before logging an error object.
 
 ::warning
 **Don't log `err.originalError` directly.** `AjaxError` (via its

--- a/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
+++ b/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
@@ -126,7 +126,7 @@ These codes do not throw — they appear in `result.getErrors()` (and `getErrorM
 | `BITRIX_REST_V3_EXCEPTION_ACCESSDENIEDEXCEPTION` | REST v3: permission denied. |
 | `BITRIX_REST_V3_EXCEPTION_INVALIDJSONEXCEPTION` | REST v3: payload is not valid JSON. |
 | `BITRIX_REST_V3_EXCEPTION_INVALIDFILTEREXCEPTION` | REST v3: malformed filter. |
-| `BITRIX_REST_V3_EXCEPTION_INVALIDSELECTEXCEPTION` | REST v3: malformed `select`. |
+| `BITRIX_REST_V3_EXCEPTION_INVALIDSELECTEXCEPTION` | REST v3: malformed `select` — **or** a batch whose body is not a list of commands. The portal reads every top-level entry of a batch body as a command and needs `method` and `query` on each, so one entry missing `query`, or an extra entry that is not a command at all, fails the whole batch under this code. A v3 batch from a browser still hits it: see [BatchV3 Limitations](/docs/working-with-the-rest-api/batch-rest-api-ver3/#limitations). |
 | `BITRIX_REST_V3_EXCEPTION_ENTITYNOTFOUNDEXCEPTION` | REST v3: entity does not exist. |
 | `BITRIX_REST_V3_EXCEPTION_METHODNOTFOUNDEXCEPTION` | REST v3: method does not exist. |
 | `BITRIX_REST_V3_EXCEPTION_UNKNOWNDTOPROPERTYEXCEPTION` | REST v3: unknown DTO property. |

--- a/eslint-rules/no-credential-in-logger.js
+++ b/eslint-rules/no-credential-in-logger.js
@@ -26,6 +26,13 @@
  *     (`logger.debug(`GET ${url}`)`) and `'…' + url` concatenation. Now that the
  *     rule spans the whole SDK, reviewers in pull / frame / hook / oauth (not just
  *     the HTTP layer) must reject these by hand: log the bare method name.
+ *   • Vocabulary: `headers` / `Authorization` were added when the SDK first put a
+ *     credential in a header rather than in the body — the `restApi:v3` batch on an
+ *     OAuth transport sends `Authorization: Bearer …` (#455/#491). `redactSensitiveParams()`
+ *     walks *params*; it has no concept of headers, so for this one class the lint
+ *     layer is the only net there is, not defence in depth. `header` is matched
+ *     singular too, and `Authorization` explicitly, because the leak-shaped
+ *     access is `config.headers.Authorization` rather than a word ending in `s`.
  *   • Vocabulary: `auth` and `sessid` are deliberately NOT in CREDENTIAL_KEY —
  *     `auth` is too common a word (false-positive risk: `authorized`, `author`,
  *     `authManager`, `isAdminAuth`…) and both are already masked at runtime by
@@ -44,12 +51,12 @@ const LOGGER_METHODS = new Set([
 // Credential-shaped property KEY (selector 4) / member-access property (selector 2).
 // `[Tt]oken(?!s\b)` carves out a plural `tokens` (a real retry counter).
 // `auth` / `sessid` are intentionally excluded — see the fileoverview vocabulary note.
-const CREDENTIAL_KEY = /[Uu]rl|[Pp]assword|[Ss]ecret|[Tt]oken(?!s\b)/
+const CREDENTIAL_KEY = /[Uu]rl|[Pp]assword|[Ss]ecret|[Tt]oken(?!s\b)|[Hh]eaders?|[Aa]uthorization/
 // Credential-shaped VALUE identifier (selector 1) — the key set plus
 // `methodFormatted` (the #40 regression: the formatted URL bound to an identifier).
-const CREDENTIAL_VALUE = /[Uu]rl|methodFormatted|[Pp]assword|[Ss]ecret|[Tt]oken(?!s\b)/
+const CREDENTIAL_VALUE = /[Uu]rl|methodFormatted|[Pp]assword|[Ss]ecret|[Tt]oken(?!s\b)|[Hh]eaders?|[Aa]uthorization/
 // Axios objects whose spread drags the full request URL into the context.
-const AXIOS_SPREAD = /^(?:config|request|response)$/
+const AXIOS_SPREAD = /^(?:config|request|response|headers)$/
 
 function isLoggerCall(node) {
   return (

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -693,8 +693,11 @@ export abstract class AbstractHttp implements TypeHttp {
     // An absent or empty token would go out as the literal `Bearer undefined`.
     // `_prepareParams` used to drop it silently — `JSON.stringify` omits an
     // `undefined` value — so require a real one rather than put a nonsense
-    // credential on the wire.
-    const hasAccessToken = 'string' === typeof authData.access_token && authData.access_token.length > 0
+    // credential on the wire. Trimmed, because a token of blanks is not a token
+    // and `Bearer   ` is a malformed header rather than a failed authentication:
+    // it earns a portal error that names neither the header nor the token, where
+    // the body fallback at least fails the way this transport already fails.
+    const hasAccessToken = 'string' === typeof authData.access_token && authData.access_token.trim().length > 0
     const canSendAuthHeader = isBareArrayBody && !isHook && hasAccessToken && !isCorsEnforcedRuntime()
     const sendBareArray = isBareArrayBody && (isHook || canSendAuthHeader)
 

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -128,6 +128,33 @@ export type TypePrepareParams = TypeCallParams & {
 }
 
 /**
+ * Does this runtime apply CORS to an outbound request?
+ *
+ * Deliberately not `isServerSide()`, which asks a different question and answers
+ * this one wrongly. That predicate is `getEnvironment() !== BROWSE`, and
+ * `getEnvironment()` recognises a browser by `window.document` — which a Web
+ * Worker, a Shared Worker and a Service Worker do not have. All three would be
+ * read as "server", while CORS applies in them exactly as it does on the main
+ * thread. `WorkerGlobalScope` is the global the HTML specification gives all
+ * three, and nothing else.
+ *
+ * Being wrong in the two directions costs very different things, which is why
+ * the test is shaped to fail towards "yes". A false **yes** in a runtime without
+ * CORS — an edge worker that happens to define the global — leaves that runtime
+ * exactly where it is today: the credential stays in the body and the portal
+ * answers a visible 400. A false **no** in a browser context asks for a header
+ * the portal's preflight does not allow, and the request never leaves at all,
+ * which is an opaque network error after the retry budget burns.
+ */
+function isCorsEnforcedRuntime(): boolean {
+  if (getEnvironment() === Environment.BROWSE) {
+    return true
+  }
+
+  return 'undefined' !== typeof (globalThis as { WorkerGlobalScope?: unknown }).WorkerGlobalScope
+}
+
+/**
  * Abstract base class for all Bitrix24 REST API HTTP transports.
  *
  * Provides shared infrastructure used by {@link HttpV2} and {@link HttpV3}: Axios instance
@@ -612,10 +639,113 @@ export abstract class AbstractHttp implements TypeHttp {
   protected async _makeAxiosRequest<T>(requestId: string, method: string, params: TypeCallParams, authData: AuthData, requestConfig?: AxiosRequestConfig): Promise<AjaxResponse<T>> {
     const methodFormatted = this._prepareMethod(requestId, method, this.getBaseUrl())
 
-    const paramsFormatted = this._prepareParams(authData, params)
+    // A `restApi:v3` batch sends its commands AS the request body — a bare
+    // top-level array, no envelope (see `HttpV3.batch`). Everything else sends an
+    // object, and `_prepareParams` is built for that: it spreads `params` into a
+    // fresh object, which turns an array into `{ '0': …, '1': … }`, and then adds
+    // the OAuth `auth` as one more top-level entry.
+    //
+    // The portal iterates every top-level entry of a batch body and demands
+    // `method` and `query` on each, so that extra entry rejects the whole batch
+    // with `INVALIDSELECTEXCEPTION` before a command runs. Three cases follow,
+    // decided by where the credential can live:
+    //
+    // 1. A webhook authenticates through the URL, so the body can be the array
+    //    the portal's grammar describes. Measured live: accepted.
+    // 2. A non-hook transport on a server sends the token in the standard
+    //    header, which the portal accepts and prefers over any body or query
+    //    parameter (`rest/lib/oauth/auth.php`, `getAuthKey()`).
+    // 3. A non-hook transport **where CORS applies** cannot use that header: the
+    //    portal answers the preflight with `Access-Control-Allow-Headers: origin,
+    //    content-type, accept` (`CRestUtil::sendHeaders()`), so asking for
+    //    `Authorization` fails the preflight and the request never leaves. That
+    //    would trade a diagnosable 400 for an opaque network error, so such a
+    //    caller keeps the body it had — and the 400 it had with it.
+    //
+    // Case 3 asks about CORS rather than about "is this a server", because those
+    // are not the same question and `isServerSide()` answers the wrong one: it is
+    // `getEnvironment() !== BROWSE`, and `getEnvironment()` recognises a browser
+    // by `window.document`, which a Web Worker does not have. A worker would be
+    // read as a server and get the header — in a context where CORS applies
+    // exactly as it does on the main thread. See {@link isCorsEnforcedRuntime}.
+    //
+    // The webhook case is not conditioned on any of this: it adds no header, so
+    // there is no preflight to fail. Its body does change shape everywhere,
+    // browser included — from `{ '0': … }` to the array — which the portal reads
+    // identically, because PHP's `json_decode` cannot tell a list from a map with
+    // sequential integer keys.
+    //
+    // Gated on the version AND the method, not merely on the body being an array.
+    // `TypeCallParams` carries an index signature, so an array satisfies it, and
+    // `getHttpClient(ApiVersion.v2).call('task.commentitem.getlist', [taskId, …])`
+    // — the documented positional shape for the legacy `task.*` family — reaches
+    // this function with an array on `restApi:v2`. Everything reasoned about
+    // above is about a v3 batch; on v2 the body would change shape AND the
+    // credential would move to a header whose acceptance nothing here has
+    // established. The comment describes one case, so the code tests for that
+    // one case.
+    const isV3Batch = ApiVersion.v3 === this._version && 'batch' === method
+    const isBareArrayBody = isV3Batch && Array.isArray(params)
+    // Load-bearing, not defensive: `AuthHookManager` returns the webhook secret
+    // as `access_token` (`hook/auth.ts`), so dropping this term would put a
+    // portal-wide secret into an `Authorization` header.
+    const isHook = 'hook' === authData.refresh_token
+    // An absent or empty token would go out as the literal `Bearer undefined`.
+    // `_prepareParams` used to drop it silently — `JSON.stringify` omits an
+    // `undefined` value — so require a real one rather than put a nonsense
+    // credential on the wire.
+    const hasAccessToken = 'string' === typeof authData.access_token && authData.access_token.length > 0
+    const canSendAuthHeader = isBareArrayBody && !isHook && hasAccessToken && !isCorsEnforcedRuntime()
+    const sendBareArray = isBareArrayBody && (isHook || canSendAuthHeader)
+
+    const paramsFormatted = sendBareArray
+      ? params as unknown as TypePrepareParams
+      : this._prepareParams(authData, params)
+
+    // Merged into whatever the caller's own config already carries — today the
+    // `Idempotency-Key` header — rather than replacing it.
+    //
+    // `maxRedirects: 0` comes with the header and only with it. A credential in
+    // the body was safe across a redirect by accident: a 301/302 turns POST into
+    // GET and drops the body, so the old `auth` never travelled. A header does —
+    // `follow-redirects` strips `Authorization` when the host changes, but keeps
+    // it for the same host and for a **subdomain**, so a portal answering
+    // `301 Location: https://cdn.<portal>/…` would hand the token to whatever
+    // serves that name.
+    //
+    // Set here rather than on the axios instance because the instance carries
+    // every request the SDK makes, and a redirect somewhere in that traffic may
+    // be load-bearing for someone. This branch is different: it is reached only
+    // by a v3 batch on a non-hook transport, which fails on every portal today —
+    // there is no working behaviour here to preserve. A deployment that does
+    // redirect gets a legible 301 through `validateStatus` instead of a silent
+    // hop with a bearer token attached.
+    //
+    // Before the spread, not after, so it is a default rather than a lock: a
+    // transport that overrides `_prepareRequestConfig` — `HttpV2` already does —
+    // can hand back a `maxRedirects` and win. `TypeCallOptions` carries no such
+    // field today, so there is no way for an ordinary caller to reopen it, which
+    // is the right way round for a credential.
+    const effectiveConfig: AxiosRequestConfig | undefined = canSendAuthHeader
+      ? {
+          maxRedirects: 0,
+          ...requestConfig,
+          headers: {
+            ...requestConfig?.headers,
+            Authorization: `Bearer ${authData.access_token}`
+          }
+        }
+      : requestConfig
+
     // `paramsFormatted` carries the OAuth `auth` (access_token) for non-hook flows;
     // log a redacted copy so the secret never enters logger context, while axios
     // still receives the original below. (#39)
+    // The `Authorization` header is deliberately NOT logged, and nothing here may
+    // start logging it: `redactSensitiveParams` walks `params` and never touches
+    // headers, so a token put into logger context would arrive in the clear —
+    // the #39 defect, in a channel neither the redactor nor the local
+    // `no-credential-in-logger` rule can see. Pinned by a test rather than left
+    // to this comment.
     const paramsFormattedForLog = JSON.stringify(redactSensitiveParams(paramsFormatted), null, 0)
 
     this.getLogger().info(
@@ -626,7 +756,7 @@ export abstract class AbstractHttp implements TypeHttp {
       }
     ).catch(() => {})
 
-    const response = await this._clientAxios.post<SuccessPayload<T>>(methodFormatted, paramsFormatted, requestConfig)
+    const response = await this._clientAxios.post<SuccessPayload<T>>(methodFormatted, paramsFormatted, effectiveConfig)
 
     // Redact the log-bound copy only; callers still receive the untouched
     // `response.data` below. First-party success bodies don't embed credentials

--- a/packages/jssdk/src/core/interaction/batch/parse-row.ts
+++ b/packages/jssdk/src/core/interaction/batch/parse-row.ts
@@ -23,7 +23,14 @@ export class ParseRow {
       if (typeof row === 'object' && 'method' in row && typeof row.method === 'string') {
         return {
           method: row.method,
-          query: row.params,
+          // `?? {}` because `params` is optional on both command shapes while
+          // `query` is not optional to the portal: it reads every top-level entry
+          // of a v3 batch body as a command and rejects the WHOLE batch with
+          // `INVALIDSELECTEXCEPTION` when one of them has no `query` — measured,
+          // and one bad entry is enough to take the others down with it.
+          // `JSON.stringify` drops an `undefined` value, so leaving it undefined
+          // is not "sending an empty query", it is sending no key at all.
+          query: row.params ?? {},
           as: row.as ?? options.asDefaultValue,
           parallel: row.parallel ?? options.parallelDefaultValue
         }
@@ -32,7 +39,8 @@ export class ParseRow {
       if (Array.isArray(row) && row.length > 0 && typeof row[0] === 'string') {
         return {
           method: row[0],
-          query: row[1],
+          // Same reason as above — `['rest.scope.list']` is a valid tuple.
+          query: row[1] ?? {},
           as: options.asDefaultValue,
           parallel: options.parallelDefaultValue
         }

--- a/skills/b24jssdk-rest/SKILL.md
+++ b/skills/b24jssdk-rest/SKILL.md
@@ -40,6 +40,8 @@ There is no manual-pagination path any more — the list helpers page for you. T
 - **`callList` / `fetchList`** *emulate* a cursor on top of the `list` action by injecting a `[idField, '>', n]` condition into `filter` and forcing `order`. Works for any `*.list` method (v2 and v3).
 - **`callTail` / `fetchTail`** (v3 only) drive the server's *native* `tail` action via its `cursor: { field, value, order, limit }` parameter. Use these when a method publishes a `*.tail` endpoint. The cursor field must **not** appear in `filter` (the server rejects it), is auto-added to `select`, and `order: 'DESC'` requires an explicit `initialValue`.
 
+Every example uses `$b24` of type `TypeB24`, but **`actions.v3.batch` is the one place the three entry points are not interchangeable** — it does not work under `B24Frame`. See the anti-patterns at the end.
+
 `filter` on v3 is the array form or a `FilterV3` logic group — never the v2 object dialect (`{ '>id': 100 }`), which the portal rejects on every v3 method. All four walkers refuse it client-side. `callList` / `fetchList` additionally require an **array**, because they extend it with the page condition, and throw `JSSDK_ACTION_V3_LIST_FILTER_NOT_ARRAY`; `callTail` / `fetchTail` forward `filter` untouched, so a bare group is fine there and only the v2 dialect throws — `JSSDK_ACTION_V3_TAIL_FILTER_INVALID`.
 
 All of them — and the two `restApi:v2` list walkers — also throw `JSSDK_ACTION_CURSOR_STALLED` when a full page comes back and the cursor read from it equals the one just sent. That means the page condition was dropped, so the walk can never end; it rejects rather than collecting the same page for ever.
@@ -517,6 +519,7 @@ const hasNotes = Boolean(doc?.paths?.['/note.collection.list'])
 - ❌ Reaching for `batch.make` on a bulk load that must not duplicate — a batch carries no key. Loop single calls and accept the throughput cost, or accept the duplicates.
 - ❌ `idempotencyKey: crypto.randomUUID()` written at the call site for a job that can be retried by a *different* process — the restart mints a new key and writes a duplicate anyway. Derive the key from the operation (`deal-${orderId}-create`), or persist a minted one with the job before calling.
 - ❌ Reusing one `idempotencyKey` for two different writes — the portal answers HTTP 422 `…IDEMPOTENCYKEYREUSEDEXCEPTION` rather than deduplicating. Prefix by operation: `deal-42-create` vs `deal-42-close`.
+- ❌ `actions.v3.batch.make` / `batchByChunk.make` from a browser (`B24Frame`) — on v3 the commands are the request body, so the credential has to travel in an `Authorization` header, and the portal's CORS preflight allows only `origin, content-type, accept`. The SDK therefore leaves the token in the body there and the portal rejects the batch with `BITRIX_REST_V3_EXCEPTION_INVALIDSELECTEXCEPTION`. Use `actions.v2.batch.make` in the frame, or run the v3 batch on a backend.
 - ❌ `B24Hook` in a browser bundle — leaks the webhook secret. Use `B24Frame` there.
 
 ## Cross-reference

--- a/test/integration/core/no-credential-in-logger.unit.spec.ts
+++ b/test/integration/core/no-credential-in-logger.unit.spec.ts
@@ -58,7 +58,18 @@ describe('no-credential-in-logger rule (#226, guards #39/#40)', () => {
     ['key+member { token: cfg.value }', 'logger.error(\'m\', { token: cfg.value })'],
     // capital-`Token` KEY — locks the `[Tt]` arm of CREDENTIAL_KEY; a future
     // edit that narrowed it to `t` (lowercase only) would silently let this slip.
-    ['key+identifier { Token: someVar } (capital T)', 'logger.debug(\'m\', { Token: someVar })']
+    ['key+identifier { Token: someVar } (capital T)', 'logger.debug(\'m\', { Token: someVar })'],
+    // Headers, added when the SDK first put a credential in one rather than in
+    // the body — the `restApi:v3` batch on an OAuth transport sends
+    // `Authorization: Bearer …` (#455/#491). `redactSensitiveParams()` walks
+    // params and has no concept of headers, so unlike every case above this is
+    // not defence in depth: the lint layer is the only net there is.
+    ['key+member { headers: config.headers }', 'logger.debug(\'m\', { headers: config.headers })'],
+    ['member-access { auth: config.headers.Authorization }', 'logger.info(\'m\', { auth: config.headers.Authorization })'],
+    ['spread { ...config.headers }', 'logger.error(\'m\', { ...config.headers })'],
+    ['bare identifier { headers }', 'logger.debug(\'m\', { headers })'],
+    // Singular, because the leak-shaped access is a single header by name.
+    ['key+identifier { header: authHeader }', 'logger.debug(\'m\', { header: authHeader })']
   ]
 
   const shouldStaySilent: Array<[string, string]> = [

--- a/test/integration/core/v3-batch-body-shape.unit.spec.ts
+++ b/test/integration/core/v3-batch-body-shape.unit.spec.ts
@@ -411,6 +411,92 @@ describe('the body of a v3 batch', () => {
     expect(JSON.stringify(config ?? {})).not.toContain('Bearer undefined')
   })
 
+  it('@apiV3 a v3 call that is not a batch keeps its body, even with array params', async () => {
+    // The `'batch' === method` half of the gate, on its own. Removing it while
+    // keeping the version check passed the whole suite: the v2 case below is
+    // caught by the version half instead, and nothing else fed an array to a
+    // non-batch method. `TypeCallParams` carries an index signature, so an array
+    // is accepted here without a cast on the type level, and the legacy `task.*`
+    // family is documented with positional arguments — so this is a shape a
+    // caller can actually produce, not a contrivance.
+    b24 = oauthClient()
+    const http = b24.getHttpClient(ApiVersion.v3)
+    const post = vi.spyOn(http.ajaxClient, 'post').mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as never,
+      data: { result: [], time: BATCH_OK.data.time }
+    } as never)
+
+    await http.call('task.commentitem.getlist', [1, {}, {}] as never, 'v3-not-a-batch')
+
+    const [, body, config] = post.mock.calls[0]!
+    // Reshaping this body would change the wire format of a method nobody
+    // measured, and moving the credential would put it where nothing
+    // established the portal reads it.
+    expect(Array.isArray(body)).toBe(false)
+    expect((body as { auth?: string }).auth).toBe('ACCESS_TOKEN_PLACEHOLDER')
+    expect((config as { headers?: Record<string, string> })?.headers?.Authorization).toBeUndefined()
+  })
+
+  it('@apiV3 a restApi:v2 method named batch is still not a v3 batch', async () => {
+    // The version half of the gate, on its own. `HttpV2.batch()` wraps its
+    // commands in a `{ halt, cmd }` envelope, so an array never reaches this
+    // point through the public path — which is exactly why dropping the version
+    // check passed every test. Calling `call('batch', …)` directly is the one
+    // way to ask whether the version term does any work, and it has to: v2
+    // authenticates through `auth` in the body, and nothing here established
+    // that a v2 endpoint reads an `Authorization` header at all.
+    b24 = oauthClient()
+    const http = b24.getHttpClient(ApiVersion.v2)
+    const post = vi.spyOn(http.ajaxClient, 'post').mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as never,
+      data: { result: [], time: BATCH_OK.data.time }
+    } as never)
+
+    await http.call('batch', COMMANDS as never, 'v2-batch-by-name')
+
+    const [, body, config] = post.mock.calls[0]!
+    expect(Array.isArray(body)).toBe(false)
+    expect((body as { auth?: string }).auth).toBe('ACCESS_TOKEN_PLACEHOLDER')
+    expect((config as { headers?: Record<string, string> })?.headers?.Authorization).toBeUndefined()
+  })
+
+  it('@apiV3 a token of blanks is not a token', async () => {
+    // `length > 0` accepted it and produced `Bearer   ` — a malformed header,
+    // not a failed authentication. The portal would answer something that names
+    // neither the header nor the token, where the body fallback at least fails
+    // the way this transport already fails.
+    b24 = new B24OAuth(
+      {
+        accessToken: '   ',
+        refreshToken: 'REFRESH_TOKEN_PLACEHOLDER',
+        expires: 2_000_000_000,
+        expiresIn: 3600,
+        domain: 'example.bitrix24.com',
+        memberId: 'member',
+        clientEndpoint: 'https://example.bitrix24.com/rest/',
+        serverEndpoint: 'https://oauth.bitrix.info/rest/',
+        status: 'L'
+      } as never,
+      { clientId: 'local.test', clientSecret: 'secret' } as never
+    )
+    const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue(BATCH_OK as never)
+
+    await b24.actions.v3.batch.make({ calls: COMMANDS })
+
+    const [, body, config] = post.mock.calls[0]!
+    expect((config as { headers?: Record<string, string> })?.headers?.Authorization).toBeUndefined()
+    // And it falls back to the old body rather than sending a headerless array
+    // the portal would reject for a different reason entirely.
+    expect(Array.isArray(body)).toBe(false)
+  })
+
   it('@apiV3 a restApi:v2 array body is untouched — the branch is v3-batch only', async () => {
     // `TypeCallParams` has an index signature, so an array satisfies it, and the
     // legacy `task.*` family is documented with positional arguments. Without the

--- a/test/integration/core/v3-batch-body-shape.unit.spec.ts
+++ b/test/integration/core/v3-batch-body-shape.unit.spec.ts
@@ -1,0 +1,437 @@
+/**
+ * Regression: a `restApi:v3` batch must go out as a **bare JSON array**, and the
+ * OAuth credential must not be one of its elements.
+ *
+ * On v3 the commands are the request body — there is no `{ halt, cmd }` envelope
+ * to wrap them in. `_prepareParams` used to spread that array into an object
+ * (`{ '0': …, '1': … }`) and, for any non-hook transport, add the access token as
+ * one more top-level entry:
+ *
+ *   B24Hook   {"0":{…},"1":{…}}
+ *   B24OAuth  {"0":{…},"1":{…},"auth":"<token>"}
+ *
+ * The portal iterates every top-level entry of a batch body and requires
+ * `method` and `query` on each, so the `auth` entry rejected the whole batch with
+ * `INVALIDSELECTEXCEPTION` before a single command ran — measured in the portal's
+ * own `BatchRequest` constructor. The numeric-key form survived only because PHP
+ * cannot tell a list from a map with sequential integer keys.
+ *
+ * On a server the token now travels in `Authorization: Bearer`, which the portal
+ * accepts and prefers over any body or query parameter. The header is merged into
+ * the per-request config rather than replacing it, so a caller's own
+ * `Idempotency-Key` survives alongside it.
+ *
+ * In a **browser** it cannot: the portal answers the CORS preflight with
+ * `Access-Control-Allow-Headers: origin, content-type, accept`
+ * (`CRestUtil::sendHeaders()`), so asking for `Authorization` would fail the
+ * preflight and the request would never leave. A browser transport is therefore
+ * left on the old path — still rejected by the portal, but rejected visibly with
+ * a 400 rather than blocked by the browser with an opaque network error.
+ *
+ * `*.unit.spec.ts` — no real Bitrix24 portal required (axios is mocked).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { ApiVersion, B24Hook } from '../../../packages/jssdk/src/'
+import { B24OAuth } from '../../../packages/jssdk/src/oauth/b24'
+
+const COMMANDS = [
+  { method: 'main.eventlog.list', params: { select: ['id'] } },
+  { method: 'rest.scope.list', params: {} }
+]
+
+/**
+ * Two successful command results, so the batch parser has something to fold.
+ * On v3 `result` is the per-command array directly — no `result_error` /
+ * `result_time` split as in v2.
+ */
+const BATCH_OK = {
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: {} as never,
+  data: {
+    result: [{ items: [] }, { items: [] }],
+    time: {
+      start: 0, finish: 0, duration: 0, processing: 0,
+      date_start: '1970-01-01T00:00:00+00:00',
+      date_finish: '1970-01-01T00:00:00+00:00'
+    }
+  }
+}
+
+function oauthClient(): B24OAuth {
+  return new B24OAuth(
+    {
+      accessToken: 'ACCESS_TOKEN_PLACEHOLDER',
+      refreshToken: 'REFRESH_TOKEN_PLACEHOLDER',
+      expires: 2_000_000_000,
+      expiresIn: 3600,
+      domain: 'example.bitrix24.com',
+      memberId: 'member',
+      clientEndpoint: 'https://example.bitrix24.com/rest/',
+      serverEndpoint: 'https://oauth.bitrix.info/rest/',
+      status: 'L'
+    } as never,
+    { clientId: 'local.test', clientSecret: 'secret' } as never
+  )
+}
+
+describe('the body of a v3 batch', () => {
+  let b24: B24Hook | B24OAuth | null = null
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    b24?.destroy()
+    b24 = null
+  })
+
+  it('@apiV3 is a bare array on a hook, with no credential in it', async () => {
+    b24 = B24Hook.fromWebhookUrl('https://example.bitrix24.com/rest/1/SECRET')
+    const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue(BATCH_OK as never)
+
+    await b24.actions.v3.batch.make({ calls: COMMANDS })
+
+    const [, body, config] = post.mock.calls[0]!
+    expect(Array.isArray(body)).toBe(true)
+    expect(body).toHaveLength(2)
+    expect(body).not.toHaveProperty('auth')
+    // A webhook authenticates through the URL; nothing to put in a header.
+    expect(config).toBeUndefined()
+  })
+
+  it('@apiV3 keeps the OAuth token out of the array and sends it as a header', async () => {
+    b24 = oauthClient()
+    const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue(BATCH_OK as never)
+
+    await b24.actions.v3.batch.make({ calls: COMMANDS })
+
+    const [, body, config] = post.mock.calls[0]!
+    expect(Array.isArray(body)).toBe(true)
+    expect(body).toHaveLength(2)
+    // The regression itself: `auth` used to be a third element the portal read as
+    // a command with no `method`.
+    expect(body).not.toHaveProperty('auth')
+    expect(JSON.stringify(body)).not.toContain('ACCESS_TOKEN_PLACEHOLDER')
+
+    expect((config as { headers: Record<string, string> })?.headers?.Authorization)
+      .toBe('Bearer ACCESS_TOKEN_PLACEHOLDER')
+  })
+
+  it('@apiV3 every element still carries method and query', async () => {
+    b24 = oauthClient()
+    const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue(BATCH_OK as never)
+
+    await b24.actions.v3.batch.make({ calls: COMMANDS })
+
+    const body = post.mock.calls[0]![1] as Array<Record<string, unknown>>
+    // Without this the loop runs zero assertions on an empty array and passes.
+    expect(body).toHaveLength(2)
+    // What the portal's BatchRequest constructor demands of every top-level entry.
+    for (const item of body) {
+      expect(item).toHaveProperty('method')
+      expect(item).toHaveProperty('query')
+    }
+  })
+
+  it('@apiV3 a single call is untouched — object body, token still inside it', async () => {
+    b24 = oauthClient()
+    const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue({
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+        data: { result: { items: [] }, time: BATCH_OK.data.time }
+      } as never)
+
+    await b24.actions.v3.call.make({ method: 'main.eventlog.list', params: { select: ['id'] } })
+
+    const [, body, config] = post.mock.calls[0]!
+    expect(Array.isArray(body)).toBe(false)
+    // Deliberately unchanged: the body form works for every non-batch call, and
+    // moving it too would be an untestable change to how every OAuth request
+    // authenticates.
+    expect((body as { auth?: string }).auth).toBe('ACCESS_TOKEN_PLACEHOLDER')
+    expect(config).toBeUndefined()
+  })
+
+  it('@apiV3 a browser transport keeps the old body and sends no header', async () => {
+    // The portal's CORS allow-list has no `authorization`, so the header would
+    // fail the preflight and the request would never be sent. Simulated by making
+    // `getEnvironment()` report a browser — this project runs spec files serially
+    // for exactly this kind of global mutation.
+    const originalWindow = (globalThis as { window?: unknown }).window
+    ;(globalThis as { window?: unknown }).window = { document: {} }
+
+    try {
+      b24 = oauthClient()
+      const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+        .mockResolvedValue(BATCH_OK as never)
+
+      await b24.actions.v3.batch.make({ calls: COMMANDS })
+
+      const [, body, config] = post.mock.calls[0]!
+      expect(config).toBeUndefined()
+      // Unchanged from before this fix: the numeric-key spread with `auth` in it.
+      // The portal still rejects it; that is issue #455's remaining half and it
+      // needs the portal's CORS policy to move, not the SDK.
+      expect(Array.isArray(body)).toBe(false)
+      expect((body as { auth?: string }).auth).toBe('ACCESS_TOKEN_PLACEHOLDER')
+      // And the commands are still in it. Without these, replacing the whole
+      // body with `{ auth }` — a browser batch carrying no commands at all —
+      // passed every other assertion in this file.
+      const asMap = body as Record<string, { method?: string }>
+      expect(asMap['0']?.method).toBe('main.eventlog.list')
+      expect(asMap['1']?.method).toBe('rest.scope.list')
+    } finally {
+      if (typeof originalWindow === 'undefined') {
+        delete (globalThis as { window?: unknown }).window
+      } else {
+        ;(globalThis as { window?: unknown }).window = originalWindow
+      }
+    }
+  })
+
+  it('@apiV3 a call with an idempotency key keeps its header untouched', async () => {
+    // The `else` branch: an object body never gets an Authorization header, and
+    // the caller's own config reaches axios unchanged.
+    b24 = oauthClient()
+    const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue({
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+        data: { result: { items: [] }, time: BATCH_OK.data.time }
+      } as never)
+
+    await b24.actions.v3.call.make({
+      method: 'main.eventlog.list',
+      params: { select: ['id'] },
+      idempotencyKey: 'key-42'
+    })
+
+    const headers = (post.mock.calls[0]![2] as { headers?: Record<string, string> })?.headers
+    expect(headers?.['Idempotency-Key']).toBe('key-42')
+    expect(headers?.Authorization).toBeUndefined()
+  })
+
+  it('@apiV3 merges Authorization into the caller config rather than replacing it', async () => {
+    // The merge branch, exercised as a merge. `actions.v3.batch.make` passes no
+    // options, so through it `requestConfig` is always `undefined` and
+    // `{ ...undefined, headers: { ...undefined, Authorization } }` is
+    // indistinguishable from an assignment — which is why the test above, on a
+    // non-batch call, proved nothing about it. `call()` is public and reaches the
+    // same branch carrying a real config.
+    b24 = oauthClient()
+    const http = b24.getHttpClient(ApiVersion.v3)
+    const post = vi.spyOn(http.ajaxClient, 'post').mockResolvedValue(BATCH_OK as never)
+
+    await http.call('batch', COMMANDS as never, 'probe-request-id', { idempotencyKey: 'key-42' })
+
+    const headers = (post.mock.calls[0]![2] as { headers?: Record<string, string> })?.headers
+    expect(headers?.Authorization).toBe('Bearer ACCESS_TOKEN_PLACEHOLDER')
+    // Dropped by a merge written as an assignment: a retried batch write would
+    // lose its deduplication guarantee silently.
+    expect(headers?.['Idempotency-Key']).toBe('key-42')
+  })
+
+  it('@apiV3 refuses to follow a redirect while carrying the token', async () => {
+    // A credential in the body was safe across a redirect by accident: a 301/302
+    // turns POST into GET and drops the body, so the old `auth` never travelled.
+    // A header does travel — `follow-redirects` keeps `Authorization` for the
+    // same host and for a subdomain — so the hop is refused instead.
+    //
+    // Only on this branch: it is the one the header rides on, and it fails on
+    // every portal today, so there is no working redirect behaviour to lose.
+    b24 = oauthClient()
+    const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue(BATCH_OK as never)
+
+    await b24.actions.v3.batch.make({ calls: COMMANDS })
+
+    const config = post.mock.calls[0]![2] as { maxRedirects?: number, headers?: Record<string, string> }
+    expect(config?.maxRedirects).toBe(0)
+    expect(config?.headers?.Authorization).toBe('Bearer ACCESS_TOKEN_PLACEHOLDER')
+  })
+
+  it('@apiV3 leaves redirects alone on every other request', async () => {
+    // The instance carries every request the SDK makes, and a redirect somewhere
+    // in that traffic may be load-bearing for someone. Nothing outside the
+    // header-carrying branch is constrained.
+    b24 = oauthClient()
+    const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue({
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+        data: { result: { items: [] }, time: BATCH_OK.data.time }
+      } as never)
+
+    await b24.actions.v3.call.make({ method: 'main.eventlog.list', params: { select: ['id'] } })
+
+    const config = post.mock.calls[0]![2] as { maxRedirects?: number } | undefined
+    expect(config?.maxRedirects).toBeUndefined()
+  })
+
+  it('@apiV3 keeps the token out of the logger, which no redactor covers', async () => {
+    // `redactSensitiveParams` walks `params`; nothing walks headers, and the local
+    // `no-credential-in-logger` rule does not know the word `Authorization`
+    // either. So the only thing between this token and every wired log sink is
+    // that nobody logs the config — pinned here rather than left to a comment.
+    b24 = oauthClient()
+    vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post').mockResolvedValue(BATCH_OK as never)
+
+    const logged: string[] = []
+    vi.spyOn(b24.getHttpClient(ApiVersion.v3).getLogger(), 'info')
+      .mockImplementation(async (_message: string, context?: Record<string, unknown>) => {
+        logged.push(JSON.stringify(context ?? {}))
+      })
+
+    await b24.actions.v3.batch.make({ calls: COMMANDS })
+
+    expect(logged.length).toBeGreaterThan(0)
+    for (const entry of logged) {
+      expect(entry).not.toContain('ACCESS_TOKEN_PLACEHOLDER')
+    }
+  })
+
+  it('@apiV3 a command with no params still carries an empty query', async () => {
+    // `{ method: 'rest.scope.list' }` with no `params` is a valid command shape,
+    // and `query: row.params` left it `undefined` — which `JSON.stringify` drops,
+    // so the entry went out with no `query` key at all. Measured against a portal:
+    // refused with the same `INVALIDSELECTEXCEPTION`, and one such entry takes the
+    // whole batch down with it. Invisible until now, because the `auth` entry
+    // failed the batch first.
+    b24 = B24Hook.fromWebhookUrl('https://example.bitrix24.com/rest/1/SECRET')
+    const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue(BATCH_OK as never)
+
+    await b24.actions.v3.batch.make({
+      calls: [{ method: 'rest.scope.list' }, ['main.eventlog.list']] as never
+    })
+
+    const body = post.mock.calls[0]![1] as Array<Record<string, unknown>>
+    expect(body).toHaveLength(2)
+    for (const item of body) {
+      expect(item['query']).toEqual({})
+    }
+    // The shape that reaches the wire, not merely the object before serialisation.
+    expect(JSON.parse(JSON.stringify(body))[0]).toHaveProperty('query')
+  })
+
+  it('@apiV3 a webhook in a browser sends the array too — no header to preflight', async () => {
+    // The one case the "browser is left exactly as it was" wording did not cover.
+    // A hook adds no header, so there is no preflight to fail and the body may be
+    // the array everywhere. Behaviour is unchanged — the portal reads both forms
+    // identically — but the bytes are not, which is what a proxy or a recorded
+    // fixture sees.
+    const originalWindow = (globalThis as { window?: unknown }).window
+    ;(globalThis as { window?: unknown }).window = { document: {} }
+
+    try {
+      b24 = B24Hook.fromWebhookUrl('https://example.bitrix24.com/rest/1/SECRET')
+      const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+        .mockResolvedValue(BATCH_OK as never)
+
+      await b24.actions.v3.batch.make({ calls: COMMANDS })
+
+      const [, body, config] = post.mock.calls[0]!
+      expect(Array.isArray(body)).toBe(true)
+      expect(config).toBeUndefined()
+    } finally {
+      if (typeof originalWindow === 'undefined') {
+        delete (globalThis as { window?: unknown }).window
+      } else {
+        ;(globalThis as { window?: unknown }).window = originalWindow
+      }
+    }
+  })
+
+  it('@apiV3 a browser Web Worker is a browser, not a server', async () => {
+    // `getEnvironment()` recognises a browser by `window.document`, which a worker
+    // does not have — so `isServerSide()` called it a server, and the header would
+    // have been added where CORS forbids it, producing exactly the opaque failure
+    // this change exists to avoid. The guard asks about CORS instead.
+    const scope = globalThis as { WorkerGlobalScope?: unknown }
+    const original = scope.WorkerGlobalScope
+    scope.WorkerGlobalScope = function WorkerGlobalScope() {}
+
+    try {
+      b24 = oauthClient()
+      const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+        .mockResolvedValue(BATCH_OK as never)
+
+      await b24.actions.v3.batch.make({ calls: COMMANDS })
+
+      const [, body, config] = post.mock.calls[0]!
+      expect(config).toBeUndefined()
+      expect(Array.isArray(body)).toBe(false)
+      expect((body as { auth?: string }).auth).toBe('ACCESS_TOKEN_PLACEHOLDER')
+    } finally {
+      if (typeof original === 'undefined') {
+        delete scope.WorkerGlobalScope
+      } else {
+        scope.WorkerGlobalScope = original
+      }
+    }
+  })
+
+  it('@apiV3 an empty access token is not sent as `Bearer undefined`', async () => {
+    // `_prepareParams` dropped an absent token silently, because `JSON.stringify`
+    // omits an `undefined` value. Interpolating it into a header does not — it
+    // spells it out. Fall back to the old body rather than put a nonsense
+    // credential on the wire.
+    b24 = new B24OAuth(
+      {
+        accessToken: '',
+        refreshToken: 'REFRESH_TOKEN_PLACEHOLDER',
+        expires: 2_000_000_000,
+        expiresIn: 3600,
+        domain: 'example.bitrix24.com',
+        memberId: 'member',
+        clientEndpoint: 'https://example.bitrix24.com/rest/',
+        serverEndpoint: 'https://oauth.bitrix.info/rest/',
+        status: 'L'
+      } as never,
+      { clientId: 'local.test', clientSecret: 'secret' } as never
+    )
+    const post = vi.spyOn(b24.getHttpClient(ApiVersion.v3).ajaxClient, 'post')
+      .mockResolvedValue(BATCH_OK as never)
+
+    await b24.actions.v3.batch.make({ calls: COMMANDS })
+
+    const [, body, config] = post.mock.calls[0]!
+    expect(config).toBeUndefined()
+    expect(Array.isArray(body)).toBe(false)
+    expect(JSON.stringify(config ?? {})).not.toContain('Bearer undefined')
+  })
+
+  it('@apiV3 a restApi:v2 array body is untouched — the branch is v3-batch only', async () => {
+    // `TypeCallParams` has an index signature, so an array satisfies it, and the
+    // legacy `task.*` family is documented with positional arguments. Without the
+    // version gate such a call would have had its body reshaped and its credential
+    // moved into a header on a protocol where nothing here established that the
+    // header is read at all.
+    b24 = oauthClient()
+    const http = b24.getHttpClient(ApiVersion.v2)
+    const post = vi.spyOn(http.ajaxClient, 'post').mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as never,
+      data: { result: [], time: BATCH_OK.data.time }
+    } as never)
+
+    await http.call('task.commentitem.getlist', [1, {}, {}] as never, 'v2-positional')
+
+    const [, body, config] = post.mock.calls[0]!
+    expect(Array.isArray(body)).toBe(false)
+    expect((body as { auth?: string }).auth).toBe('ACCESS_TOKEN_PLACEHOLDER')
+    expect((config as { headers?: Record<string, string> })?.headers?.Authorization).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fixes #455.

## What breaks today

A `restApi:v3` batch sends its commands **as** the request body: a bare top-level array, no
envelope (`HttpV3.batch`). Everything else sends an object, and `_prepareParams` is built for
that — it spreads `params` into a fresh object, which turns an array into `{ '0': …, '1': … }`,
and then adds the OAuth token as one more top-level entry:

```
B24Hook   {"0":{…},"1":{…}}
B24OAuth  {"0":{…},"1":{…},"auth":"<access token>"}
```

The portal iterates **every** top-level entry of a batch body and demands `method` and `query`
on each — `BatchRequest::__construct`, reached with the raw decoded body from
`CRestApiServer::processBatchServerExecution()`. The `auth` entry has neither, so the whole
batch is rejected with `INVALIDSELECTEXCEPTION` before a single command runs.

The numeric-key form survives on a webhook only because PHP's `json_decode(..., true)` cannot
tell a list from a map with sequential integer keys.

## What changes

| Transport | Body | Credential |
|---|---|---|
| webhook | bare array | in the URL, as always |
| non-hook, no CORS | bare array | `Authorization: Bearer` |
| non-hook, CORS applies | unchanged | unchanged |

The header goes through the per-request config #475 introduced, **merged** into it rather than
replacing it, so a caller's own `Idempotency-Key` survives beside it.

### A second failure the first one was hiding

Fixing the `auth` entry exposed the same portal rule biting somewhere else. `query: row.params`
left `query` **undefined** for a command written without params — `{ method: 'rest.scope.list' }`,
or the tuple `['rest.scope.list']`, both valid shapes — and `JSON.stringify` drops an undefined
value, so the entry went out with no `query` key at all.

Measured against a portal:

```
[{"method":"rest.scope.list","parallel":true}]                → 400 INVALIDSELECTEXCEPTION
[{"method":"rest.scope.list","query":{},"parallel":true}]     → 200
[{…no query…},{…with query…}]                                 → 400, the whole batch
```

One such entry takes the others down with it. Nobody could see this before, because the `auth`
entry failed the batch first. `ParseRow` now defaults `query` to `{}` on both command shapes.

### Four narrowings, each of which was a defect first

**Gated on the version and the method, not on the body being an array.** `TypeCallParams`
carries an index signature, so an array satisfies it, and
`getHttpClient(ApiVersion.v2).call('task.commentitem.getlist', [taskId, …])` — the documented
positional shape for the legacy `task.*` family — reaches `_makeAxiosRequest` with an array on
**v2**. Everything reasoned about here is about a v3 batch; on v2 the body would have changed
shape *and* the credential would have moved to a header whose acceptance nothing here
establishes.

**The CORS question is asked directly.** It was `this.isServerSide()`, which is
`getEnvironment() !== BROWSE`, and `getEnvironment()` recognises a browser by `window.document`
— which a Web Worker does not have. A worker was therefore read as a server and would have got
the header, in a context where CORS applies exactly as it does on the main thread: the
preflight fails and the request never leaves. That is precisely the opaque failure this change
exists to avoid, reintroduced by the guard meant to prevent it. The predicate now tests for a
CORS-enforcing runtime, and is deliberately shaped to fail towards "yes" — a false yes leaves a
runtime where it already is, a false no breaks it invisibly.

**An empty access token no longer becomes `Bearer undefined`.** `_prepareParams` dropped an
absent token silently, because `JSON.stringify` omits an undefined value; interpolating it into
a header spells it out instead. Such a transport falls back to the old body.

**`maxRedirects: 0`, on this request and no other.** A credential in the body was safe across a
redirect by accident: a 301/302 turns POST into GET and drops the body, so the token that used
to sit in `auth` never travelled. A header does travel — `follow-redirects` strips
`Authorization` when the host changes but keeps it for the same host and for a **subdomain**, so
a portal answering `301 Location: https://cdn.<portal>/…` would hand the token to whatever
serves that name.

Set on the request rather than on the axios instance, deliberately: the instance carries every
request the SDK makes, and a redirect somewhere in that traffic may be load-bearing for someone.
This branch is different — it is reached only by a v3 batch on a non-hook transport, which fails
on every portal today, so there is no working behaviour to preserve. A deployment that does
redirect gets a legible 301 rather than a silent hop with a bearer attached.

Applied **before** the per-request config is spread, so it is a default rather than a lock: a
transport overriding `_prepareRequestConfig` — `HttpV2` already does — can hand back its own
`maxRedirects` and win. `TypeCallOptions` carries no such field, so an ordinary caller cannot
reopen it by accident, which is the right way round for a credential. Documented on the
`CoreHttp` page along with the rest of the axios instance, since the SDK exposes no constructor
option for axios settings and `ajaxClient.defaults` is the only lever — and `defaults` does
**not** reach this one, because a per-request value outranks an instance default in axios
(measured, not assumed).

## Verified end to end, not by hand-built request

Earlier revisions of this PR verified the *portal* with `curl`. This one runs the SDK.

A local application on a self-hosted stand (official `bitrix-tools/env-docker`,
`SM_VERSION 26.150.0`), `auth_type: oauth` — not a webhook. One run, one build, one portal, one
token, both branches at once, because a browser in this same build takes the **old** path:

```
SERVER  (bare array + Bearer):      isSuccess=true   errors=[]
BROWSER (old body, auth inside):    isSuccess=false
        errors=["… `Each request item must have a "method" and "query" attribute`"]
```

So the before and the after are the shipped code, and the browser half is confirmed to be still
broken — which is what this PR claims rather than something it hides. A separate comment below
covers the OAuth token's provenance on that stand, and what that method does and does not
exercise.

## Why the browser is left alone

The portal answers the CORS preflight with

```
Access-Control-Allow-Headers: origin, content-type, accept
```

`authorization` is not on that list — `CRestUtil::sendHeaders()`, re-confirmed on a fourth
portal against the batch endpoint itself. A browser transport already preflights (axios sends
`Content-Type: application/json`); asking for `Authorization` on top would fail the preflight
and the request would never leave, trading a diagnosable 400 for an opaque network error after
the retry budget burns.

**A frame app therefore still cannot batch on v3.** It is not, however, shut out: measured on
the same portal, a bare array body with the credential in the **query string** is accepted, and
a query parameter costs nothing on a preflight the request is already making. That is
deliberately not what this PR does — the SDK puts a credential in a body today and never in a
URL, and URLs reach access logs, `Referer` headers and proxies in a way bodies do not, which is
what #39 and `redactSensitiveParams` are about. The trade belongs to a reviewer, not to this
change. Raised with Bitrix24 separately and noted in #455.

## Tests

`test/integration/core/v3-batch-body-shape.unit.spec.ts`, project `jsSdk:unit`, axios mocked.
Fifteen cases.

Seven of them exist because a mutation sweep found the first six insufficient, so the sweep is
worth reporting rather than the count. Twenty-one mutations were applied to the source and the
suite re-run against each; these survived, and now do not:

| survivor | what it was | killed by |
|---|---|---|
| header merge written as an assignment | a batch with a caller `Idempotency-Key` loses it silently | a test that reaches the merge branch through the public `call()`, which is the only way to get a real `requestConfig` there — the old "idempotency" test ran a **non-batch** call and exercised the `else` branch, so its comment described something it did not do |
| browser body loses every command | a browser batch shipping `{auth}` and zero commands passed everything | asserting the commands are in the browser body, not only its shape |
| the token logged alongside the params | the #39 defect, in a channel neither the redactor nor `no-credential-in-logger` can see | a test that spies the logger and asserts the token appears in no context |
| `'hook' === …` → `==` | equivalent — `refresh_token` is a string | no action |

Plus the four new guards: dropping the v3/method gate, the CORS check, the empty-token check,
or either `query` default all redden the suite now. Every failure is an `AssertionError` naming
the expectation — no timeouts, no crashes.

## Checks

- `pnpm vitest run --project jsSdk:unit` — 740 passed, 0 failed (64 files)
- `pnpm lint` — clean
- `pnpm lint:md` — 0 issues
- `pnpm docs:lint` — 0 errors, **15** warnings; `main` has **16**, so this change clears one and
  adds none
- `docs:typecheck-blocks` (172), `skills:typecheck-blocks` (86), `package-jssdk:typecheck`,
  `test:typecheck` — clean

`pnpm typecheck` in full still reports four errors in `skills/b24jssdk-recipes/examples/` about
`idempotencyKey` / `isIdempotentReplay`; they reproduce on a clean `main` and predate #475. CI's
own `typecheck` job is green, because it installs that package fresh.

## Documentation

A wire-format change with a new header owes more than a source comment, and the first revision
of this PR shipped none. Added:

- **`3.migration/3.within-2x.md`** — a `2.3.0` section. The body shape changes for **every**
  transport, `B24Hook` included, so anyone with a proxy, a WAF body rule, a recorded fixture or
  a request-log assertion sees a different request from a patch upgrade with no code change on
  their side. `AjaxError.requestInfo.params` is explicitly called out as *unchanged* — it has
  always carried the commands array, and claiming otherwise in a migration guide would be a
  false note in the one place readers trust.
- **`3.batch-rest-api-ver3.md`** — the CORS limitation, in `Limitations`, where a reader who
  hit it will look; and the "use `B24Frame` in the browser" recommendation, which pointed
  straight at the broken case, corrected. Mirrored on `4.batch-by-chunk-rest-api-ver3.md`.
- **`96.error-codes.md`** — `INVALIDSELECTEXCEPTION` widened: it is also what a malformed batch
  body answers, which is the code a frame developer actually receives.
- **`78.logging.md`** — the bullet saying `Authorization` comes only from "your own axios
  interceptor" and that "headers are not part of the SDK's standard logger context anyway".
  The SDK sets that header itself now.
- **`70.core-http.md`** — what a v3 batch actually puts on the wire and where the credential
  goes, plus a new section on configuring the axios instance. That section exists because this
  PR needed somewhere to explain `maxRedirects`, and finding that place showed there was none:
  the SDK exposes no constructor option for axios settings at all, and `ajaxClient.defaults`
  was documented only as "reuse it for non-REST calls". It now documents the two settings the
  SDK itself makes (`timeout`, `User-Agent`) as well.
- **`.github/contributing/transports-and-results.md`** — the batch-semantics paragraph and a
  note that a header is not a parameter and nothing redacts it, per that guide's own rule about
  new credential-bearing paths. `Last reviewed` bumped.
- **`skills/b24jssdk-rest`** — an anti-pattern bullet, so an agent does not generate the
  browser case in the first place.
- **`CHANGELOG.md`** — a hand-written paragraph, following what #481, #488 and #489 did.

## Left for a reviewer to decide

**An instance-level `Authorization`** set through the constructor's axios options is now
overridden on this one request shape and kept on every other. Narrow, but it is an asymmetry
this change introduces.

## Note on the redactor

An earlier draft also taught `redactSensitiveParams` to walk a top-level array, because making
the body an array would otherwise have put every command in the `post/send` log unmasked. #488
landed that independently, so this PR no longer carries it — but the two are coupled, and this
change should not ship onto a tree without it.