### PR TITLE
feat(platform)!: drop Node 20, which has been EOL since April

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,9 @@ jobs:
     # Test on every supported non-EOL Node line so the runtimes the SDK
     # advertises in `engines` are actually exercised (#174). 22 = the line the
     # publish workflows build the artifact on (lowest supported + validated);
-    # 24 = newest active LTS. (Node 20 is still in `engines` but EOL and slated
-    # for removal in #312, so it is intentionally not in the matrix.)
+    # 24 = newest active LTS. Since #312 dropped Node 20 from `engines`, the
+    # matrix and the advertised floor finally agree — nothing is advertised that
+    # this job does not run.
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### ⚠ BREAKING CHANGES
 
+* **Node 20 is no longer supported** (#312). `engines.node` moves from
+  `^20.0.0 || >=22.0.0` to `>=22.0.0` in both `@bitrix24/b24jssdk` and
+  `@bitrix24/b24jssdk-nuxt`.
+
+    Node 20 reached end-of-life on 2026-04-30 and no longer receives security
+    fixes. CI has tested only Node 22 and 24 for some time, so the `2.x` manifest
+    advertised a line nothing exercised; the matrix and the advertised floor now
+    agree.
+
+    On **Node 22 or newer** nothing changes. On **Node 20**, `npm install` prints
+    an `EBADENGINE` warning, and under `engine-strict=true` — pnpm's default
+    inside a workspace — the install fails outright. This is a packaging floor,
+    not an API change: no source has to change, only the Node version you run on.
+
 * **The deprecated legacy surface is removed** (#277). Marked `@deprecated` since
   `2.0.0` and carrying a `removalVersion: '3.0.0'` in every runtime warning, these
   symbols are now gone:

--- a/docs/app/components/Banner.vue
+++ b/docs/app/components/Banner.vue
@@ -5,8 +5,8 @@ import AlertIcon from '@bitrix24/b24icons-vue/outline/AlertIcon'
 <template>
   <B24Banner
     id="node20-drop-3-0-0-banner"
-    title="Node 20 support ends in 3.0.0 — move to Node 22 or newer"
-    to="/docs/getting-started/migration/v3/#runtime-node-20-is-dropped-in-300"
+    title="Node 20 is no longer supported as of 3.0.0 — move to Node 22 or newer"
+    to="/docs/getting-started/migration/v3/#runtime-node-20-was-dropped-in-300"
     :icon="AlertIcon"
     close
     color="air-primary-alert"

--- a/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
+++ b/docs/content/docs/1.getting-started/2.installation/4.nodejs.md
@@ -21,11 +21,11 @@ Both the `ESM` and `CommonJS` entries keep their dependencies (`axios`, `luxon`,
 Before you begin, make sure you have the latest version of Node.js installed.
 
 ::note
-We support version Node.js `^20.0.0 || >=22.0.0` (Node 18 is EOL and no longer supported).
+We support Node.js `>=22.0.0`. Node 18 and Node 20 are both end-of-life and no longer supported.
 ::
 
 ::warning
-**Dropping Node 20 is planned, and has not happened yet.** It reached end-of-life on 2026-04-30, and the SDK already tests only Node 22 and 24, so a future release will raise `engines.node` to `>=22.0.0`. The manifest still accepts Node 20 today. Move to Node 22 (LTS) or newer when you can. See the [v3 migration guide](/docs/getting-started/migration/v3/#runtime-dropping-node-20-is-planned-and-has-not-happened-yet).
+**Node 20 was dropped in `3.0.0`.** It reached end-of-life on 2026-04-30, and `engines.node` is now `>=22.0.0`. On Node 20 `npm install` prints an `EBADENGINE` warning, and under `engine-strict=true` — pnpm's default in a workspace — the install fails outright. Move to Node 22 (LTS) or newer before upgrading. See the [v3 migration guide](/docs/getting-started/migration/v3/#runtime-node-20-was-dropped-in-300).
 ::
 
 Then run the following command to install the library:

--- a/docs/content/docs/1.getting-started/3.migration/2.v3.md
+++ b/docs/content/docs/1.getting-started/3.migration/2.v3.md
@@ -178,27 +178,21 @@ Replaced by the universal [`Logger` / `LoggerFactory`](/docs/working-with-the-re
 + $logger.info('response', { someInfo: dataList })
 ```
 
-## Runtime: dropping Node 20 is planned, and has not happened yet
+## Runtime: Node 20 was dropped in 3.0.0
 
-::caution
-**This has not shipped.** `packages/jssdk/package.json` still declares
-`engines.node` as `^20.0.0 || >=22.0.0`, so `3.0.0` installs on Node 20 exactly
-as `2.x` did. The change is tracked in
-[#312](https://github.com/bitrix24/b24jssdk/issues/312) and is described here so
-you can plan the runtime move — not because it is in this release.
-::
+`3.0.0` raises the Node floor. `engines.node` moves from `^20.0.0 || >=22.0.0` to
+`>=22.0.0`, so **Node 20 is no longer supported**.
 
-The intent is to move `engines.node` to `>=22.0.0`. Node 20 reached end-of-life
-on 2026-04-30 — it no longer receives security fixes — and the SDK already tests
-only Node 22 and 24 in CI, so the manifest advertises a version nothing
-exercises.
+Node 20 reached end-of-life on 2026-04-30 — it no longer receives security fixes
+— and CI has tested only Node 22 and 24 for some time, so `2.x` advertised a
+version nothing exercised. `3.0.0` closes that gap.
 
-When it lands:
+What this means for you:
 
 - On **Node 22 or newer**, nothing changes.
-- On **Node 20**, `npm install` will print an `EBADENGINE` warning, and under
-  `engine-strict=true` (or pnpm's default for a workspace) the install fails
-  outright. Move to Node 22 (LTS) or newer.
+- On **Node 20**, `npm install` prints an `EBADENGINE` warning, and under
+  `engine-strict=true` (pnpm's default inside a workspace) the install fails
+  outright. Move to Node 22 (LTS) or newer before upgrading.
 
 It is a packaging floor, not an API change: no code has to change, only the Node
 version you run on. There is nothing to migrate in your source.

--- a/packages/jssdk-nuxt/package.json
+++ b/packages/jssdk-nuxt/package.json
@@ -40,7 +40,7 @@
     "dist"
   ],
   "engines": {
-    "node": "^20.0.0 || >=22.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jssdk/README-AI.md
+++ b/packages/jssdk/README-AI.md
@@ -274,7 +274,7 @@ for await (const chunk of $b24.actions.v2.fetchList.make({
 
 Notes
 
-- Supported Node versions: ^20 or >=22.
+- Supported Node versions: >=22. Node 20 was dropped in 3.0.0 (EOL 2026-04-30).
 - B24Hook warns if used on the client; keep it server-side.
 
 

--- a/packages/jssdk/docker-compose.yml
+++ b/packages/jssdk/docker-compose.yml
@@ -1,7 +1,7 @@
 # Local cross-runtime smoke: mirrors the CI `test` job's Node matrix (22 + 24),
 # the supported+validated lines. EOL Node 18 was removed with the `engines`
-# drop in #174; Node 20 stays in `engines` for now but is EOL and slated for
-# removal in #312, so it is not exercised here.
+# drop in #174, and EOL Node 20 with #312 — so this file, the CI matrix and
+# `engines` now describe the same set, with nothing advertised that is not run.
 services:
   test-node22:
     image: node:22-alpine

--- a/packages/jssdk/package.json
+++ b/packages/jssdk/package.json
@@ -62,7 +62,7 @@
     "package.json"
   ],
   "engines": {
-    "node": "^20.0.0 || >=22.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/skills/b24jssdk-core/SKILL.md
+++ b/skills/b24jssdk-core/SKILL.md
@@ -51,7 +51,7 @@ const $b24 = new B24Hook({
 Notes:
 
 - Keep `B24Hook` server-side only. The webhook URL contains a long-lived secret.
-- Supported Node: `^20`, `>=22`.
+- Supported Node: `>=22` (Node 20 was dropped in 3.0.0 — it is EOL).
 
 ## B24Frame (in-iframe app)
 


### PR DESCRIPTION
Closes #312.

`engines.node` moves from `^20.0.0 || >=22.0.0` to `>=22.0.0` in both `@bitrix24/b24jssdk` and `@bitrix24/b24jssdk-nuxt` (kept in lockstep).

## The gap this actually closes

Not "Node 20 is old" — that the manifest **advertised a line CI never ran**. #174 put the test matrix on 22 and 24 and deliberately left 20 out, since spending runner minutes on a version already slated for removal was not worth it. That left Node 20 advertised-but-untested, and #312 exists to close the gap from the manifest end rather than by growing the matrix backwards. The matrix and the advertised floor finally agree.

## Scope

Smaller than the issue's checklist suggested, because most of it was already done:

| Item from #312 | State |
| --- | --- |
| `engines.node` in both manifests | **changed here** |
| `4.nodejs.md`, `README-AI.md`, `b24jssdk-core/SKILL.md` | **changed here** |
| migration guide / release note | **changed here** + CHANGELOG entry |
| `99.examples/*` floors | nothing to change — no example declares `engines` |
| `packages/jssdk/docker-compose.yml` matrix | already `node:22-alpine` / `node:24-alpine` |
| CI matrix | already `[22, 24]` |

Also updated: the CI matrix comment, which explained why 20 was absent from the matrix while present in `engines`. That contradiction no longer exists, so the comment describing it would have been the next thing to mislead someone.

## A note on the docs half

Part of this is a revert of my own hedge. While removing the legacy surface (#509 / #277) I found the migration guide asserting that 3.0.0 raises the Node floor — not true of any merged code at that point — so that page and the installation page were reworded to "planned, has not happened yet". Now it has happened, and they say so again.

## Checks

- `pnpm install` clean, no `EBADENGINE` on this runner
- `jsSdk:unit` + `skills:unit` + `jsSdk:types` pass, no type errors
- `docs-lint --strict` 0/0 · `docs-link-check` 0 broken (the migration-section anchor moved, and its inbound link moved with it) · `docs-typecheck` 175 blocks · `skills-typecheck` 86 · `check-api-reference-index` 95 exports
- `eslint` and `lint:md` clean

## Release note

This is the third breaking change in 3.0.0, after the v3 batch wire format (#491) and the legacy-surface removal (#277). It is a packaging floor, not an API change: no source has to change, only the Node version you run on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_