### PR TITLE
fix(actions): bound the filter walk by work, not only by depth

### DIFF
--- a/packages/jssdk/src/core/actions/v3/_keyset-paginate.ts
+++ b/packages/jssdk/src/core/actions/v3/_keyset-paginate.ts
@@ -94,8 +94,8 @@ function isPortalFilterGroup(value: unknown): boolean {
  * - **`depth`** stops a legitimately deep nesting. The limit is far past any
  *   filter anyone writes; reaching it means the shape is pathological, and
  *   answering "no" there is right — the caller loses a warning, not a request.
- * - **`seen`** stops the same node being explored twice. Depth alone bounds the
- *   distance the walk travels, not the work it does, and those come apart as
+ * - **`seen`** stops the same node being explored twice over. Depth alone bounds
+ *   the distance the walk travels, not the work it does, and those come apart as
  *   soon as one node is reachable by two edges: `const a = []; a.push(a, a)`
  *   gives `T(d) = 1 + 2·T(d − 1)`, and a plain DAG built without any cycle at all
  *   — `let n = [['x', '=', 1]]; for (let i = 0; i < 32; i++) n = [n, n]` — does
@@ -103,35 +103,52 @@ function isPortalFilterGroup(value: unknown): boolean {
  *   **85 seconds** of blocked event loop inside a check whose only output is a
  *   warning. With `seen` it returns immediately.
  *
- * `seen` is consulted globally within one call, not per path: a node that did
- * not mention the field the first time will not mention it the second, and one
- * that did short-circuits the whole walk through `some`. The one case that gets
- * a less precise answer is a node first reached with the depth budget already
- * spent and met again higher up — it stays `false`. That needs a filter nested
- * past 32 levels *and* sharing a node across them, which is well beyond what
- * either bound is protecting.
+ * `seen` records **the depth each node was explored with**, not merely that it
+ * was seen, and a cached `false` is trusted only when that visit had at least as
+ * much budget as this one. The distinction is the whole correctness of the memo,
+ * because a `false` means one of two different things: "this subtree does not
+ * mention the field", or "the budget ran out before we could tell". Storing them
+ * as one answer loses a real `true`, and not only in a corner:
+ *
+ * ```js
+ * const a = [['x', '=', 1]]
+ * let chain = a
+ * for (let i = 0; i < 30; i++) { chain = [chain] }
+ * filterMentionsField([chain, a], 'x') // must be true
+ * ```
+ *
+ * The long path reaches `a` with one level of budget left, cannot look inside it
+ * and answers `false`; the short path meets `a` again with 31 levels to spare. A
+ * memo that recorded only "visited" would hand back that truncated `false` — and
+ * `[a, chain]`, the same objects in the other order, would answer `true`. The
+ * depth-keyed memo answers `true` either way, and still collapses the shapes
+ * above, where every revisit happens at the same depth or shallower.
  */
 const MAX_FILTER_DEPTH = 32
 
 export function filterMentionsField(filter: unknown, field: string, depth = MAX_FILTER_DEPTH): boolean {
-  return walkFilterForField(filter, field, depth, new WeakSet())
+  return walkFilterForField(filter, field, depth, new WeakMap())
 }
 
 function walkFilterForField(
   filter: unknown,
   field: string,
   depth: number,
-  seen: WeakSet<object>
+  seen: WeakMap<object, number>
 ): boolean {
   if (depth <= 0) {
     return false
   }
 
   if (typeof filter === 'object' && filter !== null) {
-    if (seen.has(filter)) {
+    // Trust a cached `false` only if that visit had at least this much budget.
+    // A node explored with one level left would otherwise poison a later visit
+    // that had thirty — see the worked example above.
+    const exploredWith = seen.get(filter)
+    if (exploredWith !== undefined && exploredWith >= depth) {
       return false
     }
-    seen.add(filter)
+    seen.set(filter, depth)
   }
 
   if (Array.isArray(filter)) {

--- a/packages/jssdk/src/core/actions/v3/_keyset-paginate.ts
+++ b/packages/jssdk/src/core/actions/v3/_keyset-paginate.ts
@@ -87,19 +87,51 @@ function isPortalFilterGroup(value: unknown): boolean {
  * inside the array form either. Both are exactly where a caller puts a
  * condition once they reach for `FilterV3.or()`.
  *
- * `depth` bounds the walk. A filter is ordinary JavaScript, not parsed JSON, so
- * a caller can hand over a structure that points back at itself — `const f = {
- * conditions: [] }; f.conditions.push(f)` — and an unbounded walk would take the
- * stack down inside a check whose whole purpose is to make failures clearer.
- * The limit is far past any filter anyone writes; reaching it means the shape is
- * pathological, and answering "no" there is right: the caller loses a warning,
- * not a request.
+ * Two bounds, because a filter is ordinary JavaScript rather than parsed JSON
+ * and so can be shaped in ways `JSON.parse` could never produce. They answer
+ * different questions and neither replaces the other:
+ *
+ * - **`depth`** stops a legitimately deep nesting. The limit is far past any
+ *   filter anyone writes; reaching it means the shape is pathological, and
+ *   answering "no" there is right — the caller loses a warning, not a request.
+ * - **`seen`** stops the same node being explored twice. Depth alone bounds the
+ *   distance the walk travels, not the work it does, and those come apart as
+ *   soon as one node is reachable by two edges: `const a = []; a.push(a, a)`
+ *   gives `T(d) = 1 + 2·T(d − 1)`, and a plain DAG built without any cycle at all
+ *   — `let n = [['x', '=', 1]]; for (let i = 0; i < 32; i++) n = [n, n]` — does
+ *   the same. Measured at the shipped depth of 32, the two-edge cycle took
+ *   **85 seconds** of blocked event loop inside a check whose only output is a
+ *   warning. With `seen` it returns immediately.
+ *
+ * `seen` is consulted globally within one call, not per path: a node that did
+ * not mention the field the first time will not mention it the second, and one
+ * that did short-circuits the whole walk through `some`. The one case that gets
+ * a less precise answer is a node first reached with the depth budget already
+ * spent and met again higher up — it stays `false`. That needs a filter nested
+ * past 32 levels *and* sharing a node across them, which is well beyond what
+ * either bound is protecting.
  */
 const MAX_FILTER_DEPTH = 32
 
 export function filterMentionsField(filter: unknown, field: string, depth = MAX_FILTER_DEPTH): boolean {
+  return walkFilterForField(filter, field, depth, new WeakSet())
+}
+
+function walkFilterForField(
+  filter: unknown,
+  field: string,
+  depth: number,
+  seen: WeakSet<object>
+): boolean {
   if (depth <= 0) {
     return false
+  }
+
+  if (typeof filter === 'object' && filter !== null) {
+    if (seen.has(filter)) {
+      return false
+    }
+    seen.add(filter)
   }
 
   if (Array.isArray(filter)) {
@@ -112,11 +144,11 @@ export function filterMentionsField(filter: unknown, field: string, depth = MAX_
     if (typeof filter[0] === 'string') {
       return filter[0] === field
     }
-    return filter.some(node => filterMentionsField(node, field, depth - 1))
+    return filter.some(node => walkFilterForField(node, field, depth - 1, seen))
   }
 
   if (typeof filter === 'object' && filter !== null && 'conditions' in filter) {
-    return filterMentionsField((filter as { conditions: unknown }).conditions, field, depth - 1)
+    return walkFilterForField((filter as { conditions: unknown }).conditions, field, depth - 1, seen)
   }
 
   return false

--- a/test/integration/core/v3-tail-object-filter.unit.spec.ts
+++ b/test/integration/core/v3-tail-object-filter.unit.spec.ts
@@ -392,6 +392,41 @@ describe('the filter walk is bounded by work, not only by depth', () => {
     expect(Date.now() - started).toBeLessThan(budgetMs)
   })
 
+  it('finds a field behind a node the long path could not look inside', () => {
+    // The memo has to distinguish two very different `false`s: "this subtree
+    // does not mention the field" and "the budget ran out before we could tell".
+    // A plain visited set stores them as one, and the truncated answer wins.
+    //
+    // `a` is reached twice: down the 30-deep chain with one level of budget
+    // left — too little to look inside it — and directly from the top with 31
+    // levels to spare. `some` walks the chain first.
+    const a: unknown[] = [['x', '=', 1]]
+    let chain: unknown = a
+    for (let index = 0; index < 30; index++) {
+      chain = [chain]
+    }
+
+    expect(filterMentionsField([chain, a], 'x')).toBe(true)
+    // The same objects in the other order. A memo that kept a truncated answer
+    // would disagree with itself here, which is how this was found.
+    expect(filterMentionsField([a, chain], 'x')).toBe(true)
+  })
+
+  it('returns at once for a shared-node DAG built from logic groups', () => {
+    // The two cases above are plain arrays, and a memo that only recorded array
+    // nodes passed every test in this file. A group — `{ logic, conditions }`,
+    // which is what `FilterV3.or()` returns — is the other half of what this
+    // walk descends through, and the shape a caller actually reaches for.
+    let group: unknown = { logic: 'and', conditions: [['x', '=', 1]] }
+    for (let index = 0; index < probeDepth; index++) {
+      group = { logic: 'or', conditions: [group, group] }
+    }
+
+    const started = Date.now()
+    expect(filterMentionsField(group, 'id', probeDepth + 2)).toBe(false)
+    expect(Date.now() - started).toBeLessThan(budgetMs)
+  })
+
   it('still finds a field that sits behind a shared node', () => {
     // The visited set must not swallow a real match. `shared` is reached twice;
     // the first visit has to answer truthfully, and `some` short-circuits before

--- a/test/integration/core/v3-tail-object-filter.unit.spec.ts
+++ b/test/integration/core/v3-tail-object-filter.unit.spec.ts
@@ -17,6 +17,7 @@
  * `*.unit.spec.ts` — no real Bitrix24 portal required (axios is mocked).
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
+import { filterMentionsField } from '../../../packages/jssdk/src/core/actions/v3/_keyset-paginate'
 import { ApiVersion, B24Hook, FilterV3, ParamsFactory } from '../../../packages/jssdk/src/'
 
 const EMPTY_PAGE = {
@@ -340,5 +341,120 @@ describe('the cursor field hiding inside a logic group', () => {
     })
 
     expect(warning).not.toHaveBeenCalledWith(expect.stringContaining('must not appear in `filter`'))
+  })
+})
+
+/**
+ * `filterMentionsField` is bounded twice, and the two bounds answer different
+ * questions. `MAX_FILTER_DEPTH` stops the walk going too *far*; the visited set
+ * stops it doing too *much*. The tests below are the second one: every case here
+ * is within the depth limit and would still not finish without it.
+ *
+ * Measured against the shipped depth of 32 before the visited set existed, the
+ * first case took **85 seconds** of blocked event loop — inside a check whose
+ * only output is a warning. The assertions are on wall-clock time because that
+ * is the property that was broken.
+ *
+ * They run at an explicit depth of 24 rather than the shipped 32, so that
+ * removing the visited set makes them **fail** rather than hang: at 24 the old
+ * walk took 223 ms for the cycle and 386 ms for the DAG — measured — against a
+ * 100 ms budget it now clears in under one. At 32 the same cycle took 85
+ * seconds, which is the number worth knowing and the wrong number to build a
+ * test around.
+ */
+describe('the filter walk is bounded by work, not only by depth', () => {
+  const budgetMs = 100
+  const probeDepth = 24
+
+  it('returns at once for a node that points at itself twice', () => {
+    // `T(d) = 1 + 2·T(d − 1)`. The single-edge version of this — the one the
+    // docstring used to give as *the* example — is linear and was always fine,
+    // which is exactly why the gap went unnoticed.
+    const twoEdge: unknown[] = []
+    twoEdge.push(twoEdge, twoEdge)
+
+    const started = Date.now()
+    expect(filterMentionsField(twoEdge, 'id', probeDepth)).toBe(false)
+    expect(Date.now() - started).toBeLessThan(budgetMs)
+  })
+
+  it('returns at once for a shared-node DAG with no cycle at all', () => {
+    // No node points back at an ancestor here, so a path-based cycle check would
+    // not help: the cost comes from one node being reachable by two edges, at
+    // every level.
+    let node: unknown = [['x', '=', 1]]
+    for (let index = 0; index < probeDepth; index++) {
+      node = [node, node]
+    }
+
+    const started = Date.now()
+    expect(filterMentionsField(node, 'id', probeDepth + 2)).toBe(false)
+    expect(Date.now() - started).toBeLessThan(budgetMs)
+  })
+
+  it('still finds a field that sits behind a shared node', () => {
+    // The visited set must not swallow a real match. `shared` is reached twice;
+    // the first visit has to answer truthfully, and `some` short-circuits before
+    // the second is ever asked.
+    const shared = FilterV3.or(['id', '=', 1])
+    expect(filterMentionsField([shared, shared], 'id')).toBe(true)
+  })
+
+  it('still finds a field on the second branch when the first shares a node', () => {
+    const shared = FilterV3.or(['severity', '=', 'ERROR'])
+    expect(filterMentionsField([shared, shared, FilterV3.or(['id', '=', 1])], 'id')).toBe(true)
+  })
+
+  it('answers no for a shared node that does not mention the field', () => {
+    // The other half of the visited set, and the one the cases above cannot
+    // reach: they all end in `true`, so a `seen.has(node) → return true` would
+    // pass every one of them. Here the revisit is the only thing that could
+    // produce a `true`, and it must not.
+    const shared = FilterV3.or(['severity', '=', 'ERROR'])
+    expect(filterMentionsField([shared, shared], 'id')).toBe(false)
+  })
+
+  it('answers the same filter the same way twice', () => {
+    // The visited set has to be per call. A module-level one would still pass
+    // every case above — each builds its own filter — and would then answer
+    // `false` to the second question about any object it had already walked.
+    // Reusing one `params` object across two `callTail` calls is ordinary, so
+    // this is the shape that would break in real code and nowhere in a test.
+    const filter = [FilterV3.or(['id', '=', 1])]
+
+    expect(filterMentionsField(filter, 'id')).toBe(true)
+    expect(filterMentionsField(filter, 'id')).toBe(true)
+
+    // And the set is scoped to one question, not to the object: asking about a
+    // different field has to walk the same nodes again.
+    const both = [FilterV3.or(['id', '=', 1], ['severity', '=', 'ERROR'])]
+    expect(filterMentionsField(both, 'id')).toBe(true)
+    expect(filterMentionsField(both, 'severity')).toBe(true)
+  })
+
+  it('still stops at MAX_FILTER_DEPTH when nothing is shared', () => {
+    // The visited set alone terminates any finite structure, which makes it easy
+    // to stop noticing that the depth bound does separate work: a chain of
+    // distinct nodes shares nothing, so only depth can end it. Nesting past the
+    // limit answers `false` even though the field is really down there — the
+    // documented trade, and the reason both bounds are kept.
+    const deep = (levels: number): unknown => {
+      let node: unknown = ['id', '>', 1]
+      for (let index = 0; index < levels; index++) {
+        node = [node]
+      }
+      return node
+    }
+
+    expect(filterMentionsField(deep(5), 'id')).toBe(true)
+    expect(filterMentionsField(deep(40), 'id')).toBe(false)
+  })
+
+  it('keeps answering for the shapes a caller actually writes', () => {
+    expect(filterMentionsField([['id', '>', 1]], 'id')).toBe(true)
+    expect(filterMentionsField([FilterV3.or(['id', '>', 1])], 'id')).toBe(true)
+    expect(filterMentionsField(FilterV3.or(['id', '>', 1]), 'id')).toBe(true)
+    expect(filterMentionsField([['severity', '=', 'id']], 'id')).toBe(false)
+    expect(filterMentionsField(undefined, 'id')).toBe(false)
   })
 })


### PR DESCRIPTION
Follow-up to #489, on code that PR introduced. I wrote it, including the comment that got it
wrong.

## What breaks

`filterMentionsField` walks a caller-supplied filter to warn when the tail cursor field also
appears in it. It is bounded by `MAX_FILTER_DEPTH = 32`, and its docstring says that bound
handles a self-referential filter.

It handles the example the docstring gives — `const f = { conditions: [] };
f.conditions.push(f)`, one node pointing at itself once, which is linear and returns in under a
millisecond. That is exactly why the gap went unnoticed.

It does not handle a node reachable by **two** edges. The recursion is then
`T(d) = 1 + 2·T(d − 1)`:

```js
const a = []
a.push(a, a)
filterMentionsField(a, 'id')
```

| depth | time |
|---|---|
| 16 | 4.7 ms |
| 20 | 14.3 ms |
| 24 | 223.0 ms |
| 26 | 893.5 ms |
| 28 | 4.9 s |
| 30 | 20.7 s |
| **32 — the shipped bound** | **85.0 s** |

85 seconds of synchronous, blocked event loop inside a check whose only output is a warning.
Measured directly at the shipped depth, not extrapolated. (Re-measured on a second, slower
machine during review: 8.4 s at depth 28 there against 4.9 s here — the absolute numbers move
with the hardware, the doubling per level does not.)

**A cycle is not required.** The cost comes from sharing, not from looping back:

```js
let node = [['x', '=', 1]]
for (let i = 0; i < 32; i++) node = [node, node]
```

No node points at an ancestor, so a path-based cycle check — mark on entry, unmark on exit —
would not close this. Measured on the old code: 8.3 ms at depth 16, 23.7 ms at 20, **386 ms at
24**, doubling per level from there.

Depth bounds how far the walk travels. It says nothing about how much work it does. The
docstring conflated the two.

## Exposure

`JSON.parse` cannot produce shared references, so a filter that arrived over the wire cannot
trigger this. It needs a filter assembled programmatically — which is what a server does when
it builds a v3 filter from client input, and also what any caller does who reuses one
sub-filter object across two `FilterV3.or()` branches. That narrows the exposure without
removing it, and the walk is reached with raw caller data at `call-tail.ts:96` and
`fetch-tail.ts:99`; `assertTailFilter` passes arrays straight through without cloning or
normalising, so nothing between the caller's object and this walk can break the aliasing.

## What changes

A memo of visited nodes, threaded through the walk. Both shapes above then return immediately —
386 ms → 0.0 ms for the DAG at depth 24, measured before and after on the same machine.

**The memo is keyed by depth, not by identity alone.** This is the correction that came out of
review; the first version of this PR used a plain `WeakSet` and was wrong. A `false` from this
walk means one of two different things — "this subtree does not mention the field", or "the
budget ran out before we could tell" — and a set that records only *visited* stores them as the
same answer. A node explored down a long path, with too little budget left to look inside it,
then poisons a later visit that had plenty:

```js
const a = [['x', '=', 1]]
let chain = a
for (let i = 0; i < 30; i++) { chain = [chain] }

filterMentionsField([chain, a], 'x') // was false — wrong
filterMentionsField([a, chain], 'x') // true
```

The same objects in the other order, a different answer. Total depth there is about 31, inside
the shipped bound — so this was **not** the precision loss the first version documented as
acceptable. That documented case cannot happen at all: `depth <= 0` returns before the node is
ever marked, so a node reached with the budget already spent is never recorded. The docstring
described the one unreachable case and was silent about the reachable one.

So the memo now records the depth each node was explored with, and trusts a cached `false` only
when that visit had at least as much budget as this one. The shapes this PR exists for still
collapse, because every revisit in them happens at the same depth or shallower.

`MAX_FILTER_DEPTH` stays. The two bounds answer different questions and neither replaces the
other: depth stops a legitimately deep nesting — a chain of distinct nodes shares nothing, so
only depth can end it — while the memo stops the same node being explored twice over. The
public signature is unchanged: `filterMentionsField(filter, field, depth?)` delegates to an
internal walker that carries the memo, which is built per call and never escapes it.

## Tests

Ten cases in `test/integration/core/v3-tail-object-filter.unit.spec.ts`, beside the existing
single-edge cycle test.

Two are the blow-up shapes, asserted on wall-clock time — that is the property that was broken.
They run at an explicit depth of **24**, not the shipped 32, so that removing the memo makes
them *fail* rather than hang: measured, the whole file then reddens in **732 ms** on an
assertion. At 32 the same cycle takes 85 seconds, which is the number worth knowing and the
wrong number to build a test around. Measured on the reviewing machine, the passing path costs
4–6 ms against a 100 ms budget, so the margin is three orders of magnitude and CI-safe.

The rest guard the other direction, because a memo is exactly the kind of change that can start
swallowing real answers or inventing them:

- **the asymmetric-depth case above**, in both element orders — the one the first version got
  wrong;
- a field behind a shared node still reports `true`;
- a field on a later branch is still found when an earlier branch shares a node;
- **a shared node that does not mention the field reports `false`** — every other case here ends
  in `true`, so `seen.has(node) → return true` would have passed all of them;
- **a chain of distinct nodes deeper than `MAX_FILTER_DEPTH` still answers `false`** — the memo
  alone terminates any finite structure, which makes it easy to stop noticing that the depth
  bound does separate work;
- **the same filter asked twice gives the same answer**, and asking about a different field
  walks the same nodes again — a memo hoisted out of the call would pass every case above and
  break only in real code, where one `params` object is reused across two `callTail` calls;
- a shared-node DAG built from logic groups rather than plain arrays, since every pathological
  shape here was an array;
- the ordinary shapes (bare triple, group in an array, bare group, a field name appearing as a
  *value*, `undefined`) answer as before.

Mutations run rather than imagined: dropping the depth key from the memo — that is, the first
version of this PR — reddens the asymmetric-depth case; removing the memo entirely reddens two;
`return true` on a revisit reddens three; dropping the depth bound reddens one.

One thing worth recording because it is *not* testable: a memo that recorded only arrays and
skipped group objects passes everything. It is indistinguishable, because a shared group always
shares its own `conditions` array, and that array is caught one level down. The group DAG case
above is honest coverage of group descent, not a killer for that mutation.

## Checks

- `pnpm vitest run --project jsSdk:unit` — 725 passed, 0 failed
- `pnpm lint` — clean
- `pnpm run package-jssdk:typecheck` — clean
- `docs-typecheck` / `skills-typecheck-blocks` — 172 / 86 blocks, 0 errors
- `pnpm docs:lint-pages:strict` — clean

## How it was found

The blow-up came from an adversarial review of an unrelated change to the same file, by a
reviewer asked specifically to look for unbounded paths. The wrong-answer bug in the fix came
from the review panel on this PR — two reviewers found it independently, and the repro was run
before it was believed.

Rebased onto `main` after #493 and #497 landed — both touch this file, neither touches this
function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr