### PR TITLE
fix(actions): stop a list or tail walk when the cursor stops advancing

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: CallListV2.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 2.'
 category: 'actions'
-audited: 2026-09-05
+audited: 2026-09-07
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: CallList
@@ -19,6 +19,9 @@ links:
   - label: Skill — b24jssdk-rest
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-rest/SKILL.md
+  - label: Cursor-stall guard
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/actions/_cursor-stalled.ts
 ---
 
 ::caution{title="⚠️ REST API DEPRECATION"}
@@ -123,6 +126,7 @@ The `customKeyForResult`{lang="ts-type"} parameter allows you to specify the key
 
 - **Page size**: Fixed limitation of Bitrix24 REST API version 2 — `50` records per request.
 - **Sorting is fixed**: The method always sorts by `cursorIdKey` (which defaults to `idKey`) ascending, because cursor pagination relies on a `>cursorIdKey` filter to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
+- **A cursor that stops advancing is fatal**: if a page comes back full and its last `idKey` value equals the one already filtered on, the `>cursorIdKey` condition was dropped and the same page will keep arriving. The walk cannot end on its own — the page is full, so the `length < 50` stop never fires — so it throws `SdkError`{lang="ts-type"} with code `JSSDK_ACTION_CURSOR_STALLED` instead of collecting duplicates for ever. The usual cause is `idKey` naming the response field while `cursorIdKey` is left to default to it: `tasks.task.list` returns a lowercase `id` but filters on an uppercase `ID`, so it needs both (`idKey: 'id'`, `cursorIdKey: 'ID'`).
 - **Only for list methods**: Intended only for methods that return data arrays.
 
 ## Error Handling

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallListV3.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 3.'
 category: 'actions'
-audited: 2026-09-05
+audited: 2026-09-07
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: CallList
@@ -19,6 +19,12 @@ links:
   - label: Skill — b24jssdk-rest
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-rest/SKILL.md
+  - label: Cursor-stall guard
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/actions/_cursor-stalled.ts
+  - label: Keyset driver
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/actions/v3/_keyset-paginate.ts
 ---
 
 ::note
@@ -119,6 +125,7 @@ Some v3 list methods (e.g. `note.*`) also return a `nextCursor`{lang="ts-type"} 
 - **Page size**: Bitrix24 REST API version 3 limitation — maximum `1000` records per request.
 - **Sorting is fixed**: The method always sorts by `cursorIdKey` (which defaults to `idKey`) ascending, because cursor pagination relies on `[cursorIdKey, '>', nextId]` filters to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
 - **`filter` must be the v3 array form**: `[['id', '>', 100]]`, or the output of `FilterV3.build(...)`. The `restApi:v2` object dialect (`{ '>id': 100 }`) is accepted by `TypeCallParamsV3`{lang="ts-type"} for backward compatibility and works with a plain `call`, but not here: cursor pagination appends `[cursorIdKey, '>', nextId]` to the same filter on every page, so an array is the only shape it can extend. Passing an object throws `SdkError`{lang="ts-type"} with code `JSSDK_ACTION_V3_LIST_FILTER_NOT_ARRAY`. It used to be accepted and then failed mid-walk with `filter is not iterable`.
+- **A cursor that stops advancing is fatal**: if a page comes back full and its last `idKey` value equals the one already filtered on, the `>cursorIdKey` condition was dropped and the same page will keep arriving. The walk cannot end on its own — the page is full, so the largest-page-seen stop never fires — so it throws `SdkError`{lang="ts-type"} with code `JSSDK_ACTION_CURSOR_STALLED` instead of collecting duplicates for ever. The usual cause is `idKey` naming the response field while `cursorIdKey` is left to default to it: `tasks.task.list` returns a lowercase `id` but filters on an uppercase `ID`, so it needs both (`idKey: 'id'`, `cursorIdKey: 'ID'`).
 - **Only for list methods**: Intended only for methods that return data arrays.
 
 ## Error Handling
@@ -221,7 +228,10 @@ const response = await $b24.actions.v3.callList.make({
 })
 ```
 
-If `idKey` can't be read from a full page, the SDK logs a `warning` and stops paginating instead of silently truncating.
+The two ways of getting this wrong fail differently, and the difference matters:
+
+- **`idKey` cannot be read from a full page** — you named a field the response does not carry. The SDK logs a `warning` and stops paginating rather than silently truncating; the `Result` holds what arrived so far, and it is real data.
+- **`cursorIdKey` names a field the server does not filter on** — `idKey` reads fine, so the walk keeps going, but the page condition is dropped and the same page comes back for ever. That one throws `SdkError`{lang="ts-type"} with code `JSSDK_ACTION_CURSOR_STALLED`, because everything collected at that point is one page repeated.
 
 ## Alternatives and Recommendations
 

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: FetchListV2.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 2 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-09-05
+audited: 2026-09-07
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: FetchList
@@ -19,6 +19,9 @@ links:
   - label: Skill — b24jssdk-rest
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-rest/SKILL.md
+  - label: Cursor-stall guard
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/actions/_cursor-stalled.ts
 ---
 
 ::caution{title="⚠️ REST API DEPRECATION"}
@@ -135,6 +138,7 @@ The `customKeyForResult`{lang="ts-type"} parameter allows you to specify the key
 
 - **Page size**: Fixed limitation of Bitrix24 REST API version 2 — `50` records per request.
 - **Sorting is fixed**: The method always sorts by `cursorIdKey` (which defaults to `idKey`) ascending, because cursor pagination relies on a `>cursorIdKey` filter to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
+- **A cursor that stops advancing is fatal**: if a page comes back full and its last `idKey` value equals the one already filtered on, the `>cursorIdKey` condition was dropped and the same page will keep arriving. The walk cannot end on its own — the page is full, so the `length < 50` stop never fires — so it throws `SdkError`{lang="ts-type"} with code `JSSDK_ACTION_CURSOR_STALLED` instead of collecting duplicates for ever. The usual cause is `idKey` naming the response field while `cursorIdKey` is left to default to it: `tasks.task.list` returns a lowercase `id` but filters on an uppercase `ID`, so it needs both (`idKey: 'id'`, `cursorIdKey: 'ID'`).
 - **Only for list methods**: Intended only for methods that return data arrays.
 
 ## Error Handling

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: FetchListV3.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 3 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-09-05
+audited: 2026-09-07
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: FetchList
@@ -19,6 +19,12 @@ links:
   - label: Skill — b24jssdk-rest
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-rest/SKILL.md
+  - label: Cursor-stall guard
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/actions/_cursor-stalled.ts
+  - label: Keyset driver
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/actions/v3/_keyset-paginate.ts
 ---
 
 ## Overview
@@ -128,6 +134,7 @@ Some v3 list methods (e.g. `note.*`) also return a `nextCursor`{lang="ts-type"} 
 - **Page size**: Bitrix24 REST API version 3 limitation — maximum `1000` records per request.
 - **Sorting is fixed**: The method always sorts by `cursorIdKey` (which defaults to `idKey`) ascending, because cursor pagination relies on `[cursorIdKey, '>', nextId]` filters to walk the dataset. A user-supplied `order` value would break that invariant, so the type signature excludes `order` and any value passed at runtime is stripped with a `warning` log entry. To narrow the result set, use `filter` instead.
 - **`filter` must be the v3 array form**: `[['id', '>', 100]]`, or the output of `FilterV3.build(...)`. The `restApi:v2` object dialect (`{ '>id': 100 }`) is accepted by `TypeCallParamsV3`{lang="ts-type"} for backward compatibility and works with a plain `call`, but not here: cursor pagination appends `[cursorIdKey, '>', nextId]` to the same filter on every page, so an array is the only shape it can extend. Passing an object throws `SdkError`{lang="ts-type"} with code `JSSDK_ACTION_V3_LIST_FILTER_NOT_ARRAY`. It used to be accepted and then failed mid-walk with `filter is not iterable`.
+- **A cursor that stops advancing is fatal**: if a page comes back full and its last `idKey` value equals the one already filtered on, the `>cursorIdKey` condition was dropped and the same page will keep arriving. The walk cannot end on its own — the page is full, so the largest-page-seen stop never fires — so it throws `SdkError`{lang="ts-type"} with code `JSSDK_ACTION_CURSOR_STALLED` instead of collecting duplicates for ever. The usual cause is `idKey` naming the response field while `cursorIdKey` is left to default to it: `tasks.task.list` returns a lowercase `id` but filters on an uppercase `ID`, so it needs both (`idKey: 'id'`, `cursorIdKey: 'ID'`).
 - **Only for list methods**: Intended only for methods that return data arrays.
 
 ## Error Handling
@@ -275,7 +282,10 @@ for await (const chunk of generator) {
 }
 ```
 
-If `idKey` can't be read from a full page, the SDK logs a `warning` and stops paginating instead of silently truncating.
+The two ways of getting this wrong fail differently, and the difference matters:
+
+- **`idKey` cannot be read from a full page** — you named a field the response does not carry. The SDK logs a `warning` and stops paginating rather than silently truncating; the `Result` holds what arrived so far, and it is real data.
+- **`cursorIdKey` names a field the server does not filter on** — `idKey` reads fine, so the walk keeps going, but the page condition is dropped and the same page comes back for ever. That one throws `SdkError`{lang="ts-type"} with code `JSSDK_ACTION_CURSOR_STALLED`, because everything collected at that point is one page repeated.
 
 ## Alternatives and Recommendations
 

--- a/docs/content/docs/2.working-with-the-rest-api/6.errors.md
+++ b/docs/content/docs/2.working-with-the-rest-api/6.errors.md
@@ -3,7 +3,7 @@ title: Error codes and handling
 description: 'Reference for SdkError and AjaxError codes raised by the SDK, plus the Bitrix24 REST error codes that surface through them.'
 navigation:
   title: Errors
-audited: 2026-09-06
+audited: 2026-09-07
 links:
   - label: SdkError
     iconName: GitHubIcon
@@ -17,6 +17,9 @@ links:
   - label: Skill — b24jssdk-core
     iconName: GitHubIcon
     to: https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-core/SKILL.md
+  - label: Cursor-stall guard
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/actions/_cursor-stalled.ts
 ---
 
 ## Overview
@@ -30,7 +33,9 @@ The SDK raises errors through two related classes:
 
 - `AjaxError extends SdkError` — thrown when an HTTP call to Bitrix24 fails. Adds `requestInfo` (`method`, `requestId`, request params) so you can correlate with portal-side logs, and `isV3Envelope`, saying whether the portal answered in the `restApi:v3` error shape (`{ error: { code, message } }`) rather than the flat v2 one — which is what the [category rule](/docs/working-with-the-rest-api/error-codes/#classification-by-category-restapiv3) keys on, and is `undefined` for an error that never came from a parsed REST body. Since v1.1.2 (#39), `requestInfo` does **not** include the full request URL and credential-bearing fields inside `params` are redacted — the goal is to keep webhook secrets out of `toJSON()` / `toString()` output.
 
-Method-style results that don't throw — `Call`, `CallList`, `Batch`, `BatchByChunk` — surface failures through `Result`/`AjaxResult`: check `.isSuccess` and read `.getErrorMessages()`. `FetchList`, by contrast, **does** throw on failure (the generator can't complete partially).
+Method-style results that don't throw — `Call`, `CallList`, `Batch`, `BatchByChunk` — surface **portal-side** failures through `Result`/`AjaxResult`: check `.isSuccess` and read `.getErrorMessages()`. `FetchList`, by contrast, **does** throw on failure (the generator can't complete partially).
+
+That split is about REST errors, not about every failure. `CallList` and `CallTail` also raise `SdkError` for the handful of conditions that make the walk itself impossible — a `filter` they cannot extend, and a cursor that stops advancing (`JSSDK_ACTION_CURSOR_STALLED`). Those reject the promise rather than resolving with a `Result`, so wrap the call in `try`/`catch` as well as checking `isSuccess` if you want to handle both.
 
 ## Which field failed: `AjaxError.validation`
 
@@ -144,6 +149,7 @@ Codes are stable strings — match on them, don't parse messages.
 | `JSSDK_INTERACTION_BATCH_EMPTY_PROCESSING_STRATEGY` | 500 | batch processing | Internal — strategy lookup failed. |
 | `JSSDK_ACTION_V3_LIST_FILTER_NOT_ARRAY` | 500 | `actions.v3.callList` / `fetchList` | `filter` was not an array. These actions append `[cursorIdKey, '>', cursor]` to it on every page, so only an array can be extended — a `FilterV3` logic group is a valid v3 filter but must be wrapped: `filter: [FilterV3.or(...)]`. |
 | `JSSDK_ACTION_V3_TAIL_FILTER_INVALID` | 500 | `actions.v3.callTail` / `fetchTail` | `filter` was the `restApi:v2` object dialect (`{ '>id': 100 }`). These actions forward `filter` untouched, so an array **or** a bare logic group is fine — only the v2 dialect is refused, and it is refused here rather than one round trip later, where the portal reports it in wording that never names the dialect. |
+| `JSSDK_ACTION_CURSOR_STALLED` | 500 | `callList` / `fetchList` (**v2 and v3**), `callTail` / `fetchTail` (v3) | The cursor came back equal to the one just sent — the server is answering with the same page, so the walk can never end. The page is full, so no end-of-data check sees it. **List walkers**: the `>` page condition was dropped, almost always because the id field is spelled one way in the response and another in the request — check `idKey` against `cursorIdKey` (on `restApi:v2` `tasks.task.list` that pair is `idKey: 'id'`, `cursorIdKey: 'ID'`; the v3 method is lowercase both ways and needs no override). **Tail walkers**: check `cursorField` — it must be the field the server pages by, be present in `select`, and advance between pages. Unlike a soft REST error this **rejects** instead of resolving. `fetchList` / `fetchTail` have already yielded every page they read, the repeated one included, so a `for await` consumer that persisted them has to undo that. |
 | `JSSDK_INTERACTION_BATCH_ROW_FAIL` | 500 | batch row parser | A single batch row could not be parsed. |
 | `JSSDK_INVALID_PARAMS` | 400 | HTTP transport | The shape of `params` was rejected before the request was sent. |
 | `JSSDK_PARAMS_TOO_LARGE` | 413 | HTTP transport | Serialized request body exceeded the size limit. Split the call. |
@@ -226,7 +232,7 @@ catch (error) {
 
 ### Use `isSuccess` for non-throwing methods
 
-`Call`, `CallList`, `Batch`, `BatchByChunk` return a `Result` / `AjaxResult` instead of throwing:
+`Call`, `CallList`, `Batch`, `BatchByChunk` return a `Result` / `AjaxResult` instead of throwing for a REST-side failure. `CallList` and `CallTail` still reject on the walk-level guards listed above (`JSSDK_ACTION_V3_LIST_FILTER_NOT_ARRAY`, `JSSDK_ACTION_V3_TAIL_FILTER_INVALID`, `JSSDK_ACTION_CURSOR_STALLED`), so add a `try`/`catch` if those matter to you:
 
 ::rest-api-version-only
 #rest-api-ver2
@@ -273,6 +279,11 @@ catch (error) {
     // a page request failed; persisted chunks before this point are still good
     return resumeFromLastSavedId()
   }
+  if (error instanceof SdkError && error.code === 'JSSDK_ACTION_CURSOR_STALLED') {
+    // not the same situation: the walk was repeating one page, so the chunks
+    // already persisted contain duplicates and have to be rolled back
+    return discardAndReportStalledCursor()
+  }
   throw error
 }
 ```
@@ -292,6 +303,11 @@ catch (error) {
   ) {
     // a page request failed; persisted chunks before this point are still good
     return resumeFromLastSavedId()
+  }
+  if (error instanceof SdkError && error.code === 'JSSDK_ACTION_CURSOR_STALLED') {
+    // not the same situation: the walk was repeating one page, so the chunks
+    // already persisted contain duplicates and have to be rolled back
+    return discardAndReportStalledCursor()
   }
   throw error
 }

--- a/docs/content/docs/99.examples/1.dashboard-deals-csv.md
+++ b/docs/content/docs/99.examples/1.dashboard-deals-csv.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Export deals to CSV'
 description: 'Stream every CRM deal that matches a date filter into a CSV file using a webhook and FetchListV2.'
-audited: 2026-09-05
+audited: 2026-09-07
 category: 'examples'
 featured: true
 cookbookOrder: 2
@@ -118,7 +118,7 @@ node scripts/deals-to-csv.mjs
 
 - `crm.item.list` returns up to 50 records per page; this is a server-side limit, not an SDK setting.
 - The generator does **not** support a custom `order` parameter — cursor pagination requires sorting by `cursorIdKey` (default `idKey`) ascending. Specifying `order` in `params` triggers a runtime warning and is stripped.
-- `idKey` defaults to `'ID'` (uppercase) for v2 endpoints. CRM item methods return `id` (lowercase), so override it explicitly as in the example. If a method sorts/filters by a different field name than it returns (e.g. `tasks.task.list` sorts by `ID` but returns `id`), also set `cursorIdKey`.
+- `idKey` defaults to `'ID'` (uppercase) for v2 endpoints. CRM item methods return `id` (lowercase), so override it explicitly as in the example. If a method sorts/filters by a different field name than it returns (e.g. `tasks.task.list` sorts by `ID` but returns `id`), also set `cursorIdKey` — `crm.item.list` accepts the lowercase name in both places, which is why this script needs only `idKey`. Get that pair wrong and the walk throws `JSSDK_ACTION_CURSOR_STALLED` rather than looping: see [Errors](/docs/working-with-the-rest-api/error-codes/).
 - One `B24Hook` instance corresponds to a single user account on the portal. If the deals you need are owned by another user, the webhook must be created by that user (or by an account with cross-user access).
 - For very large windows that exhaust the per-day method-call budget, split the date range into smaller chunks and run them sequentially.
 

--- a/packages/jssdk/src/core/actions/_cursor-stalled.ts
+++ b/packages/jssdk/src/core/actions/_cursor-stalled.ts
@@ -1,0 +1,65 @@
+import { SdkError } from '../sdk-error'
+
+/**
+ * The error every keyset walk raises when its cursor stops advancing.
+ *
+ * A keyset walk reads a cursor out of the page it just received and sends it
+ * back on the next request. If the value that comes back is the one already
+ * sent, the walk cannot make progress — the server is answering with the same
+ * page — and **nothing else in any of these loops notices**: the page is full,
+ * so the end-of-data checks stay silent, and the walk runs until the eager
+ * helpers exhaust memory or the streaming ones yield the same rows for ever.
+ *
+ * Shared by both API versions on purpose. The v3 helpers drive a common
+ * generator (`actions/v3/_keyset-paginate.ts`); the v2 ones each carry their own
+ * inline loop. Three insertion points, one failure, one code — so a caller
+ * matching on the string does not have to know which loop they were in, and the
+ * error page documents it once.
+ *
+ * **`status: 500`, not 400.** The neighbouring client-side guards use 400
+ * because they decide from the arguments alone, before a request is sent. This
+ * one cannot: an identical cursor means the page condition was not applied, and
+ * from here there is no way to tell a caller who named the wrong field from a
+ * portal that ignores the condition on this method. Reporting a caller error
+ * would be a guess.
+ *
+ * **It throws rather than folding into the `Result`.** The eager helpers catch
+ * their soft-error wrapper and return what they collected; an `SdkError` goes
+ * past that, so `callList` / `callTail` reject instead of resolving. What makes
+ * that right is what the collected rows are worth: for the list walkers the page
+ * condition is either honoured from the first request or dropped from the first
+ * request, so every row held at that point is page one repeated, and returning
+ * it would hand back duplicates that read as data. For the tail walkers a stall
+ * can begin after real pages, and those are lost — the honest cost of refusing a
+ * result that is both incomplete and duplicated with no way to tell which rows
+ * are which. A caller who wants the pages that did arrive should walk with
+ * `fetchList` / `fetchTail`, which yield each page before this throws.
+ *
+ * @param action - Caller-facing label, e.g. `callList.make` — the same wording
+ *   the filter guards use, so both errors from one action read alike.
+ * @param hint - What to check, in the vocabulary of *that* action. The list
+ *   walkers expose `idKey` / `cursorIdKey`; the tail walkers expose
+ *   `cursorField`, and telling a `callTail` caller to set `cursorIdKey` would
+ *   send them after an option their action does not have.
+ */
+export function cursorStalledError(action: string, hint: string): SdkError {
+  // Static text plus the two labels, both literals chosen by the action. No
+  // cursor value, filter, field value or method name is interpolated: unlike
+  // AjaxError, SdkError does NOT run its description through
+  // `redactSensitiveParams`, and a cursor is a field value read off the
+  // response.
+  return new SdkError({
+    code: 'JSSDK_ACTION_CURSOR_STALLED',
+    description: `${action}: the cursor did not move — the server answered with the same page again, so this walk can never finish. ${hint} `
+      + `Stopping instead of looping for ever. Note that a streaming helper (fetchList / fetchTail) has already yielded every page it read, including the repeated one, so a consumer that persisted them has to undo that.`,
+    status: 500
+  })
+}
+
+/** What to check when an emulated-keyset **list** walk stalls. */
+export const CURSOR_STALLED_HINT_LIST
+  = 'Check `idKey` — the id field as the response spells it — against `cursorIdKey`, the field name the request sorts and filters by. When the two differ, the page condition is written with a name the server does not match, and it is dropped: on `restApi:v2` `tasks.task.list` the response carries a lowercase `id` while the filter accepts an uppercase `ID`, so that walk needs `idKey: \'id\', cursorIdKey: \'ID\'`. The v3 method spells it lowercase both ways and needs no override.'
+
+/** What to check when a native **tail** walk stalls. */
+export const CURSOR_STALLED_HINT_TAIL
+  = 'Check `cursorField`: it must name the field the server actually pages by, it must be readable in the response (include it in `select`), and its values must advance from page to page — a block of rows sharing one value is enough to stall the walk, so prefer a unique field. With `order: \'DESC\'`, check `initialValue` too.'

--- a/packages/jssdk/src/core/actions/v2/call-list.ts
+++ b/packages/jssdk/src/core/actions/v2/call-list.ts
@@ -2,6 +2,7 @@ import type { TypeCallParams, TypeCallParamsV2 } from '../../../types/http'
 import type { AjaxResult } from '../../http/ajax-result'
 import { AbstractAction } from '../abstract-action'
 import { Result } from '../../result'
+import { cursorStalledError, CURSOR_STALLED_HINT_LIST } from '../_cursor-stalled'
 
 export type ActionCallListV2 = {
   method: string
@@ -138,6 +139,22 @@ export class CallListV2 extends AbstractAction {
       const lastItem = resultData[resultData.length - 1] as Record<string, any>
       const cursorValue = lastItem ? Number.parseInt(lastItem[idKey], 10) : Number.NaN
       if (Number.isFinite(cursorValue)) {
+        // A full page whose last id is the one already filtered on means the
+        // `>idKey` condition was dropped and this page will keep arriving. The
+        // check above cannot see it — a repeated page is full, so
+        // `resultData.length < batchSize` stays false however long the walk runs
+        // — and `allItems` grows by the same 50 rows for ever.
+        //
+        // Measured on a live portal, `tasks.task.list` with `idKey: 'id'` and no
+        // `cursorIdKey`: the walk was capped at three pages and collected 150
+        // rows of which 50 were unique, the cursor reading 3 every time. The
+        // response spells the id lowercase, the filter accepts it uppercase, so
+        // `>id` matches nothing the server knows and is ignored. That is the
+        // configuration #185 added `cursorIdKey` for; this is the signal that it
+        // is missing, instead of a hang.
+        if (cursorValue === requestParams.filter[moreIdKey]) {
+          throw cursorStalledError('callList.make', CURSOR_STALLED_HINT_LIST)
+        }
         requestParams.filter[moreIdKey] = cursorValue
       } else {
         // A full page came back, yet no usable numeric cursor id could be read from

--- a/packages/jssdk/src/core/actions/v2/fetch-list.ts
+++ b/packages/jssdk/src/core/actions/v2/fetch-list.ts
@@ -2,6 +2,7 @@ import type { TypeCallParams, TypeCallParamsV2 } from '../../../types/http'
 import type { AjaxResult } from '../../http/ajax-result'
 import { AbstractAction } from '../abstract-action'
 import { SdkError } from '../../sdk-error'
+import { cursorStalledError, CURSOR_STALLED_HINT_LIST } from '../_cursor-stalled'
 
 export type ActionFetchListV2 = {
   method: string
@@ -140,6 +141,13 @@ export class FetchListV2 extends AbstractAction {
       const lastItem = resultData[resultData.length - 1] as Record<string, any>
       const cursorValue = lastItem ? Number.parseInt(lastItem[idKey], 10) : Number.NaN
       if (Number.isFinite(cursorValue)) {
+        // See the note in `v2/call-list.ts`: a full page whose last id equals
+        // the one already filtered on means `>idKey` was dropped, and the same
+        // page repeats for ever. Here the pages have already been yielded, so
+        // the consumer holds the duplicates — the error says so.
+        if (cursorValue === requestParams.filter[moreIdKey]) {
+          throw cursorStalledError('fetchList.make', CURSOR_STALLED_HINT_LIST)
+        }
         requestParams.filter[moreIdKey] = cursorValue
       } else {
         // A full page came back, yet no usable numeric cursor id could be read from

--- a/packages/jssdk/src/core/actions/v3/_keyset-paginate.ts
+++ b/packages/jssdk/src/core/actions/v3/_keyset-paginate.ts
@@ -3,6 +3,7 @@ import type { LoggerInterface } from '../../../types/logger'
 import type { TypeCallParams, TypeFilterV3 } from '../../../types/http'
 import type { AjaxResult } from '../../http/ajax-result'
 import { SdkError } from '../../sdk-error'
+import { cursorStalledError } from '../_cursor-stalled'
 
 /**
  * Reject a non-array `filter` for the emulated-keyset list actions.
@@ -215,6 +216,20 @@ export type KeysetPaginateStrategy = {
   noCursorWarning: string
   /** Label logged at `error` level when the underlying `call` fails. */
   errorLabel: string
+  /**
+   * Caller-facing name of the action, e.g. `callList.make` — the wording the
+   * filter guards already use, so both errors from one action read alike.
+   * Separate from {@link KeysetPaginateStrategy.errorLabel}, which is an
+   * internal log label (`callFastListMethod`) and does not belong in a message
+   * the caller reads.
+   */
+  actionLabel: string
+  /**
+   * What to check when the cursor stops advancing, in the vocabulary of *this*
+   * action: the list walkers expose `idKey` / `cursorIdKey`, the tail walkers
+   * expose `cursorField`. See `actions/_cursor-stalled.ts` for the two texts.
+   */
+  stalledCursorHint: string
 }
 
 /**
@@ -232,6 +247,12 @@ export type KeysetPaginateStrategy = {
  * On a soft error it throws {@link KeysetPaginationError}; the calling helper
  * decides whether to fold it into a `Result` (eager) or rethrow as an
  * `SdkError` (streaming).
+ *
+ * A cursor that stops advancing is a different case and throws `SdkError`
+ * directly, past that fold — see the guard below for why.
+ *
+ * @throws {KeysetPaginationError} when the underlying `call` reports a soft error
+ * @throws {SdkError} `JSSDK_ACTION_CURSOR_STALLED`
  */
 export async function* keysetPaginate<T = unknown>(
   b24: TypeB24,
@@ -278,9 +299,45 @@ export async function* keysetPaginate<T = unknown>(
 
     const lastItem = resultData[resultData.length - 1] as Record<string, any>
     const next = lastItem ? strategy.readNextCursor(lastItem) : null
-    if (next === null || next === undefined) {
+
+    // `readNextCursor` is declared to return `number | string | null`, but the
+    // tail walkers read the value straight off the response — `lastItem[
+    // cursorField]`, typed `any` — so nothing narrows it at runtime. A
+    // `cursorField` naming an object- or array-valued field (ordinary in a v3
+    // response) then yields a **fresh reference on every page**, which the stall
+    // check below cannot see: `===` between two distinct objects is never true,
+    // so the walk this guard exists to stop would run forever anyway.
+    //
+    // A non-primitive is therefore treated as no cursor at all and takes the
+    // same warning-and-stop path as an unreadable one — in both cases
+    // `cursorField` does not name a scalar, which is exactly what the warning
+    // already tells the caller. This subsumes the `null` / `undefined` check it
+    // replaces; the list walkers hand back `null` for an unparsable id and keep
+    // the behaviour they had.
+    if (typeof next !== 'number' && typeof next !== 'string') {
       logger.warning(strategy.noCursorWarning).catch(() => {})
       break
+    }
+
+    // Nothing above this line catches a repeating page: the `maxPageSize` stop
+    // fires on a page *shorter* than the largest seen, and a repeated page is
+    // the same size as itself. See `actions/_cursor-stalled.ts` for what the
+    // error says and why it throws rather than folding into the `Result`.
+    //
+    // `===` rather than `==`, so no genuinely different value is read as a stall
+    // — `0 == ''` and `0 == false` are true, and stopping on one of those would
+    // be stopping on a lie. The cost is one extra request when a server changes
+    // only the type of an identical cursor (`100` → `'100'`): that reads as
+    // movement, and the guard fires on the next page once the type settles.
+    //
+    // Two limits, both deliberate. It catches a repeat of the **immediately
+    // preceding** cursor, not a longer cycle — a server alternating between two
+    // pages still loops, and seeing that needs a set of every cursor so far,
+    // which grows with the walk. And it sits after the `maxPageSize` stop, so a
+    // stalled page that happens to be shorter than an earlier one ends the walk
+    // quietly instead of reaching here; that is how that check already behaved.
+    if (next === cursor) {
+      throw cursorStalledError(strategy.actionLabel, strategy.stalledCursorHint)
     }
 
     cursor = next

--- a/packages/jssdk/src/core/actions/v3/call-list.ts
+++ b/packages/jssdk/src/core/actions/v3/call-list.ts
@@ -2,6 +2,7 @@ import type { TypeCallParams, TypeCallParamsV3, TypeFilterV3 } from '../../../ty
 import { AbstractAction } from '../abstract-action'
 import { Result } from '../../result'
 import { assertArrayFilter, keysetPaginate, KeysetPaginationError } from './_keyset-paginate'
+import { CURSOR_STALLED_HINT_LIST } from '../_cursor-stalled'
 
 export type ActionCallListV3 = {
   method: string
@@ -124,7 +125,9 @@ export class CallListV3 extends AbstractAction {
           return Number.isFinite(value) ? value : null
         },
         noCursorWarning: `callList.make: pagination stops here — no numeric id could be read from the returned items via idKey "${idKey}". Make sure idKey matches the id field in the response; if the sortable field name differs from it, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`,
-        errorLabel: 'callFastListMethod'
+        errorLabel: 'callFastListMethod',
+        actionLabel: 'callList.make',
+        stalledCursorHint: CURSOR_STALLED_HINT_LIST
       })) {
         for (const item of page) {
           allItems.push(item)

--- a/packages/jssdk/src/core/actions/v3/call-tail.ts
+++ b/packages/jssdk/src/core/actions/v3/call-tail.ts
@@ -4,6 +4,7 @@ import { Result } from '../../result'
 import { SdkError } from '../../sdk-error'
 import type { FilterV3Group } from '../../../tools/filter-v3'
 import { assertTailFilter, filterMentionsField, keysetPaginate, KeysetPaginationError } from './_keyset-paginate'
+import { CURSOR_STALLED_HINT_TAIL } from '../_cursor-stalled'
 
 export type ActionCallTailV3 = {
   method: string
@@ -126,7 +127,9 @@ export class CallTailV3 extends AbstractAction {
         // value (cursorField not selected / wrong name) stops the walk.
         readNextCursor: lastItem => lastItem[cursorField] ?? null,
         noCursorWarning: `callTail.make: pagination stops here — no value could be read from the returned items via cursorField "${cursorField}". Make sure cursorField matches a field present in the response (and in \`select\`).`,
-        errorLabel: 'callTailMethod'
+        errorLabel: 'callTailMethod',
+        actionLabel: 'callTail.make',
+        stalledCursorHint: CURSOR_STALLED_HINT_TAIL
       })) {
         for (const item of page) {
           allItems.push(item)

--- a/packages/jssdk/src/core/actions/v3/fetch-list.ts
+++ b/packages/jssdk/src/core/actions/v3/fetch-list.ts
@@ -2,6 +2,7 @@ import type { TypeCallParams, TypeCallParamsV3, TypeFilterV3 } from '../../../ty
 import { AbstractAction } from '../abstract-action'
 import { SdkError } from '../../sdk-error'
 import { assertArrayFilter, keysetPaginate, KeysetPaginationError } from './_keyset-paginate'
+import { CURSOR_STALLED_HINT_LIST } from '../_cursor-stalled'
 
 export type ActionFetchListV3 = {
   method: string
@@ -125,7 +126,9 @@ export class FetchListV3 extends AbstractAction {
           return Number.isFinite(value) ? value : null
         },
         noCursorWarning: `fetchList.make: pagination stops here — no numeric id could be read from the returned items via idKey "${idKey}". Make sure idKey matches the id field in the response; if the sortable field name differs from it, also set cursorIdKey (e.g. idKey: 'id', cursorIdKey: 'ID').`,
-        errorLabel: 'fetchListMethod'
+        errorLabel: 'fetchListMethod',
+        actionLabel: 'fetchList.make',
+        stalledCursorHint: CURSOR_STALLED_HINT_LIST
       })
     } catch (error) {
       if (error instanceof KeysetPaginationError) {

--- a/packages/jssdk/src/core/actions/v3/fetch-tail.ts
+++ b/packages/jssdk/src/core/actions/v3/fetch-tail.ts
@@ -3,6 +3,7 @@ import { AbstractAction } from '../abstract-action'
 import { SdkError } from '../../sdk-error'
 import type { FilterV3Group } from '../../../tools/filter-v3'
 import { assertTailFilter, filterMentionsField, keysetPaginate, KeysetPaginationError } from './_keyset-paginate'
+import { CURSOR_STALLED_HINT_TAIL } from '../_cursor-stalled'
 
 export type ActionFetchTailV3 = {
   method: string
@@ -130,7 +131,9 @@ export class FetchTailV3 extends AbstractAction {
         // value (cursorField not selected / wrong name) stops the walk.
         readNextCursor: lastItem => lastItem[cursorField] ?? null,
         noCursorWarning: `fetchTail.make: pagination stops here — no value could be read from the returned items via cursorField "${cursorField}". Make sure cursorField matches a field present in the response (and in \`select\`).`,
-        errorLabel: 'fetchTailMethod'
+        errorLabel: 'fetchTailMethod',
+        actionLabel: 'fetchTail.make',
+        stalledCursorHint: CURSOR_STALLED_HINT_TAIL
       })
     } catch (error) {
       if (error instanceof KeysetPaginationError) {

--- a/skills/b24jssdk-rest/SKILL.md
+++ b/skills/b24jssdk-rest/SKILL.md
@@ -42,6 +42,8 @@ There is no manual-pagination path any more — the list helpers page for you. T
 
 `filter` on v3 is the array form or a `FilterV3` logic group — never the v2 object dialect (`{ '>id': 100 }`), which the portal rejects on every v3 method. All four walkers refuse it client-side. `callList` / `fetchList` additionally require an **array**, because they extend it with the page condition, and throw `JSSDK_ACTION_V3_LIST_FILTER_NOT_ARRAY`; `callTail` / `fetchTail` forward `filter` untouched, so a bare group is fine there and only the v2 dialect throws — `JSSDK_ACTION_V3_TAIL_FILTER_INVALID`.
 
+All of them — and the two `restApi:v2` list walkers — also throw `JSSDK_ACTION_CURSOR_STALLED` when a full page comes back and the cursor read from it equals the one just sent. That means the page condition was dropped, so the walk can never end; it rejects rather than collecting the same page for ever.
+
 ```ts
 import { B24Hook, FilterV3 } from '@bitrix24/b24jssdk'
 
@@ -338,7 +340,7 @@ const generator = $b24.actions.v3.fetchList.make<EventLogItem>({
 
 **The rule the defaults come from: `restApi:v3` field names are camelCase, `restApi:v2` names are UPPER_SNAKE.** Measured across 108 descriptors from two entities (`tasks.task` 95, `main.eventlog` 13) — not one v3 name starts with an uppercase letter. That is why `idKey` defaults to `'id'` on v3 and `'ID'` on v2, and it is a rule rather than a per-method quirk: expect it to hold for the next method too.
 
-`idKey` is the id field **in the response** (the cursor reads its value); `cursorIdKey` is the field **in the request** used for `order` and the `>` page filter, and it defaults to `idKey`. They differ only when a method spells the id one way in the request and another in the response — `tasks.task.list` **on v2** is the known case (request `ID`, response `id`), and without the override the cursor reads a field that is not there, never advances, and repeats the first page for ever. On the **v3** endpoint the same method is all-lowercase (`id` both ways, rows under `result.items`), so no override is needed.
+`idKey` is the id field **in the response** (the cursor reads its value); `cursorIdKey` is the field **in the request** used for `order` and the `>` page filter, and it defaults to `idKey`. They differ only when a method spells the id one way in the request and another in the response — `tasks.task.list` **on v2** is the known case (request `ID`, response `id`), and it breaks in two different ways depending on which half you get wrong. Leave `idKey` at its default `'ID'` and the cursor reads a field the response does not carry: the walk warns and stops after the first 50 rows. Set `idKey: 'id'` but leave `cursorIdKey` defaulting to it and the opposite happens — the read works, but the request filters on `>id`, which the method ignores, so the same page returns for ever; that one now throws `JSSDK_ACTION_CURSOR_STALLED` instead of hanging. Set both. On the **v3** endpoint the same method is all-lowercase (`id` both ways, rows under `result.items`), so no override is needed.
 
 Ask the portal rather than guess: **`<entity>.field.list`** returns every field with `type`, `filterable`, `sortable`, `editable` and `requiredGroups`, under `result.items`; `<entity>.field.get` returns one, under `result.item`. Both take an optional `select` that narrows the descriptor keys. A v3 field without `Filterable` / `Sortable` is **refused**, not ignored — `BITRIX_REST_V3_EXCEPTION_VALIDATION_REQUESTVALIDATIONEXCEPTION` with the offending name in `validation[].field`. On the portal measured, `tasks.task` exposes exactly one filterable field: `id`.
 
@@ -505,7 +507,8 @@ const hasNotes = Boolean(doc?.paths?.['/note.collection.list'])
 - ❌ Passing `order` to `callList.make` — silently ignored with a warning. Narrow with `filter` instead.
 - ❌ `customKeyForResult: 'result'` for `crm.item.list` — wrong, use `'items'`. Otherwise you'll get an empty list silently.
 - ❌ `idKey: 'ID'` for `crm.item.list` — wrong, use `'id'`. The classic `crm.deal.list` is the opposite.
-- ❌ `idKey: 'ID'` alone for `tasks.task.list` — the response id is lowercase `id`, so the cursor can't read it and paging silently stops after 50. Use `idKey: 'id', cursorIdKey: 'ID'`.
+- ❌ `idKey: 'ID'` alone for `tasks.task.list` — the response id is lowercase `id`, so the cursor can't read it and paging warns and stops after 50. Use `idKey: 'id', cursorIdKey: 'ID'`.
+- ❌ `idKey: 'id'` alone for the same method — the read works but the request filters on `>id`, which the method ignores, so the same page repeats; throws `JSSDK_ACTION_CURSOR_STALLED`. Same fix: set both.
 - ❌ `Promise.all` over `callList.make` for parallel paging — internal cursor pagination is sequential by design; you'll get duplicates or skipped rows.
 - ❌ Hand-paging a v3 list method by the `nextCursor` it returns (e.g. `note.*`) — `callList` / `fetchList` page via their own `idKey` cursor and walk every page; `nextCursor` is informational and the SDK ignores it. Just use the list helpers with `idKey` + `customKeyForResult`.
 - ❌ `batch.make({ calls, isHaltOnError: false })` — batch flags at the top level are **not applied**. They belong under `options: { isHaltOnError, returnAjaxResult, requestId }`. TypeScript now rejects the literal and the SDK logs a warning for callers it cannot see, but nothing recovers the intent: `returnAjaxResult` dropped this way makes `entry.isSuccess` `undefined` on a plain object, so a batch where everything succeeded reads as a batch where everything failed (#426).

--- a/test/integration/core/cursor-stalled.unit.spec.ts
+++ b/test/integration/core/cursor-stalled.unit.spec.ts
@@ -1,0 +1,265 @@
+/**
+ * Regression: a cursor that does not advance must stop the walk.
+ *
+ * Every list/tail helper pages by reading a cursor out of the page it just
+ * received and sending it back. When the server does not apply the page
+ * condition, the same page keeps arriving and **nothing in any of these loops
+ * notices**: the page is full, so the end-of-data checks stay silent, and the
+ * walk runs until the eager helpers exhaust memory or the streaming ones yield
+ * the same rows for ever.
+ *
+ * Measured on a live portal, `restApi:v2` `tasks.task.list` with `idKey: 'id'`
+ * and no `cursorIdKey`: the walk was capped at three pages and collected 150
+ * rows of which **50 were unique**, the cursor reading 3 every time. The
+ * response spells the id lowercase while the filter accepts it uppercase, so
+ * `>id` matches nothing the server knows and is dropped. That is the
+ * configuration #185 added `cursorIdKey` for — note it is *not* the default
+ * `idKey: 'ID'`, which fails the other way (`lastItem['ID']` is `undefined`, so
+ * the walk warns and stops after one page; pinned in
+ * `list-cursor-id-key.unit.spec.ts`).
+ *
+ * Both API versions are covered because both can stall and neither could
+ * notice: v3 through the shared `keysetPaginate` driver, v2 through the two
+ * inline loops in `actions/v2/`.
+ *
+ * The walk **rejects** rather than folding the failure into a `Result` the way a
+ * soft REST error does. For the list walkers the appended condition is either
+ * honoured from the first request or dropped from the first request, so every
+ * row held at that point is page one repeated and returning it would hand back
+ * duplicates that read as data. The streaming helpers have already yielded those
+ * pages — pinned below, because it is the caller's problem to undo.
+ *
+ * The mock servers here stop after a bounded number of pages. That is
+ * deliberate: with the guard removed these tests then fail on the assertion
+ * immediately instead of spinning until vitest's timeout, which reports nothing
+ * about the cursor.
+ *
+ * `*.unit.spec.ts` — no real Bitrix24 portal required (the helpers run against a
+ * mock `call.make`).
+ */
+import { describe, it, expect } from 'vitest'
+import { CallListV2 } from '../../../packages/jssdk/src/core/actions/v2/call-list'
+import { FetchListV2 } from '../../../packages/jssdk/src/core/actions/v2/fetch-list'
+import { CallListV3 } from '../../../packages/jssdk/src/core/actions/v3/call-list'
+import { FetchListV3 } from '../../../packages/jssdk/src/core/actions/v3/fetch-list'
+import { CallTailV3 } from '../../../packages/jssdk/src/core/actions/v3/call-tail'
+import { FetchTailV3 } from '../../../packages/jssdk/src/core/actions/v3/fetch-tail'
+
+type Item = Record<string, unknown>
+
+const STALLED = 'JSSDK_ACTION_CURSOR_STALLED'
+
+function makeLogger() {
+  const warnings: string[] = []
+  const logger = {
+    warning: async (m: string) => warnings.push(m),
+    error: async () => {},
+    info: async () => {},
+    log: async () => {},
+    debug: async () => {},
+    trace: async () => {}
+  }
+  return { logger: logger as never, warnings }
+}
+
+/**
+ * A server that ignores the page condition: it answers with the same full page
+ * every time, whatever cursor it is sent. After `stopAfter` pages it answers
+ * empty — see the file header for why the mock is bounded rather than endless.
+ */
+function ignoringServer(opts: { customKey: string, page: Item[], stopAfter?: number }) {
+  const stopAfter = opts.stopAfter ?? 6
+  const calls: unknown[] = []
+
+  const make = async (callOpts: { params: unknown }) => {
+    calls.push(structuredClone(callOpts.params))
+    const slice = calls.length > stopAfter ? [] : opts.page
+    return {
+      isSuccess: true,
+      getData: () => ({ result: { [opts.customKey]: slice } }),
+      getErrorMessages: () => [],
+      errors: [] as Array<[number, Error]>
+    } as never
+  }
+
+  return { make, calls }
+}
+
+function b24V2(make: unknown) {
+  return { actions: { v2: { call: { make } } } } as never
+}
+
+function b24V3(make: unknown) {
+  return { actions: { v3: { call: { make } } } } as never
+}
+
+const PAGE = [{ id: '1', title: 'row 1' }, { id: '2', title: 'row 2' }]
+
+/**
+ * The v2 walkers hardcode a page of 50 and stop on `length < 50`, so a stalled
+ * v2 page has to be exactly that size to get past the end-of-data check and
+ * reach the cursor at all. The v3 driver measures against the largest page it
+ * has seen, so two rows are enough there.
+ */
+const FULL_V2_PAGE = Array.from({ length: 50 }, (_, index) => ({
+  id: String(index + 1),
+  title: `row ${index + 1}`
+}))
+
+describe('a cursor that does not move', () => {
+  describe('restApi:v2 — where the stall was measured', () => {
+    it('callList rejects instead of collecting the same page for ever', async () => {
+      // The measured configuration: the response id is readable (`idKey: 'id'`),
+      // so the walk gets past the "no numeric id" warning, but the request
+      // filters on `>id`, which this server ignores.
+      const { make, calls } = ignoringServer({ customKey: 'tasks', page: FULL_V2_PAGE })
+      const { logger, warnings } = makeLogger()
+      const action = new CallListV2(b24V2(make), logger)
+
+      await expect(action.make<Item>({
+        method: 'tasks.task.list',
+        idKey: 'id',
+        customKeyForResult: 'tasks'
+      })).rejects.toMatchObject({ code: STALLED })
+
+      // Two requests: the first establishes the cursor, the second returns it
+      // unchanged. Nothing beyond that is paid for.
+      expect(calls).toHaveLength(2)
+      // Not the `no numeric id` branch — that one is a warning, and confusing
+      // the two is the whole reason this test names the configuration.
+      expect(warnings).toEqual([])
+    })
+
+    it('fetchList rejects too, after the consumer already holds the duplicates', async () => {
+      const { make } = ignoringServer({ customKey: 'tasks', page: FULL_V2_PAGE })
+      const { logger } = makeLogger()
+      const action = new FetchListV2(b24V2(make), logger)
+
+      const seen: unknown[] = []
+      await expect((async () => {
+        for await (const chunk of action.make<Item>({
+          method: 'tasks.task.list',
+          idKey: 'id',
+          customKeyForResult: 'tasks'
+        })) {
+          seen.push(...chunk.map(row => row['id']))
+        }
+      })()).rejects.toMatchObject({ code: STALLED })
+
+      // Exactly the duplication the error warns about: page one, then page one
+      // again. A `for await` consumer that persisted these has to undo them.
+      expect(seen).toHaveLength(100)
+      expect(new Set(seen).size).toBe(50)
+    })
+  })
+
+  describe('restApi:v3 — the shared keyset driver', () => {
+    it('callList rejects, and the message names the list options', async () => {
+      const { make, calls } = ignoringServer({ customKey: 'items', page: PAGE })
+      const { logger } = makeLogger()
+      const action = new CallListV3(b24V3(make), logger)
+
+      const error = await action.make<Item>({
+        method: 'main.eventlog.list',
+        customKeyForResult: 'items'
+      }).catch((error_: Error) => error_)
+
+      expect(error).toMatchObject({ code: STALLED })
+      expect(calls).toHaveLength(2)
+      // The wording is the other half of the guard's job: it has to name the
+      // options this action actually has, and read like its filter guard
+      // (`callList.make: …`) rather than like the internal log label.
+      expect((error as Error).message).toContain('callList.make:')
+      expect((error as Error).message).toContain('cursorIdKey')
+    })
+
+    it('fetchList rejects after yielding what it read', async () => {
+      const { make } = ignoringServer({ customKey: 'items', page: PAGE })
+      const { logger } = makeLogger()
+      const action = new FetchListV3(b24V3(make), logger)
+
+      const seen: unknown[] = []
+      await expect((async () => {
+        for await (const chunk of action.make<Item>({
+          method: 'main.eventlog.list',
+          customKeyForResult: 'items'
+        })) {
+          seen.push(...chunk.map(row => row['id']))
+        }
+      })()).rejects.toMatchObject({ code: STALLED })
+
+      expect(seen).toEqual(['1', '2', '1', '2'])
+    })
+
+    it('callTail rejects, and the message names cursorField — not cursorIdKey', async () => {
+      const { make, calls } = ignoringServer({ customKey: 'items', page: PAGE })
+      const { logger } = makeLogger()
+      const action = new CallTailV3(b24V3(make), logger)
+
+      const error = await action.make<Item>({
+        method: 'main.eventlog.tail',
+        params: { select: ['id'] },
+        customKeyForResult: 'items'
+      }).catch((error_: Error) => error_)
+
+      expect(error).toMatchObject({ code: STALLED })
+      expect(calls).toHaveLength(2)
+      // `ActionCallTailV3` has no `idKey` and no `cursorIdKey`. Sending a tail
+      // caller after either would send them after an option TypeScript rejects,
+      // which is what the single shared message used to do.
+      expect((error as Error).message).toContain('callTail.make:')
+      expect((error as Error).message).toContain('cursorField')
+      expect((error as Error).message).not.toContain('cursorIdKey')
+    })
+
+    it('fetchTail rejects too — the walker is shared, the wiring is not', async () => {
+      const { make } = ignoringServer({ customKey: 'items', page: PAGE })
+      const { logger } = makeLogger()
+      const action = new FetchTailV3(b24V3(make), logger)
+
+      const seen: unknown[] = []
+      await expect((async () => {
+        for await (const chunk of action.make<Item>({
+          method: 'main.eventlog.tail',
+          params: { select: ['id'] },
+          customKeyForResult: 'items'
+        })) {
+          seen.push(...chunk.map(row => row['id']))
+        }
+      })()).rejects.toMatchObject({ code: STALLED })
+
+      expect(seen).toEqual(['1', '2', '1', '2'])
+    })
+  })
+
+  it('a cursor field that is not a scalar stops the walk instead of defeating it', async () => {
+    // The hole an equality check alone leaves open. The tail walkers read the
+    // cursor straight off the response — `lastItem[cursorField]`, an `any` — so
+    // a `cursorField` naming an object-valued field (ordinary in a v3 response)
+    // yields a fresh reference on every page. `next === cursor` between two
+    // distinct objects is never true, so a stalled server would loop for ever
+    // *past* the guard.
+    //
+    // Such a value is treated as no cursor at all: the same warn-and-stop path
+    // an unreadable cursor already took, because the mistake is the same one —
+    // `cursorField` does not name a scalar — and the warning already says so.
+    const { make, calls } = ignoringServer({
+      customKey: 'items',
+      page: [{ id: '1', owner: { id: 7 } }, { id: '2', owner: { id: 8 } }]
+    })
+    const { logger, warnings } = makeLogger()
+    const action = new CallTailV3(b24V3(make), logger)
+
+    const response = await action.make<Item>({
+      method: 'main.eventlog.tail',
+      params: { select: ['id', 'owner'] },
+      cursorField: 'owner',
+      customKeyForResult: 'items'
+    })
+
+    expect(response.isSuccess).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(response.getData()).toHaveLength(2)
+    expect(warnings.some(w => w.includes('cursorField "owner"'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## What breaks

If the server stops applying the page condition, the walk never ends.

Every page comes back full, so no end-of-data check fires — the v3 driver stops on a page
*shorter* than the largest it has seen, and a repeated page is the same size as itself; the v2
loops stop on `length < 50`, and a repeated full page is not shorter than 50. The streaming
helpers yield the same rows for ever; the eager ones grow an array until the process dies.
Nothing in any of the three loops noticed that the cursor had not moved.

## Measured

`restApi:v2` `tasks.task.list`, `idKey: 'id'`, `cursorIdKey` left to default:

| | |
|---|---|
| pages fetched before the walk was capped | 3 |
| rows collected | 150 |
| **unique rows** | **50** |
| cursor read from every page | 3 |

The response spells the id lowercase and the filter accepts it uppercase, so the `>id`
condition matches nothing the server knows and is dropped.

That is the field split #185 added `cursorIdKey` for — but **not** #185's reported symptom.
With `idKey` at its default `'ID'` the failure is the other one: `lastItem['ID']` is
`undefined`, the walk warns and stops after 50 rows, which is what `CHANGELOG.md` describes and
what `list-cursor-id-key.unit.spec.ts` pins. Setting `idKey: 'id'` fixes the read and exposes
the request half, and *that* configuration hangs. Both halves of one mistake, failing opposite
ways; the docs now say so explicitly, because getting them confused is easy and only one of
them is survivable.

## What changes

One code, `JSSDK_ACTION_CURSOR_STALLED`, raised wherever a cursor comes back equal to the one
just sent — `callList` / `fetchList` on **both** API versions, `callTail` / `fetchTail` on v3.

Guarding only v3 would have been backwards: v3 is where the shared driver made the fix cheap,
and v2 is where the hang was actually measured. Three insertion points, one failure, one code,
one row in the error table.

**The remedy is written per action.** A single shared message would have told a `callTail`
caller to check `idKey` and `cursorIdKey` — neither of which exists on `ActionCallTailV3`,
whose cursor option is `cursorField`. The strategy now carries its own hint, and the tests
assert that a tail error names `cursorField` and does **not** name `cursorIdKey`.

**Non-primitive cursors are stopped too.** The tail walkers read the cursor straight off the
response — `lastItem[cursorField]`, typed `any` — so a `cursorField` naming an object- or
array-valued field yields a fresh reference on every page. `===` between two distinct objects
is never true, so the guard alone would have been defeated in exactly the case it exists for.
A non-primitive is now treated as no cursor at all, taking the warn-and-stop path an unreadable
cursor already took.

**Why throw rather than stop quietly.** A silent `break` returns a truncated result that looks
complete. A stalled cursor is a broken walk, not an end of data.

**Why throw rather than fold it into the `Result`.** The eager helpers catch their soft-error
wrapper and return what they collected; an `SdkError` goes past that, so `callList` /
`callTail` reject rather than resolving with a partial result. For the list walkers the page
condition is either honoured from the first request or dropped from the first request, so every
row held at that point is page one repeated — returning it would hand back duplicates that read
as data. For the tail walkers a stall can begin after real pages, and those are lost; that is a
real cost, and the alternative is a result that is both incomplete and duplicated with no way
for the caller to tell which rows are which.

`status: 500`, not the 400 the neighbouring client-side guards use, because this one cannot
decide from the arguments: an identical cursor means the condition was not applied, and from
inside the loop there is no way to tell a caller who named the wrong field from a portal that
ignores the condition on this method.

`b24gosdk` guards the same case with `ErrCursorStalled`, independently.

## What it does not catch

Stated rather than defended against:

- **Cycles longer than one.** It compares against the immediately preceding cursor. A server
  alternating between two pages still loops; seeing that needs a set of every cursor so far,
  which grows with the walk.
- **A stalled page shorter than an earlier one.** The `maxPageSize` stop runs first, so that
  walk ends quietly — pre-existing behaviour of that check, not something this changes. It is
  reachable with a non-unique tail `cursorField`, where it can also return overlapping rows as
  a successful result. Out of scope here; it is a property of end-of-data detection, not of the
  cursor.

## Tests

`test/integration/core/cursor-stalled.unit.spec.ts`, project `jsSdk:unit`. Seven cases across
all six walkers: v2 `callList` and `fetchList`, v3 `callList`, `fetchList`, `callTail`,
`fetchTail`, and the non-scalar cursor field.

Two things the tests pin beyond the throw itself. The streaming helpers' consumers are asserted
to hold the duplicates (`['1','2','1','2']`) — the throw means *discard what you got*, not
*you got everything*. And the message wording is asserted, because a shared message that named
the wrong options passed every earlier version of this test.

The mock servers stop after a bounded number of pages on purpose: with the guard removed the
suite then fails on an assertion in **379 ms** rather than spinning to vitest's timeout, which
reports nothing about the cursor. Verified by neutering the error factory — six of seven fail,
the seventh being the one that does not depend on it.

## Checks

- `pnpm vitest run --project jsSdk:unit` — 713 passed, 0 failed (63 files)
- `pnpm lint` — clean
- `pnpm lint:md` — 0 issues
- `pnpm docs:lint` — 0 errors, 13 warnings (the pre-existing set; the one this change added, on
  `99.examples/1.dashboard-deals-csv.md`, is resolved in the diff)
- `pnpm run package-jssdk:typecheck`, `test:typecheck`, `docs:typecheck-blocks` — clean

`pnpm typecheck` in full still reports four errors in `skills/b24jssdk-recipes/examples/` about
`idempotencyKey` / `isIdempotentReplay`. They reproduce identically on a clean `main` — that
package resolves its own installed copy of the SDK, which predates #475.

## Docs

The code is documented where its sibling `JSSDK_ACTION_V3_LIST_FILTER_NOT_ARRAY` is: the error
table, the four action pages' `Limitations`, and `skills/b24jssdk-rest`.

Three corrections came with it, all in `6.errors.md`:

- "Method-style results that don't throw — `Call`, `CallList`, …" was already dented by the
  filter guards and is now load-bearing. It is qualified: that split is about REST errors, and
  `CallList` / `CallTail` do reject on the walk-level guards.
- The `fetchList` catch example commented *"persisted chunks before this point are still
  good"*. True for a failed page request, false for a stalled cursor — the generator yields the
  duplicate page before the guard fires. Both examples gained the second branch.
- The `idKey` / `cursorIdKey` section on the v3 pages ended at *"the SDK logs a `warning` and
  stops paginating"*, which is now half the story. It spells out both failure modes.

Four pages carry the shared driver in their `links:` now. Their `audited:` stamps were not
catching changes made in `_keyset-paginate.ts`, because `docs:lint-pages` compares `links:`
targets against `git log` and those pages only linked their own action file. That is why this
change surfaced a stale stamp on an examples page and nothing else.

## Review

Five reviewers plus the change's own author. They found, and this diff answers: the `#185`
attribution above (wrong as first written), the tail-vocabulary message, the non-primitive
cursor hole, the "no duplicates handed back" claim being false for the streaming helpers, the
`maxPageSize` reason being misstated, tests that failed by timeout rather than assertion, and
an assertion (`rejects.not.toHaveProperty('isSuccess')`) that passed for any rejection at all.

Follows #489 — same file, and it is why this one waited.