### PR TITLE
test(actions): pin what the cursor-stall guard's tests could not tell apart, and document the upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Bug Fixes
 
+* **A list or tail walk whose cursor stops advancing now fails instead of running for ever.** When the server does not apply the page condition, the same full page keeps arriving and nothing in the loops noticed: the `restApi:v3` driver stops on a page *shorter* than the largest it has seen, the `restApi:v2` loops stop on `length < 50`, and a repeated full page is neither. The streaming helpers yielded the same rows for ever; the eager ones grew an array until the process died.
+
+    Measured on `restApi:v2` `tasks.task.list` with `idKey: 'id'` and no `cursorIdKey`: three pages, 150 rows, 50 unique, the cursor reading 3 every time — the response spells the id lowercase while the filter accepts it uppercase, so `>id` matches nothing and is dropped. The two halves of that mistake fail in opposite ways: leave `idKey` at its default `'ID'` and the cursor cannot be read, so the walk warns and stops after 50 rows; set `idKey: 'id'` alone and the read works while the request condition is ignored. Only the second one used to hang.
+
+    `JSSDK_ACTION_CURSOR_STALLED` covers `callList` / `fetchList` on **both** API versions and `callTail` / `fetchTail` on v3, with the remedy written in each action's own vocabulary — the list walkers have `idKey` / `cursorIdKey`, the tail ones have `cursorField`.
+
+    **Worth knowing:** this **rejects** rather than resolving with a partial `Result`, so a `callList` / `callTail` that used to hang now needs a `try`/`catch`. For the list walkers everything collected at that point is page one repeated, and handing it back would return duplicates that read as data. `fetchList` / `fetchTail` have already yielded every page they read, the repeated one included, so a consumer that persisted them has to undo that. A `cursorField` naming an object- or array-valued field is now treated as no cursor at all — it takes the existing warn-and-stop path, because two distinct references are never equal and would have defeated the guard in exactly the case it exists for.
+
 * **`callTail` / `fetchTail` now refuse the `restApi:v2` object filter dialect before sending.** `{ '>id': 100 }` was forwarded to the portal, which answered "unknown filter condition" in wording that never names the dialect — one round trip later and with nothing to act on. A `FilterV3` logic group stays allowed there: those two forward `filter` untouched, and the portal accepts a bare group as the whole filter (measured). `callList` / `fetchList` still require an array, because they append the page condition to it — and when they see a group they now say so instead of reporting it as the v2 dialect.
 
     Two codes rather than one: `JSSDK_ACTION_V3_LIST_FILTER_NOT_ARRAY` for the list walkers, where a non-array really is the fault, and the new `JSSDK_ACTION_V3_TAIL_FILTER_INVALID` for the tail ones, where a non-array is valid and only the v2 dialect is refused.

--- a/docs/content/docs/1.getting-started/3.migration/3.within-2x.md
+++ b/docs/content/docs/1.getting-started/3.migration/3.within-2x.md
@@ -1,0 +1,96 @@
+---
+title: Behaviour changes inside 2.x
+description: 'Changes within the 2.x line that need a change on your side even though no API was removed — what breaks, how to tell, and what to do.'
+navigation.title: Inside 2.x
+audited: 2026-09-07
+links:
+  - label: CHANGELOG
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/CHANGELOG.md
+  - label: Cursor-stall guard
+    iconName: GitHubIcon
+    to: https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/actions/_cursor-stalled.ts
+---
+
+The other two guides on this page are about symbols that are removed. This one
+is about the smaller set of changes that removed nothing and still need
+something from you: a call that used to return now throws, or a value that used
+to be ignored now means something.
+
+::note
+Everything here ships inside the `2.x` line, so `pnpm up @bitrix24/b24jssdk`
+picks it up without a major-version step. That is exactly why it is worth
+reading — nothing about the upgrade signals that behaviour moved.
+::
+
+## 2.3.0 — a stalled pagination cursor now throws
+
+**What changed.** `callList` / `fetchList` (both API versions) and `callTail` /
+`fetchTail` (v3) now raise `SdkError`{lang="ts-type"} with code
+`JSSDK_ACTION_CURSOR_STALLED` when a full page comes back and the cursor read
+from it equals the one just sent. That means the server did not apply the page
+condition, so the same page will keep arriving.
+
+**What it replaces.** Not an error — a hang. The walk had no way to end: the
+page is full, so no end-of-data check fires. `fetchList` / `fetchTail` yielded
+the same rows for ever; `callList` / `callTail` grew an array until the process
+ran out of memory.
+
+**Who is affected.** Anyone whose `idKey` / `cursorIdKey` pair does not match
+the method. The measured case is `restApi:v2` `tasks.task.list` with
+`idKey: 'id'` and no `cursorIdKey`: the response spells the id lowercase, the
+filter accepts it uppercase, so `>id` matches nothing and is dropped.
+
+**What to do.** Fix the configuration — that is what the error text tells you —
+and, if you call the eager helpers, add a `try`/`catch`:
+
+```ts
+import { B24Hook, SdkError } from '@bitrix24/b24jssdk'
+
+const b24 = B24Hook.fromWebhookUrl('https://your-portal.bitrix24.ru/rest/1/SECRET')
+
+try {
+  const response = await b24.actions.v2.callList.make({
+    method: 'tasks.task.list',
+    idKey: 'id', // the id as the response spells it
+    cursorIdKey: 'ID', // the field the request sorts and filters by
+    customKeyForResult: 'tasks'
+  })
+  console.log(response.getData())
+} catch (error) {
+  if (error instanceof SdkError && error.code === 'JSSDK_ACTION_CURSOR_STALLED') {
+    // the walk was repeating one page — nothing collected is worth keeping
+    console.error('pagination is broken for this method, check idKey/cursorIdKey')
+  }
+  else {
+    throw error
+  }
+}
+```
+
+::caution
+`callList` and `callTail` are documented elsewhere as methods that return a
+`Result`{lang="ts-type"} rather than throwing. That is still true of **portal**
+errors — check `isSuccess` for those. It is not true of the guards that make the
+walk itself impossible, this one included: those reject the promise. If you have
+code that awaits `callList` without a `try`/`catch` because the docs said it
+never throws, that code needs the `catch` now.
+::
+
+**If you stream, the duplicates are already yours.** `fetchList` / `fetchTail`
+yield each page as it arrives, so by the time this throws your consumer has
+already seen the repeated page. A `catch` that resumes from the last saved id is
+right for a failed page request and wrong here — roll the persisted chunks back
+instead.
+
+**One more shape.** A `cursorField` naming an object- or array-valued field is
+now treated as no cursor at all: the walk logs a `warning` and stops, where
+before it paged for ever (two distinct references are never equal, so the guard
+alone would not have caught it). Point `cursorField` at a scalar.
+
+## See also
+
+- [Error codes and handling](/docs/working-with-the-rest-api/error-codes/) — the
+  full table, including what each walker's remedy text names.
+- [CHANGELOG](https://github.com/bitrix24/b24jssdk/blob/main/CHANGELOG.md) — every
+  change in the line, not only the ones that need action.

--- a/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
+++ b/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
@@ -239,6 +239,15 @@ await b24.actions.v3.callTail.make({
 Wrapping in an array works on all four walkers, so wrap if you would rather keep
 one habit than remember the split.
 
+One failure the filter shape cannot cause but is easy to confuse with it: if a
+full page comes back and the cursor read from it equals the one just sent, the
+page condition was dropped and the walk can never end. All six walkers — these
+four plus the two `restApi:v2` list ones — throw `SdkError`{lang="ts-type"} with
+code `JSSDK_ACTION_CURSOR_STALLED` rather than repeating one page for ever. On
+the tail walkers the usual cause is a `cursorField` whose values are not unique,
+or an `initialValue` the server echoes straight back. See
+[Errors](/docs/working-with-the-rest-api/error-codes/) for the full remedy.
+
 ## Side-by-side: the same filter in v2 and v3
 
 The dialect is the point here, not the entity — and the two halves below cannot

--- a/docs/content/docs/2.working-with-the-rest-api/6.errors.md
+++ b/docs/content/docs/2.working-with-the-rest-api/6.errors.md
@@ -35,7 +35,7 @@ The SDK raises errors through two related classes:
 
 Method-style results that don't throw — `Call`, `CallList`, `Batch`, `BatchByChunk` — surface **portal-side** failures through `Result`/`AjaxResult`: check `.isSuccess` and read `.getErrorMessages()`. `FetchList`, by contrast, **does** throw on failure (the generator can't complete partially).
 
-That split is about REST errors, not about every failure. `CallList` and `CallTail` also raise `SdkError` for the handful of conditions that make the walk itself impossible — a `filter` they cannot extend, and a cursor that stops advancing (`JSSDK_ACTION_CURSOR_STALLED`). Those reject the promise rather than resolving with a `Result`, so wrap the call in `try`/`catch` as well as checking `isSuccess` if you want to handle both.
+That split is about REST errors, not about every failure. `CallList` and `CallTail` also raise `SdkError` for the handful of conditions that make the walk itself impossible — a `filter` they cannot extend, and a cursor that stops advancing (`JSSDK_ACTION_CURSOR_STALLED`). Those reject the promise rather than resolving with a `Result`, so wrap the call in `try`/`catch` as well as checking `isSuccess` if you want to handle both. If you are upgrading inside the 2.x line and this is new to you, see [Behaviour changes inside 2.x](/docs/getting-started/migration/within-2x/).
 
 ## Which field failed: `AjaxError.validation`
 

--- a/test/integration/core/cursor-stalled.unit.spec.ts
+++ b/test/integration/core/cursor-stalled.unit.spec.ts
@@ -120,7 +120,16 @@ describe('a cursor that does not move', () => {
         method: 'tasks.task.list',
         idKey: 'id',
         customKeyForResult: 'tasks'
-      })).rejects.toMatchObject({ code: STALLED })
+      })).rejects.toMatchObject({
+        code: STALLED,
+        // 500, not the 400 the client-side guards use: from inside the loop
+        // there is no way to tell a caller who named the wrong field from a
+        // portal that ignores the condition on this method, so reporting a
+        // caller error would be a guess. Asserted because the choice is
+        // argued for at length in `_cursor-stalled.ts` and nothing else pinned
+        // it — 400 passed the whole suite.
+        status: 500
+      })
 
       // Two requests: the first establishes the cursor, the second returns it
       // unchanged. Nothing beyond that is paid for.
@@ -128,6 +137,35 @@ describe('a cursor that does not move', () => {
       // Not the `no numeric id` branch — that one is a warning, and confusing
       // the two is the whole reason this test names the configuration.
       expect(warnings).toEqual([])
+    })
+
+    it('the v2 message names the v2 action and the option to check', async () => {
+      // The v2 call sites pass their own `actionLabel` literal, and nothing
+      // read the message on this path: replacing either label with a nonsense
+      // string passed the whole suite.
+      const { make } = ignoringServer({ customKey: 'tasks', page: FULL_V2_PAGE })
+      const { logger } = makeLogger()
+
+      const error = await new CallListV2(b24V2(make), logger).make<Item>({
+        method: 'tasks.task.list',
+        idKey: 'id',
+        customKeyForResult: 'tasks'
+      }).catch((error_: Error) => error_)
+
+      expect((error as Error).message).toContain('callList.make:')
+      expect((error as Error).message).toContain('cursorIdKey')
+
+      const streaming = ignoringServer({ customKey: 'tasks', page: FULL_V2_PAGE })
+      const fetchError = await (async () => {
+        for await (const _chunk of new FetchListV2(b24V2(streaming.make), makeLogger().logger).make<Item>({
+          method: 'tasks.task.list',
+          idKey: 'id',
+          customKeyForResult: 'tasks'
+        })) { /* drain until it throws */ }
+      })().catch((error_: Error) => error_)
+
+      expect((fetchError as Error).message).toContain('fetchList.make:')
+      expect((fetchError as Error).message).toContain('cursorIdKey')
     })
 
     it('fetchList rejects too, after the consumer already holds the duplicates', async () => {
@@ -179,16 +217,22 @@ describe('a cursor that does not move', () => {
       const action = new FetchListV3(b24V3(make), logger)
 
       const seen: unknown[] = []
-      await expect((async () => {
+      const thrown = await (async () => {
         for await (const chunk of action.make<Item>({
           method: 'main.eventlog.list',
           customKeyForResult: 'items'
         })) {
           seen.push(...chunk.map(row => row['id']))
         }
-      })()).rejects.toMatchObject({ code: STALLED })
+      })().catch((error_: Error) => error_)
+
+      expect(thrown).toMatchObject({ code: STALLED })
 
       expect(seen).toEqual(['1', '2', '1', '2'])
+      // The streaming helpers carry their own `actionLabel`; only the eager
+      // ones had their wording checked, so a wrong label on either survived.
+      expect((thrown as Error).message).toContain('fetchList.make:')
+      expect((thrown as Error).message).toContain('cursorIdKey')
     })
 
     it('callTail rejects, and the message names cursorField — not cursorIdKey', async () => {
@@ -218,7 +262,7 @@ describe('a cursor that does not move', () => {
       const action = new FetchTailV3(b24V3(make), logger)
 
       const seen: unknown[] = []
-      await expect((async () => {
+      const thrown = await (async () => {
         for await (const chunk of action.make<Item>({
           method: 'main.eventlog.tail',
           params: { select: ['id'] },
@@ -226,10 +270,55 @@ describe('a cursor that does not move', () => {
         })) {
           seen.push(...chunk.map(row => row['id']))
         }
-      })()).rejects.toMatchObject({ code: STALLED })
+      })().catch((error_: Error) => error_)
+
+      expect(thrown).toMatchObject({ code: STALLED })
 
       expect(seen).toEqual(['1', '2', '1', '2'])
+      expect((thrown as Error).message).toContain('fetchTail.make:')
+      expect((thrown as Error).message).toContain('cursorField')
+      expect((thrown as Error).message).not.toContain('cursorIdKey')
     })
+  })
+
+  it('a cursor that changes only its type is movement, not a stall', async () => {
+    // `===` rather than `==`, and this is the input that tells them apart:
+    // `2 == '2'` is true, so a loose comparison would call the second page a
+    // stall and throw on a walk that is making progress. The cost of being
+    // strict is one extra request when a server changes only the type of an
+    // identical cursor — and the guard still fires on the page after that,
+    // which is the second half of what this pins.
+    //
+    // Page 1 ends at the number 2, page 2 at the string '2', page 3 at '2'
+    // again: strict equality pages through the first two and stalls on the
+    // third. A loose one would have thrown after page 2 and never reached it.
+    const pages: Item[][] = [
+      [{ id: 1 }, { id: 2 }],
+      [{ id: '1' }, { id: '2' }],
+      [{ id: '1' }, { id: '2' }]
+    ]
+    const calls: unknown[] = []
+    const make = async (callOpts: { params: unknown }) => {
+      calls.push(structuredClone(callOpts.params))
+      const slice = pages[calls.length - 1] ?? []
+      return {
+        isSuccess: true,
+        getData: () => ({ result: { items: slice } }),
+        getErrorMessages: () => [],
+        errors: [] as Array<[number, Error]>
+      } as never
+    }
+
+    const { logger } = makeLogger()
+    const error = await new CallTailV3(b24V3(make), logger).make<Item>({
+      method: 'main.eventlog.tail',
+      params: { select: ['id'] },
+      customKeyForResult: 'items'
+    }).catch((error_: Error) => error_)
+
+    // Reached the third page: the type flip was not mistaken for a stall.
+    expect(calls).toHaveLength(3)
+    expect(error).toMatchObject({ code: STALLED })
   })
 
   it('a cursor field that is not a scalar stops the walk instead of defeating it', async () => {


### PR DESCRIPTION
Follow-up to #493, from a review panel run over the merged commit.

## Mutations that survived #493's suite

Each of these is a decision the code argues for in a comment, and no input in
the seven existing cases could tell it from its opposite:

| mutation | result before this PR |
| --- | --- |
| `next === cursor` → `next == cursor` (all three insertion points) | passed |
| `status: 500` → `status: 400` in `cursorStalledError` | passed |
| the action label on either `restApi:v2` walker → nonsense | passed |
| `actionLabel` on `fetchList` / `fetchTail` (v3) → nonsense | passed |

The last two are the same gap seen twice: only the eager `callList` / `callTail`
tests read `.message`, so the four walkers that supply their own label had none
of it checked — and "the message names the right options" is the finding #493
itself was reworked to fix.

## What this adds

**The input that separates `===` from `==`.** A server whose cursor changes only
its type — `2`, then `'2'` — is making progress; `2 == '2'` is true, so a loose
comparison would throw on it. The new case walks three pages: the type flip is
followed through, and the guard fires on the page after it, which pins the cost
the comment describes ("the guard fires on the next page once the type settles")
as well as the behaviour.

**`status: 500`,** asserted once. `_cursor-stalled.ts` spends a paragraph on why
this is not the 400 the client-side guards use; nothing held it.

**Message wording on the four walkers that had none** — `callList.make:` /
`fetchList.make:` with `cursorIdKey` on the v2 pair and on v3 `fetchList`,
`fetchTail.make:` with `cursorField` and **not** `cursorIdKey` on v3 `fetchTail`.

All four mutations above now redden, verified one at a time with the tree
restored between each.

## Documenting the upgrade

The decision on #493's release type is to keep it a `fix` and let the
documentation carry the warning. So it has to actually carry it:

- **`CHANGELOG.md`** — #493 shipped without an entry, the first in this series to
  do so. Added, including the part callers need most: this **rejects** where the
  walk used to hang, so a `callList` / `callTail` that relied on it never
  throwing now needs a `try`/`catch`.
- **A new migration guide, `Behaviour changes inside 2.x`.** The two existing
  guides are about removed symbols (v0 → v1, and what 3.0.0 drops); neither has
  a home for a change that removes nothing and still needs something from the
  caller. `pnpm up` inside 2.x picks this up and nothing about the upgrade
  signals that a call which used to hang now rejects. The first entry is that
  guard: what it replaces, who is affected, the `try`/`catch` the eager helpers
  now need, why a streaming consumer has to roll back rather than resume, and
  the `cursorField`-must-be-a-scalar change. Linked from the error page.
- **`5.filtering.md`** — the only page that covers the tail walkers in any depth
  (the tail actions still have no page of their own, #492) now mentions
  `JSSDK_ACTION_CURSOR_STALLED` and what triggers it there.

## Reviewed and dismissed

Two reviewers independently reported a false positive: the seed cursor (`0`, or
a caller's `initialValue`) coinciding with the first page's last value, throwing
on a legitimate walk. **It cannot happen.** The request is a pure function of the
cursor, so an unchanged cursor produces a byte-identical next request and
therefore the same response — the walk had no way forward to be denied. What is
real in the report is that the tail hint should name the likely trigger, and
`CURSOR_STALLED_HINT_TAIL` already does ("a block of rows sharing one value is
enough to stall the walk… with `order: 'DESC'`, check `initialValue` too").

## Not fixed here — filed instead

- #495 — a cursor cycling through two values still loops for ever.
- #496 — a stalled page shorter than the largest one seen ends the v3 walk
  silently, because the `maxPageSize` stop runs first. Nothing pins that
  ordering either.

## Checks

- `pnpm vitest run --project jsSdk:unit` — 715 passed, 0 failed
- `pnpm lint` — clean
- `pnpm docs:lint-pages:strict`, `docs-link-check`, `md-internal-links` — clean
- `docs-typecheck` / `skills-typecheck-blocks` — 172 / 86 blocks, 0 errors

The new page's inbound link was verified by mutation: pointing it at a
non-existent route makes `docs-link-check` fail. Worth knowing for future work —
`md-internal-links` does **not** cover `docs/content`, only `AGENTS.md`,
`SECURITY.md` and `.github/contributing/*.md`, so it is `docs:lint-links` that
guards site routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr