### PR TITLE
feat(http)!: classify restApi:v3 errors by response category, without a flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@
 
 ### ⚠ BREAKING CHANGES
 
+* **`restApi:v3` errors are classified by response category, and the
+  `classifyV3ErrorsByCategory` parameter is gone** (#480, completing #460). An
+  error that arrived in the v3 error envelope carrying an HTTP **4xx other than
+  401, 408 or 429** is returned inside `AjaxResult` — soft — whatever its code.
+  Through the `2.x` line that was opt-in behind a restriction parameter which
+  defaulted to `false`; the parameter no longer exists.
+
+    Classification by list was really classification by module-shipping-date:
+    the built-in soft list holds nine v3 codes, one on-premise build was measured
+    to ship at least 39, and the set grows with every portal module. So
+    `INVALIDSELECTEXCEPTION` was soft while `INVALIDPAGINATIONEXCEPTION` — the
+    same caller mistake, same request, same HTTP 400 — threw.
+
+    **Two populations, and only one gets a compile error.** If you passed the
+    parameter, TypeScript now reports an unknown property: delete the line, the
+    behaviour you asked for is the default. **If you never passed it, nothing
+    fails to compile and the delivery of some v3 errors changes** — a `try` /
+    `catch` around a v3 call stops firing, control falls through into the success
+    path, and `getData()` is `undefined` there. Check `isSuccess`.
+
+    That check was already required for every code pinned soft — the nine
+    built-in v3 codes and anything in your own `softErrorCodes` — so a caller who
+    had it was already handling this path for some errors and now handles it for
+    more. **Nothing that was soft becomes thrown**; the change moves in one
+    direction only.
+
+    To keep one code throwing, pin it: `hardErrorCodes` is step 1 of the
+    classifier and the category rule is step 3, so a pinned code still throws.
+    See [Migration to v3](https://bitrix24.github.io/b24jssdk/docs/getting-started/migration/v3/#behaviour-v3-errors-are-classified-by-response-category).
+
 * **`Result<T>` and `IResult<T>` default to `unknown` instead of `any`** (#279),
   and the same narrowing reaches `TypeCallParams`: its catch-all index signature
   is now `[key: string]: unknown`, the nested `params` field is
@@ -179,11 +209,11 @@
 
     The walker underneath always handled both shapes; only the entry point refused them. Nothing about which keys are masked, or how deep the walk goes, has changed.
 
-* **`setRestrictionManagerParams` no longer wipes the parameters you did not mention.** It replaced the whole configuration, so `setRestrictionManagerParams({ maxRetries: 5 })` after a deliberate setup left `hardErrorCodes`, `retryOnNetworkError` and `classifyV3ErrorsByCategory` at `undefined` — and `rateLimit` too, which then reached the rate limiter as `undefined` behind a non-null assertion. No error, nothing in the log; the next call simply ran under a policy nobody had chosen. It now replaces what you name and leaves the rest alone.
+* **`setRestrictionManagerParams` no longer wipes the parameters you did not mention.** It replaced the whole configuration, so `setRestrictionManagerParams({ maxRetries: 5 })` after a deliberate setup left `hardErrorCodes`, `softErrorCodes` and `retryOnNetworkError` at `undefined` — and `rateLimit` too, which then reached the rate limiter as `undefined` behind a non-null assertion. No error, nothing in the log; the next call simply ran under a policy nobody had chosen. It now replaces what you name and leaves the rest alone.
 
     The nested blocks — `rateLimit`, `operatingLimit`, `adaptiveConfig` — are replaced **whole** rather than merged field by field; their types have no optional fields, and a partial block arriving from JavaScript is now refused with `JSSDK_LIMITER_INVALID_CONFIG_BLOCK` instead of switching rate limiting off on a `NaN` interval. `getRestrictionManagerParams()` returns a copy, so reading the policy no longer hands out the limiter's live state.
 
-    **Worth knowing:** an omitted key and one set to `undefined` both mean "leave it alone", so clearing a value now takes an explicit one — `hardErrorCodes: []`. Spreading `...ParamsFactory.getDefault()` does not clear `hardErrorCodes` / `softErrorCodes` / `classifyV3ErrorsByCategory`, because the factory carries no such keys. And `b24.setRestrictionManagerParams()` no longer swallows a failure from one of its clients.
+    **Worth knowing:** an omitted key and one set to `undefined` both mean "leave it alone", so clearing a value now takes an explicit one — `hardErrorCodes: []`. Spreading `...ParamsFactory.getDefault()` does not clear `hardErrorCodes` / `softErrorCodes`, because the factory carries no such keys. And `b24.setRestrictionManagerParams()` no longer swallows a failure from one of its clients.
 
 * **A response body with no `result` key now reaches you instead of being dropped.** `AjaxResult.getData()` rebuilds the payload from two named keys, so a body carrying neither was projected away and a *successful* call handed back `{ result: undefined, time: undefined }`. Such a body is wrapped now: the whole body becomes `result`.
 

--- a/docs/content/docs/1.getting-started/3.migration/2.v3.md
+++ b/docs/content/docs/1.getting-started/3.migration/2.v3.md
@@ -233,10 +233,10 @@ a field off it.
 // Before 3.0.0 this caught an unlisted v3 4xx. It no longer does.
 try {
   const response = await $b24.actions.v3.call.make({ method: 'main.eventlog.list', params: {} })
-  render(response.getData()!.result)
+  console.log(response.getData()!.result)
 }
 catch (error) {
-  showError(error)
+  console.error(error)
 }
 ```
 
@@ -244,10 +244,11 @@ catch (error) {
 // The shape that works on both: check the result, then catch what is left.
 const response = await $b24.actions.v3.call.make({ method: 'main.eventlog.list', params: {} })
 if (!response.isSuccess) {
-  showError(response.getErrorMessages().join('; '))
-  return
+  console.error(response.getErrorMessages().join('; '))
 }
-render(response.getData()!.result)
+else {
+  console.log(response.getData()!.result)
+}
 ```
 
 Reading `isSuccess` was already required for every code pinned soft — the nine
@@ -262,6 +263,8 @@ Pin it. `hardErrorCodes` is consulted before the category rule, so a code listed
 there still throws:
 
 ```ts
+import { ParamsFactory } from '@bitrix24/b24jssdk'
+
 await $b24.setRestrictionManagerParams({
   ...ParamsFactory.getDefault(),
   hardErrorCodes: ['BITRIX_REST_V3_EXCEPTION_INVALIDPAGINATIONEXCEPTION']

--- a/docs/content/docs/1.getting-started/3.migration/2.v3.md
+++ b/docs/content/docs/1.getting-started/3.migration/2.v3.md
@@ -197,6 +197,89 @@ What this means for you:
 It is a packaging floor, not an API change: no code has to change, only the Node
 version you run on. There is nothing to migrate in your source.
 
+## Behaviour: v3 errors are classified by response category
+
+This is the one change in `3.0.0` that alters what working code does **without
+producing a compile error**, so it is worth reading even if your build is clean.
+
+On `restApi:v3`, an error that arrived in the v3 error envelope carrying an HTTP
+**4xx other than 401, 408 or 429** is now returned inside `AjaxResult` — soft —
+whatever its code. Through the `2.x` line that was opt-in behind a
+`classifyV3ErrorsByCategory` restriction parameter, which defaulted to `false`;
+in `3.0.0` the rule is simply the behaviour and the parameter is gone.
+
+### If you were passing the parameter
+
+Delete the line. TypeScript reports it as an unknown property, and the behaviour
+you were asking for is what you now get by default.
+
+```diff
+  await $b24.setRestrictionManagerParams({
+    ...ParamsFactory.getDefault(),
+-   classifyV3ErrorsByCategory: true,
+    hardErrorCodes: ['MY_APP_BAD_PAYLOAD']
+  })
+```
+
+### If you were not
+
+Then the delivery of some v3 errors changes under you, and **nothing fails to
+compile**. A v3 4xx that used to reject the promise now resolves it, so a
+`try / catch` around the call stops firing and control falls through into the
+success path — where `response.getData()` is `undefined` and the next line reads
+a field off it.
+
+```ts
+// Before 3.0.0 this caught an unlisted v3 4xx. It no longer does.
+try {
+  const response = await $b24.actions.v3.call.make({ method: 'main.eventlog.list', params: {} })
+  render(response.getData()!.result)
+}
+catch (error) {
+  showError(error)
+}
+```
+
+```ts
+// The shape that works on both: check the result, then catch what is left.
+const response = await $b24.actions.v3.call.make({ method: 'main.eventlog.list', params: {} })
+if (!response.isSuccess) {
+  showError(response.getErrorMessages().join('; '))
+  return
+}
+render(response.getData()!.result)
+```
+
+Reading `isSuccess` was already required for every code pinned soft — the nine
+built-in v3 codes and anything in your own `softErrorCodes` — so a caller who had
+that check was already handling this path for some errors and now handles it for
+more. **Nothing that was soft in `2.x` becomes thrown.** The change is in one
+direction only.
+
+### If you need the old behaviour for a specific code
+
+Pin it. `hardErrorCodes` is consulted before the category rule, so a code listed
+there still throws:
+
+```ts
+await $b24.setRestrictionManagerParams({
+  ...ParamsFactory.getDefault(),
+  hardErrorCodes: ['BITRIX_REST_V3_EXCEPTION_INVALIDPAGINATIONEXCEPTION']
+})
+```
+
+There is no switch that restores the old classification wholesale, and that is
+deliberate: a dual-behaviour flag with no removal date is how a compatibility
+surface becomes permanent, which is the reason this one had a scheduled end
+(#480).
+
+### What is untouched
+
+5xx, 401, 408 and 429, the whole of `restApi:v2` — whose flat error body is not a
+v3 envelope — and every code pinned in the built-in hard list, including
+`…INSUFFICIENTSCOPEEXCEPTION` at 403. Full detail in
+[Error Codes](/docs/working-with-the-rest-api/error-codes/#classification-by-category-restapiv3).
+
 ## How to find every call site
 
 Through `2.x` these symbols announced themselves — a `JSSDK_CORE_DEPRECATED_METHOD`

--- a/docs/content/docs/2.working-with-the-rest-api/55.helper-license-manager.md
+++ b/docs/content/docs/2.working-with-the-rest-api/55.helper-license-manager.md
@@ -20,7 +20,7 @@ links:
 ::note
 On `initData`, `LicenseManager`{lang="ts-type"} calls [`ParamsFactory.fromTariffPlan(license)`](https://github.com/bitrix24/b24jssdk/blob/main/packages/jssdk/src/core/http/limiters/params-factory.ts) and applies the result via `b24.setRestrictionManagerParams(...)`. That swaps in enterprise-grade rate limits when the portal is on an enterprise tariff. See [Limiters](/docs/working-with-the-rest-api/limiters/).
 
-That automatic call is a partial update, and since v2.3.0 a partial update keeps what it does not name — so your own `hardErrorCodes`, `softErrorCodes` and `classifyV3ErrorsByCategory` survive it. Before then it replaced the whole configuration and silently reset them. See [Updating the parameters](/docs/working-with-the-rest-api/limiters/#updating-the-parameters).
+That automatic call is a partial update, and since v2.3.0 a partial update keeps what it does not name — so your own `hardErrorCodes` and `softErrorCodes` survive it. Before then it replaced the whole configuration and silently reset them. See [Updating the parameters](/docs/working-with-the-rest-api/limiters/#updating-the-parameters).
 ::
 
 ## Usage

--- a/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
+++ b/docs/content/docs/2.working-with-the-rest-api/77.limiters.md
@@ -2,7 +2,7 @@
 title: Restrictions System
 description: 'The restrictions system provides a comprehensive mechanism for managing request frequency, operation execution time, and adaptive delays.'
 category: 'limiters'
-audited: 2026-09-06
+audited: 2026-09-09
 navigation.title: Limiters
 links:
   - label: Limiters
@@ -64,7 +64,6 @@ interface RestrictionParams {
                                    // Set to `false` for non-idempotent calls — see "Non-idempotent calls" below.
   hardErrorCodes?: string[]        // Extra codes to throw immediately (merged with built-in hard list).
   softErrorCodes?: string[]        // Extra codes to return as AjaxResult with error (merged with built-in soft list).
-  classifyV3ErrorsByCategory?: boolean // restApi:v3: decide soft/hard from the response category (default: false; becomes the default in 3.0.0).
 }
 ```
 
@@ -248,9 +247,9 @@ set.
 **Clearing a value** takes an explicit value, since an omitted key now means
 "leave it alone": pass `hardErrorCodes: []` to empty a list, or the field's
 default to restore it. Spreading `...ParamsFactory.getDefault()` resets
-everything the factory *names* — but it carries no `hardErrorCodes`,
-`softErrorCodes` or `classifyV3ErrorsByCategory` key, so those three survive
-it. Name them yourself when you mean to clear them.
+everything the factory *names* — but it carries no `hardErrorCodes` or
+`softErrorCodes` key, so those two survive it. Name them yourself when you mean
+to clear them.
 
 Until [#479](https://github.com/bitrix24/b24jssdk/issues/479) this method **replaced the whole configuration**, so a partial
 update silently reset every parameter it did not mention — including the nested
@@ -547,29 +546,23 @@ per-module-shipping-date rather than per-error-kind. `INVALIDSELECTEXCEPTION`
 is soft while `INVALIDPAGINATIONEXCEPTION`, the same caller mistake in the same
 request at the same HTTP 400, throws.
 
-Decide from the response instead:
-
-```ts
-import { ParamsFactory } from '@bitrix24/b24jssdk'
-
-// const $b24 = ...
-await $b24.setRestrictionManagerParams({
-  ...ParamsFactory.getDefault(),
-  classifyV3ErrorsByCategory: true
-})
-```
+The SDK decides from the response instead, and there is nothing to configure.
 
 An error that arrived in the v3 error envelope carrying an HTTP **4xx other
-than 401, 408 or 429** is then soft, whatever its code. Pinned codes — the
+than 401, 408 or 429** is soft, whatever its code. Pinned codes — the
 built-in lists and your own — still outrank the rule, 5xx is untouched, and so
 is `restApi:v2`, whose flat error body is not a v3 envelope.
 
 ::caution
-**Off by default in 2.x; the default flips in 3.0.0.** Enabling it changes how
-an error is delivered, so a `try / catch` written against today's behaviour
-stops firing and control falls through into the success path. Move that
-handling to `if (!response.isSuccess)` first. Full detail in
-[Error Codes](/docs/working-with-the-rest-api/error-codes/#classification-by-category-restapiv3).
+**Changed in 3.0.0.** Through the `2.x` line this was opt-in, behind a
+`classifyV3ErrorsByCategory` parameter that defaulted to `false`; in `3.0.0` the
+rule is the behaviour and the parameter is gone. A v3 4xx that threw under `2.x`
+now resolves, so a `try / catch` written against the old behaviour stops firing
+and control falls through into the success path. Move that handling to
+`if (!response.isSuccess)`. Full detail in
+[Error Codes](/docs/working-with-the-rest-api/error-codes/#classification-by-category-restapiv3),
+migration steps in the
+[3.0.0 guide](/docs/getting-started/migration/v3/#behaviour-v3-errors-are-classified-by-response-category).
 ::
 
 ::note

--- a/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
+++ b/docs/content/docs/2.working-with-the-rest-api/96.error-codes.md
@@ -31,17 +31,10 @@ A `restApi:v3` code is derived from the exception class that raised it, so the s
 
 ## Classification by category (`restApi:v3`)
 
-Rather than growing the list, the SDK can decide from the **response itself**: an error that arrived in the v3 error envelope carrying an HTTP **4xx other than 401, 408 or 429** is soft, whatever its code.
+Rather than growing the list, the SDK decides from the **response itself**: an error that arrived in the v3 error envelope carrying an HTTP **4xx other than 401, 408 or 429** is soft, whatever its code. This needs no configuration — it is the behaviour.
 
 ```ts
-import { ParamsFactory } from '@bitrix24/b24jssdk'
-
 // const $b24 = ...
-await $b24.setRestrictionManagerParams({
-  ...ParamsFactory.getDefault(),
-  classifyV3ErrorsByCategory: true
-})
-
 const response = await $b24.actions.v3.call.make({
   method: 'main.eventlog.list',
   params: { pagination: { limit: 0 } }
@@ -67,7 +60,7 @@ What the rule does **not** touch:
 One 403 is pinned hard against that rule: `BITRIX_REST_V3_EXCEPTION_INSUFFICIENTSCOPEEXCEPTION`. It means the application's OAuth grant is missing a scope — a configuration fault rather than a per-record permission check — and the v2 spelling of the same condition, `insufficient_scope`, has always been thrown. The two are different strings, so without pinning the v3 form the same failure would have been delivered one way on v2 and another on v3.
 
 ::caution
-**Off by default in 2.x, on in 3.0.0.** Turning it on changes how an error is delivered: a code that throws today resolves instead, so a `try / catch` around the call stops firing and control falls through into the success path. Move that handling to `if (!response.isSuccess)` before enabling it.
+**Changed in 3.0.0.** Through the `2.x` line this rule was opt-in, behind a `classifyV3ErrorsByCategory` parameter; in `3.0.0` it is the behaviour and the parameter is gone. That changes how an error is delivered: a v3 4xx that threw under `2.x` now resolves, so a `try / catch` around the call stops firing and control falls through into the success path. Move that handling to `if (!response.isSuccess)` — see the [migration guide](/docs/getting-started/migration/v3/#behaviour-v3-errors-are-classified-by-response-category).
 ::
 
 ## Pinned hard codes (thrown)

--- a/docs/content/docs/99.examples/10.error-handling.md
+++ b/docs/content/docs/99.examples/10.error-handling.md
@@ -24,7 +24,8 @@ Also covers `setRestrictionManagerParams` with the new knobs:
 - `hardErrorCodes` — extend the SDK's "throw immediately, no retry" list with app-specific codes.
 - `softErrorCodes` — extend the "return as soft error in AjaxResult" list.
 - `retryOnNetworkError: false` — disable network retry for `*.add` / `*.update` / file uploads to avoid duplicates.
-- `classifyV3ErrorsByCategory` — `restApi:v3` only: decide soft/hard from the response rather than from a list of codes, so an error the SDK has never heard of is still delivered like its neighbours. Off by default in 2.x, on in 3.0.0; see [Error Codes](/docs/working-with-the-rest-api/error-codes/#classification-by-category-restapiv3) before enabling, because it changes how errors are delivered.
+
+On `restApi:v3` the soft/hard split is decided from the response rather than from a list of codes, so an error the SDK has never heard of is still delivered like its neighbours — see [Error Codes](/docs/working-with-the-rest-api/error-codes/#classification-by-category-restapiv3). That was opt-in through `2.x`; since `3.0.0` it needs no parameter.
 
 ## Stack
 

--- a/packages/jssdk/src/core/http/limiters/manager.ts
+++ b/packages/jssdk/src/core/http/limiters/manager.ts
@@ -455,10 +455,16 @@ export class RestrictionManager {
    *    a credential failure, and a caller's `hardErrorCodes` always wins;
    * 2. a code in `exceptionCodeForSoft` is soft — so the built-in list, the v2
    *    codes and a caller's `softErrorCodes` keep working unchanged;
-   * 3. with `classifyV3ErrorsByCategory` on, an error that arrived in the
-   *    **v3 error envelope** carrying a **4xx other than 401 / 408 / 429** is
-   *    soft, whatever its code;
-   * 4. otherwise it throws, which is what happens today for anything unlisted.
+   * 3. an error that arrived in the **v3 error envelope** carrying a **4xx
+   *    other than 401 / 408 / 429** is soft, whatever its code;
+   * 4. otherwise it throws.
+   *
+   * Step 3 was opt-in through the 2.x line, behind `classifyV3ErrorsByCategory`,
+   * and is simply the behaviour as of 3.0.0 — the flag is gone rather than
+   * inverted, because a permanent compatibility switch is what the 2.x
+   * arrangement was scheduled to avoid becoming (#480). A caller who needs the
+   * old classification for one code pins it in `hardErrorCodes`, which step 1
+   * still honours.
    *
    * Step 3 keys on the envelope the response actually carried, never on the
    * client's own version: a gateway in front of the v3 controller is documented
@@ -475,10 +481,6 @@ export class RestrictionManager {
 
     if (this.exceptionCodeForSoft.includes(codeText)) {
       return true
-    }
-
-    if (this.#config.classifyV3ErrorsByCategory !== true) {
-      return false
     }
 
     // This check, not the status range below, is what keeps an untagged error
@@ -565,7 +567,7 @@ export class RestrictionManager {
    * It used to assign — `this.#config = params` — so a caller changing one
    * field silently lost every other one. `setRestrictionManagerParams({
    * maxRetries: 5 })` after a careful setup left `hardErrorCodes`,
-   * `retryOnNetworkError`, `classifyV3ErrorsByCategory` **and** `rateLimit` all
+   * `softErrorCodes`, `retryOnNetworkError` **and** `rateLimit` all
    * `undefined`, with no error and nothing in the log. (#479)
    *
    * The tell was in our own documentation: every example of this method spreads

--- a/packages/jssdk/src/core/http/limiters/params-factory.ts
+++ b/packages/jssdk/src/core/http/limiters/params-factory.ts
@@ -30,11 +30,7 @@ export class ParamsFactory {
       },
       maxRetries: 3,
       retryDelay: 1_000,
-      retryOnNetworkError: true,
-      // Off for the 2.x line: turning it on changes how an error is delivered,
-      // which breaks a `try / catch` written against today's behaviour. Becomes
-      // the default in 3.0.0. (#460)
-      classifyV3ErrorsByCategory: false
+      retryOnNetworkError: true
     }
   }
 

--- a/packages/jssdk/src/types/limiters.ts
+++ b/packages/jssdk/src/types/limiters.ts
@@ -164,51 +164,6 @@ export interface RestrictionParams {
    * custom v3 endpoint).
    */
   softErrorCodes?: string[]
-  /**
-   * Decide the soft/hard split for `restApi:v3` by the **response category**
-   * rather than by an enumerated list of codes.
-   *
-   * With this on, an error that arrived in the v3 error envelope with an HTTP
-   * **4xx other than 401, 408 or 429** is returned inside `AjaxResult` as a
-   * soft error, whatever its code. `hardErrorCodes` and `softErrorCodes` still
-   * outrank the rule, so a pinned classification always wins; 5xx is untouched;
-   * and `restApi:v2`, whose flat error body is not a v3 envelope, is unaffected.
-   *
-   * **Why it is not the default yet.** Turning it on changes *how* an error is
-   * delivered: a code that throws today resolves instead, so a `try / catch`
-   * around the call stops firing and control falls through into the success
-   * path. That is a breaking change, so it is opt-in for the 2.x line and
-   * becomes the default in 3.0.0. Callers relying on `catch` move to
-   * `if (!response.isSuccess)`.
-   *
-   * **Why the rule exists.** The built-in soft list holds nine v3 codes; a
-   * single on-premise build ships at least 39, and the set grows with every
-   * portal module. Classification by list is therefore per-module-shipping-date
-   * rather than per-error-kind: `INVALIDSELECTEXCEPTION` is soft while
-   * `INVALIDPAGINATIONEXCEPTION` — the same caller mistake, same request, same
-   * HTTP 400 — throws. Codes are also not uniformly prefixed
-   * (`NOTE_SEARCH_QUERY_TOO_SHORT` carries none), so no pattern match can
-   * stand in for the list either.
-   *
-   * @default false
-   *
-   * @example
-   * ```ts
-   * import { ParamsFactory } from '@bitrix24/b24jssdk'
-   *
-   * await $b24.setRestrictionManagerParams({
-   *   ...ParamsFactory.getDefault(),
-   *   classifyV3ErrorsByCategory: true
-   * })
-   *
-   * const response = await $b24.actions.v3.call.make({ method: 'main.eventlog.list', params: {} })
-   * if (!response.isSuccess) {
-   *   // Reached for any 4xx the portal reports, not only the nine listed codes.
-   *   console.log(response.getErrorMessages().join('; '))
-   * }
-   * ```
-   */
-  classifyV3ErrorsByCategory?: boolean
 }
 
 /**

--- a/skills/b24jssdk-core/SKILL.md
+++ b/skills/b24jssdk-core/SKILL.md
@@ -246,16 +246,12 @@ await $b24.setRestrictionManagerParams({
   // duplicates.
   retryOnNetworkError: false,
 
-  // restApi:v3 only. Decide soft/hard from the RESPONSE — a v3 error envelope
-  // carrying a 4xx other than 401/408/429 is soft, whatever its code. Off by
-  // default in 2.x because it is breaking (a code that throws today resolves
-  // instead); the default flips in 3.0.0.
-  classifyV3ErrorsByCategory: true,
-
   maxRetries: 3,
   retryDelay: 1_000
 })
 ```
+
+**The category rule needs no configuration.** On `restApi:v3` an error that arrived in the v3 error envelope carrying a 4xx other than 401/408/429 is soft, whatever its code. Through the `2.x` line this was opt-in behind a `classifyV3ErrorsByCategory` parameter; since `3.0.0` it is simply the behaviour and that parameter no longer exists — passing it is a compile error, and the fix is to delete the line.
 
 **Why the category rule exists.** The built-in soft list holds nine v3 codes; one on-premise build was measured to ship at least 39, and the set grows with every portal module. So classification by list is per-module-shipping-date, not per-error-kind: `INVALIDSELECTEXCEPTION` is soft while `INVALIDPAGINATIONEXCEPTION` — same caller mistake, same request, same HTTP 400 — throws. Pinned codes (built-in and yours) still outrank the rule; 5xx, 401, 408, 429 and all of `restApi:v2` are untouched; 403 is soft, matching the already-pinned `…ACCESSDENIEDEXCEPTION` — except `…INSUFFICIENTSCOPEEXCEPTION`, pinned hard because it is a missing OAuth grant and its v2 twin `insufficient_scope` has always thrown.
 

--- a/test/integration/core/restriction-params-merge.unit.spec.ts
+++ b/test/integration/core/restriction-params-merge.unit.spec.ts
@@ -39,17 +39,20 @@ describe('#479 RestrictionParams merge on set', () => {
       ...ParamsFactory.getDefault(),
       retryOnNetworkError: false,
       hardErrorCodes: ['MY_APP_BAD_PAYLOAD'],
-      classifyV3ErrorsByCategory: true
+      softErrorCodes: ['MY_APP_RETRYABLE']
     })
 
     await b24.setRestrictionManagerParams({ maxRetries: 5 })
 
     const params = client.getRestrictionManagerParams()
     expect(params.maxRetries).toBe(5)
-    // Each of these was `undefined` before the fix.
+    // Each of these was `undefined` before the fix. The third slot used to hold
+    // `classifyV3ErrorsByCategory`, removed in 3.0.0 (#480); `softErrorCodes` is
+    // its nearest equivalent — a field the default set does not populate, so it
+    // can only be here because the merge kept it.
     expect(params.retryOnNetworkError).toBe(false)
     expect(params.hardErrorCodes).toEqual(['MY_APP_BAD_PAYLOAD'])
-    expect(params.classifyV3ErrorsByCategory).toBe(true)
+    expect(params.softErrorCodes).toEqual(['MY_APP_RETRYABLE'])
   })
 
   it('keeps the nested limiter blocks a partial update does not mention', async () => {

--- a/test/integration/core/v3-error-category.unit.spec.ts
+++ b/test/integration/core/v3-error-category.unit.spec.ts
@@ -10,8 +10,16 @@
  * throws. Codes are not uniformly prefixed either (`NOTE_SEARCH_QUERY_TOO_SHORT`
  * carries none), so no pattern can stand in for the list.
  *
- * The rule is opt-in for 2.x because it changes *how* an error is delivered: a
- * code that throws today resolves instead, so a `try / catch` stops firing.
+ * The rule was opt-in through the 2.x line, behind `classifyV3ErrorsByCategory`,
+ * because it changes *how* an error is delivered: a code that used to throw
+ * resolves instead, so a `try / catch` written against the old behaviour stops
+ * firing. As of 3.0.0 it is simply the behaviour and the flag is gone (#480),
+ * so the cases below configure nothing — they assert the default.
+ *
+ * The two cases that pinned the flag-off position are gone with it. Neither
+ * could survive the removal: one asserted that an unlisted v3 4xx throws, which
+ * is now the opposite of the rule, and the other that a **listed** code is soft
+ * at 400 — true by list and by category both, so it stopped being able to fail.
  *
  * Portal-free (jsSdk:unit), following the #230 spec next door: `maxRetries: 1`
  * and `_executeSingleCall` stubbed to reject, so `call()`'s classification
@@ -60,8 +68,6 @@ async function deliveryOf(http: HttpV2): Promise<'soft' | 'throw'> {
   }
 }
 
-const ON: Partial<RestrictionParams> = { classifyV3ErrorsByCategory: true }
-
 /** A v3 error body, as the portal sends it. */
 function v3ErrorResponse(code: string, status: number) {
   return {
@@ -74,26 +80,6 @@ function v3ErrorResponse(code: string, status: number) {
 }
 
 describe('#460 v3 errors classified by response category', () => {
-  describe('with the rule off — today\'s behaviour, unchanged', () => {
-    it('an unlisted v3 4xx still throws', async () => {
-      const http = httpRejectingWith({
-        code: 'BITRIX_REST_V3_EXCEPTION_INVALIDPAGINATIONEXCEPTION',
-        status: 400,
-        isV3Envelope: true
-      })
-      await expect(deliveryOf(http)).resolves.toBe('throw')
-    })
-
-    it('a listed v3 code is still soft', async () => {
-      const http = httpRejectingWith({
-        code: 'BITRIX_REST_V3_EXCEPTION_INVALIDSELECTEXCEPTION',
-        status: 400,
-        isV3Envelope: true
-      })
-      await expect(deliveryOf(http)).resolves.toBe('soft')
-    })
-  })
-
   describe('the envelope flag reaches the error through the real path', () => {
     // The cases below stub `_executeSingleCall`, so they never run
     // `parseErrorPayload`. These two do: without them, deleting
@@ -102,6 +88,11 @@ describe('#460 v3 errors classified by response category', () => {
     // nothing.
 
     it('an axios failure carrying a v3 body produces isV3Envelope === true', async () => {
+      // End to end, with nothing configured: the portal answers 400 in the v3
+      // envelope, `_convertAxiosErrorToAjaxError` tags the error, and the
+      // category rule then delivers it **inside the result** rather than
+      // throwing. Before #480 this same call threw and the assertion below read
+      // the error off a `.catch()`.
       const b24 = B24Hook.fromWebhookUrl('https://example.bitrix24.com/rest/1/SECRET', {
         restrictionParams: { ...ParamsFactory.getDefault(), maxRetries: 1, retryDelay: 1 }
       })
@@ -114,10 +105,14 @@ describe('#460 v3 errors classified by response category', () => {
         v3ErrorResponse('BITRIX_REST_V3_EXCEPTION_INVALIDPAGINATIONEXCEPTION', 400)
       ))
 
-      const thrown = await client.call('main.eventlog.list', {}).catch((error: unknown) => error)
+      const outcome = await client.call('main.eventlog.list', {}).catch((error: unknown) => error)
 
-      expect(thrown).toBeInstanceOf(AjaxError)
-      expect((thrown as AjaxError).isV3Envelope).toBe(true)
+      expect(outcome).toBeInstanceOf(AjaxResult)
+      expect((outcome as AjaxResult<unknown>).isSuccess).toBe(false)
+
+      const [error] = [...(outcome as AjaxResult<unknown>).getErrors()]
+      expect(error).toBeInstanceOf(AjaxError)
+      expect((error as AjaxError).isV3Envelope).toBe(true)
       b24.destroy()
     })
 
@@ -164,7 +159,7 @@ describe('#460 v3 errors classified by response category', () => {
     })
   })
 
-  describe('with the rule on', () => {
+  describe('the category rule — the default since 3.0.0', () => {
     it('an unlisted v3 4xx becomes soft', async () => {
       // Measured on an on-premise build: `main.eventlog.list` with
       // `pagination: { limit: 0 }`, HTTP 400.
@@ -172,7 +167,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'BITRIX_REST_V3_EXCEPTION_INVALIDPAGINATIONEXCEPTION',
         status: 400,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('soft')
     })
 
@@ -184,7 +179,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'NOTE_SEARCH_QUERY_TOO_SHORT',
         status: 400,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('soft')
     })
 
@@ -197,7 +192,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'BITRIX_REST_V3_EXCEPTION_SOMEFORBIDDENEXCEPTION',
         status: 403,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('soft')
     })
 
@@ -217,7 +212,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'BITRIX_REST_V3_EXCEPTION_ACCESSDENIEDEXCEPTION',
         status,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('soft')
     })
 
@@ -231,7 +226,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'BITRIX_REST_V3_EXCEPTION_INSUFFICIENTSCOPEEXCEPTION',
         status: 403,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('throw')
     })
 
@@ -240,7 +235,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'BITRIX_REST_V3_EXCEPTION_SOMEAUTHEXCEPTION',
         status: 401,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('throw')
     })
 
@@ -249,7 +244,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'BITRIX_REST_V3_EXCEPTION_SOMETIMEOUTEXCEPTION',
         status: 408,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('throw')
     })
 
@@ -258,7 +253,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'BITRIX_REST_V3_EXCEPTION_RATELIMITEXCEPTION',
         status: 429,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('throw')
     })
 
@@ -267,7 +262,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'BITRIX_REST_V3_EXCEPTION_INTERNAL_INTERNALEXCEPTION',
         status: 500,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('throw')
     })
 
@@ -280,13 +275,13 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'SOME_UNLISTED_V2_CODE',
         status: 400,
         isV3Envelope: false
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('throw')
     })
 
     it('an error with no envelope information at all still throws', async () => {
       // A transport failure never went through the payload parser.
-      const http = httpRejectingWith({ code: 'NETWORK_ERROR', status: 0 }, ON)
+      const http = httpRejectingWith({ code: 'NETWORK_ERROR', status: 0 })
       await expect(deliveryOf(http)).resolves.toBe('throw')
     })
 
@@ -296,7 +291,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'BITRIX_REST_V3_EXCEPTION_SOMECLIENTEXCEPTION',
         status: 499,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('soft')
     })
 
@@ -305,7 +300,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'BITRIX_REST_V3_EXCEPTION_SOMEODDEXCEPTION',
         status: 399,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('throw')
     })
 
@@ -316,7 +311,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'DUP_CODE',
         status: 400,
         isV3Envelope: true
-      }, { ...ON, hardErrorCodes: ['DUP_CODE'], softErrorCodes: ['DUP_CODE'] })
+      }, { hardErrorCodes: ['DUP_CODE'], softErrorCodes: ['DUP_CODE'] })
       await expect(deliveryOf(http)).resolves.toBe('throw')
     })
 
@@ -325,7 +320,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'MY_APP_BAD_PAYLOAD',
         status: 400,
         isV3Envelope: true
-      }, { ...ON, hardErrorCodes: ['MY_APP_BAD_PAYLOAD'] })
+      }, { hardErrorCodes: ['MY_APP_BAD_PAYLOAD'] })
       await expect(deliveryOf(http)).resolves.toBe('throw')
     })
 
@@ -336,7 +331,7 @@ describe('#460 v3 errors classified by response category', () => {
         code: 'expired_token',
         status: 400,
         isV3Envelope: true
-      }, ON)
+      })
       await expect(deliveryOf(http)).resolves.toBe('throw')
     })
   })

--- a/test/integration/core/v3-error-category.unit.spec.ts
+++ b/test/integration/core/v3-error-category.unit.spec.ts
@@ -27,7 +27,7 @@
  * run, so `isV3Envelope` is set on the error explicitly — which is also what
  * makes the flat-v2 arm meaningful.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { AxiosError } from 'axios'
 import { ApiVersion, B24Hook, ParamsFactory } from '../../../packages/jssdk/src/'
 import { HttpV2 } from '../../../packages/jssdk/src/core/http/v2'
@@ -80,6 +80,15 @@ function v3ErrorResponse(code: string, status: number) {
 }
 
 describe('#460 v3 errors classified by response category', () => {
+  // Two cases below spy on a live axios client. Without this, the stub outlives
+  // the case that installed it and reaches whatever the runner schedules next in
+  // the same file — a leak that only shows up in some orderings, which is the
+  // worst kind to debug. The sibling `restriction-params-merge.unit.spec.ts`
+  // already does this; #523 was the same class of bug one directory over.
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   describe('the envelope flag reaches the error through the real path', () => {
     // The cases below stub `_executeSingleCall`, so they never run
     // `parseErrorPayload`. These two do: without them, deleting


### PR DESCRIPTION
Closes #480. Second half of #460, whose first half shipped in #478 behind an
opt-in flag.

## What was outstanding

`classifyV3ErrorsByCategory` defaulted to `false`, so the defect #460 describes
was still what every caller got unless they read a changelog and opted in. The
promise that it becomes the default in 3.0.0 lived only in prose — a JSDoc
`@default false` and a caution box on three pages. Nothing scheduled it, and
nothing would have failed if 3.0.0 shipped without it.

## What changes

On `restApi:v3`, an error that arrived in the **v3 error envelope** carrying an
HTTP **4xx other than 401, 408 or 429** is returned inside `AjaxResult`,
whatever its code. No parameter, no configuration.

The built-in soft list holds **nine** v3 codes; one on-premise build was
measured to ship at least **39**, and the set grows with every portal module. So
classification by list was per-module-shipping-date rather than per-error-kind:
`INVALIDSELECTEXCEPTION` was soft while `INVALIDPAGINATIONEXCEPTION` — the same
caller mistake, same request, same HTTP 400 — threw.

## Removed, not inverted

The issue left this open: remove the flag, or keep it as an opt-*out*.

Removed. An opt-out is a dual-behaviour switch with no removal date, which is
exactly the shape the 2.x arrangement was scheduled to avoid becoming — and the
argument review of #478 made when filing this. The repository has changed
classification this way twice without a compatibility flag: #259 dropped the
hardcoded v3 method allowlist, #45 moved retryability off an enumerated list
onto HTTP status.

A caller who needs the old delivery for a specific code pins it:

```ts
await $b24.setRestrictionManagerParams({
  ...ParamsFactory.getDefault(),
  hardErrorCodes: ['BITRIX_REST_V3_EXCEPTION_INVALIDPAGINATIONEXCEPTION']
})
```

`hardErrorCodes` is step 1 of `isSoftError` and the category rule is step 3, so
a pinned code still throws.

## Two populations, and only one of them gets a compile error

| you were | what happens |
|---|---|
| **passing the flag** | `classifyV3ErrorsByCategory` no longer exists → TS error on the property. Delete the line; the behaviour you asked for is now the default. |
| **not passing it** | delivery of some v3 errors changes and **nothing fails to compile**. |

The second row is the one that needs the migration guide, so that is what it
leads with: a `try / catch` around a v3 call stops firing, control falls through
into the success path, and `getData()` is `undefined` there.

Reading `isSuccess` was already required for every code pinned soft — the nine
built-in v3 codes and anything in a caller's own `softErrorCodes` — so a caller
who had that check was already handling this path for some errors and now
handles it for more. **Nothing that was soft becomes thrown.** One direction
only.

## Tests

Two cases went with the flag. Neither could have survived it:

- *an unlisted v3 4xx still throws* — now the opposite of the rule;
- *a listed v3 code is still soft* at 400 — true by list **and** by category, so
  it had stopped being able to fail. Keeping it would have been a green
  assertion that pins nothing, which is the failure mode this repository has
  removed twice (#498).

One case **changed** rather than went, and it is the interesting one.
`an axios failure carrying a v3 body produces isV3Envelope === true` read the
error off a `.catch()` because that call used to throw. It now resolves, so the
error is read out of the result:

```ts
const outcome = await client.call('main.eventlog.list', {}).catch((error: unknown) => error)

expect(outcome).toBeInstanceOf(AjaxResult)
expect((outcome as AjaxResult<unknown>).isSuccess).toBe(false)

const [error] = [...(outcome as AjaxResult<unknown>).getErrors()]
expect((error as AjaxError).isV3Envelope).toBe(true)
```

That is the change working end to end through the public path — `B24Hook`,
`ParamsFactory.getDefault()`, a real axios rejection carrying a real v3 error
body — with nothing configured. It failed on the first run of this branch, which
is how it should have failed: the assertion that the old behaviour threw.

`restriction-params-merge.unit.spec.ts` used the flag as its third
"survives a partial update" field. Replaced with `softErrorCodes`, which has the
property that mattered: the default set does not populate it, so it can only be
present because the merge kept it.

The remaining 22 cases in `v3-error-category.unit.spec.ts` now configure nothing
and assert the default — including the boundaries (399 throws, 499 soft), the
excluded statuses, the flat-v2 arm, and the ordering of the three steps.

## Documentation

- `2.v3.md` — new section **Behaviour: v3 errors are classified by response
  category**, with the diff for callers who passed the flag, the before/after
  shape for callers who did not, and how to pin a code back to throwing. Placed
  beside the Node 20 section added by #512, which is the other non-symbol entry
  on that page.
- `96.error-codes.md` — the example loses its configuration; the caution becomes
  "changed in 3.0.0" rather than "off in 2.x, on in 3.0.0".
- `77.limiters.md` — the field leaves the `RestrictionParams` listing and the
  "what `...getDefault()` does not clear" paragraph; the enabling snippet is
  gone.
- `10.error-handling.md`, `55.helper-license-manager.md`,
  `skills/b24jssdk-core/SKILL.md` — the flag drops out of the knob lists; the
  skill gains a sentence saying the parameter no longer exists and that passing
  it is a compile error.

`CHANGELOG.md` keeps its `2.3.0` mention of the flag: it describes what that
release did, and rewriting history there would be false.

## Checks

- `pnpm vitest run --project jsSdk:unit` — **768 passed**, 0 failed (65 files);
  `main` at `5023a5b` is 770, and the difference is exactly the two cases
  removed above.
- `pnpm lint`, `pnpm lint:md` — clean
- `package-jssdk:typecheck`, `test:typecheck`, `docs:typecheck-blocks` (177),
  `skills:typecheck-blocks` (86) — clean
- `pnpm docs:lint` — 0 errors, 13 warnings; identical to `main` after bumping
  `audited:` on `77.limiters.md`, the only page whose `links:` cite
  `manager.ts`
- `docs-link-check` 0 broken, `api-reference-index` 95 exports — unchanged, since
  what was removed is a property of a type rather than an export
