### PR TITLE
docs: refresh the audited stamps the #494 merge left behind

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallListV3.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 3.'
 category: 'actions'
-audited: 2026-09-07
+audited: 2026-09-08
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: CallList

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: FetchListV3.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 3 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-09-07
+audited: 2026-09-08
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: FetchList


### PR DESCRIPTION
**`main` is red.** `docs-lint` fails on it right now, and this restores it.

## What happened

`docs-lint` exits non-zero on a freshness warning, not only on an error. #494's own CI was
green on 2026-09-07; the squash commit that landed it is dated 2026-09-08. So the two pages
citing `packages/jssdk/src/core/actions/v3/_keyset-paginate.ts` in their `links:` —
`2.call-list-rest-api-ver3.md` and `2.fetch-list-rest-api-ver3.md`, both stamped
`audited: 2026-09-07` — acquired a source newer than their stamp at the instant of the merge,
and nothing ran between the green check and the red `main`.

This is a gap in the gate rather than an accident of this particular PR: **any** PR whose
branch check passes late in the day can redden `main` when its squash commit crosses midnight,
and no check on the PR can see that coming. Worth a follow-up (below); this PR just unblocks
the branch.

## What was actually checked

Both pages were re-read against the current file before the dates moved — the stamp is a claim
about the whole page, and bumping it without reading is what makes the gate meaningless.

#494 changed exactly one thing in that file: `filterMentionsField`, the walk behind the
"cursor field must not appear in `filter`" warning on the **tail** actions. Neither of these
pages documents the tail walkers or that warning. What they do document about the shared
driver still holds:

- the injected `[cursorIdKey, '>', id]` page condition;
- the end-of-data stop on "a page shorter than the largest page seen so far", including why it
  keys on the returned page size rather than the requested `limit`;
- the `JSSDK_ACTION_CURSOR_STALLED` limitation added by #493;
- the `filter`-must-be-an-array limitation and the `nextCursor`-is-informational note.

So the bump is honest, not a rubber stamp.

## Checks

- `pnpm docs:lint-pages:strict` — 0 errors, **0 warnings** (was 2)
- `docs-link-check` — 0 broken links

## Follow-up worth filing

The date-crossing hole above. Options: compare the source's commit date against the stamp with
a day of tolerance, or have the gate look at the merge-base rather than the raw `git log` date.
Either way it should not be possible for a green PR to redden `main` by the clock alone. Happy
to open the issue if you want it tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_