### PR TITLE
fix(test): install browser globals by descriptor, so the unit suite stops depending on file order

### DIFF
--- a/test/0_setup/browser-globals.ts
+++ b/test/0_setup/browser-globals.ts
@@ -1,0 +1,55 @@
+/**
+ * Install and remove a browser global in a Node test, by descriptor rather than
+ * by assignment.
+ *
+ * `globalThis.navigator = …` reads as equivalent to `defineProperty` and is not.
+ * Node ships a built-in `navigator` whose own property has a **getter and no
+ * setter**, and spec files are ES modules — so in strict mode that assignment
+ * throws:
+ *
+ *     TypeError: Cannot set property navigator of #<Object> which has only a getter
+ *
+ * The pull specs did exactly that and passed anyway, because their teardown used
+ * `delete`, which removes the built-in for the rest of the process. Whichever
+ * file ran first paid the error; every file after it found a plain, writable
+ * property. `jsSdk:unit` runs its files serially in one process, so "which file
+ * runs first" silently decided whether the suite was green.
+ *
+ * The default order happened to be lucky. Adding an unrelated spec file
+ * elsewhere in the suite was enough to change the order and expose it — which is
+ * how it surfaced, as a single unexplained failure in a pull request about
+ * `.env.test` (#511). Measured on `main` before this fix: five failures in five
+ * shuffled runs, zero in the unshuffled order.
+ *
+ * `defineProperty` works whether or not a getter-only property is in the way,
+ * and `restoreGlobal` puts the original descriptor back instead of deleting it —
+ * so a file leaves the process as it found it, and the next file's assumptions
+ * about Node's built-ins stay true.
+ *
+ * Exercised directly by
+ * `test/integration/pull/pull-globals-descriptor.unit.spec.ts`.
+ */
+const savedDescriptors = new Map<string, PropertyDescriptor | undefined>()
+
+/** Install `value` as `globalThis[name]`, remembering what was there. */
+export function defineGlobal(name: string, value: unknown): void {
+  if (!savedDescriptors.has(name)) {
+    savedDescriptors.set(name, Object.getOwnPropertyDescriptor(globalThis, name))
+  }
+  Object.defineProperty(globalThis, name, { value, configurable: true, writable: true })
+}
+
+/** Put back whatever `defineGlobal` displaced — including nothing at all. */
+export function restoreGlobal(name: string): void {
+  const saved = savedDescriptors.get(name)
+  if (saved) {
+    Object.defineProperty(globalThis, name, saved)
+  } else {
+    // The key is the caller's global name, so there is no static alternative —
+    // and setting it to `undefined` is a different state from absent for every
+    // guard the SDK writes against these globals.
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete (globalThis as never as Record<string, unknown>)[name]
+  }
+  savedDescriptors.delete(name)
+}

--- a/test/integration/pull/pull-client-lifecycle-222.unit.spec.ts
+++ b/test/integration/pull/pull-client-lifecycle-222.unit.spec.ts
@@ -13,6 +13,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { PullClient } from '../../../packages/jssdk/src/pullClient/client'
 import type { TypeB24 } from '../../../packages/jssdk/src/types/b24'
+// Installing these by descriptor, and restoring the original, is what keeps this
+// file independent of the order the suite runs its files in — see
+// `test/0_setup/browser-globals.ts` for why assignment is not equivalent.
+import { defineGlobal, restoreGlobal } from '../../0_setup/browser-globals'
 
 type Listener = (...args: any[]) => void
 
@@ -34,10 +38,10 @@ function installWindowStub() {
       added.get(type)?.delete(handler)
     }
   }
-  ;(globalThis as any).window = stub
-  ;(globalThis as any).document = { location: { href: 'https://test.local/' } }
-  ;(globalThis as any).navigator = { onLine: true }
-  ;(globalThis as any).XMLHttpRequest = class {
+  defineGlobal('window', stub)
+  defineGlobal('document', { location: { href: 'https://test.local/' } })
+  defineGlobal('navigator', { onLine: true })
+  defineGlobal('XMLHttpRequest', class {
     responseType = ''
     onreadystatechange: Listener | null = null
     open() {}
@@ -46,15 +50,15 @@ function installWindowStub() {
     setRequestHeader() {}
     addEventListener() {}
     removeEventListener() {}
-  }
+  })
   return stub
 }
 
 function clearGlobals() {
-  delete (globalThis as any).window
-  delete (globalThis as any).document
-  delete (globalThis as any).navigator
-  delete (globalThis as any).XMLHttpRequest
+  restoreGlobal('window')
+  restoreGlobal('document')
+  restoreGlobal('navigator')
+  restoreGlobal('XMLHttpRequest')
 }
 
 function createClient(): PullClient {

--- a/test/integration/pull/pull-globals-descriptor.unit.spec.ts
+++ b/test/integration/pull/pull-globals-descriptor.unit.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * The pull specs must install their browser globals by descriptor, not by
+ * assignment — and must put back what they found.
+ *
+ * `globalThis.navigator = …` reads as equivalent to `defineProperty` and is not.
+ * Node's built-in `navigator` is a getter with no setter, and a spec file is an
+ * ES module, so in strict mode the assignment throws:
+ *
+ *     TypeError: Cannot set property navigator of #<Object> which has only a getter
+ *
+ * It passed anyway for as long as it did because the teardown used `delete`,
+ * which removes the built-in for the whole process. The first file to run paid
+ * the error; every later file found a plain writable property. `jsSdk:unit` runs
+ * its files serially in one process, so "which file runs first" decided whether
+ * the suite was green — a dependency on file order that the default order
+ * happened to satisfy. Measured on `main`: five failures in five shuffled runs,
+ * zero in the unshuffled order.
+ *
+ * A regression test cannot simply be "run the suite in the wrong order", because
+ * the harness picks the order. So this pins the two properties that make order
+ * stop mattering, directly — and exercises the real helpers rather than a local
+ * copy, since a test comparing two expressions it computed itself cannot fail.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { defineGlobal, restoreGlobal } from '../../0_setup/browser-globals'
+
+const ORIGINAL = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+
+function restore() {
+  if (ORIGINAL) {
+    Object.defineProperty(globalThis, 'navigator', ORIGINAL)
+  } else {
+    delete (globalThis as never as Record<string, unknown>).navigator
+  }
+}
+
+describe('#222 pull specs install browser globals safely', () => {
+  afterEach(restore)
+
+  it('Node ships navigator as a getter with no setter — the premise', () => {
+    // If this stops holding, the fix is unnecessary rather than wrong; the test
+    // says so instead of quietly passing for a new reason.
+    expect(ORIGINAL).toBeDefined()
+    expect(typeof ORIGINAL!.get).toBe('function')
+    expect(ORIGINAL!.set).toBeUndefined()
+    expect(ORIGINAL!.configurable).toBe(true)
+  })
+
+  it('plain assignment throws against that descriptor — the bug', () => {
+    expect(() => {
+      ;(globalThis as never as Record<string, unknown>).navigator = { onLine: true }
+    }).toThrowError(/only a getter/)
+  })
+
+  it('defineGlobal installs over the getter-only built-in — the fix', () => {
+    defineGlobal('navigator', { onLine: true })
+    expect((globalThis.navigator as unknown as { onLine: boolean }).onLine).toBe(true)
+    restoreGlobal('navigator')
+  })
+
+  it('restoreGlobal puts the built-in back, rather than deleting it', () => {
+    defineGlobal('navigator', { onLine: false })
+    restoreGlobal('navigator')
+
+    const now = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+    // `delete` — the old teardown — leaves this undefined, and the next file's
+    // assignment then succeeds for the wrong reason. That is the whole bug.
+    expect(now).toBeDefined()
+    expect(typeof now!.get).toBe('function')
+  })
+
+  it('the lifecycle spec no longer assigns any browser global directly', async () => {
+    // Read as text rather than exercised, because the failure mode is a future
+    // edit reintroducing the assignment — which would pass every behavioural
+    // test in that file, in the lucky order.
+    const { readFileSync } = await import('node:fs')
+    const { fileURLToPath } = await import('node:url')
+    const { dirname, join } = await import('node:path')
+
+    const here = dirname(fileURLToPath(import.meta.url))
+    const source = readFileSync(join(here, 'pull-client-lifecycle-222.unit.spec.ts'), 'utf8')
+
+    expect(source).not.toMatch(/\(globalThis as any\)\.(window|document|navigator|XMLHttpRequest)\s*=/)
+    expect(source).toContain('defineGlobal(')
+    expect(source).toContain('restoreGlobal(')
+  })
+})


### PR DESCRIPTION
Found while reviewing #511, which is **not** the cause.

## The symptom

#511 reported one unexplained failure — `1 failed | 788 passed` — that did not reproduce in eight subsequent runs, and it could not identify the test.

Repeating the same run never would have found it. Shuffling the file order does, immediately:

| branch | shuffled runs | result |
| --- | --- | --- |
| `main` | 5 | **5 failed** |
| #511's branch | 5 | 3 failed |
| this branch | 5 | **0 failed** |

The failing test is always the same:

```
FAIL test/integration/pull/pull-client-lifecycle-222.unit.spec.ts
TypeError: Cannot set property navigator of #<Object> which has only a getter
```

## The cause

The spec installed its SSR stubs by assignment:

```ts
;(globalThis as any).navigator = { onLine: true }
```

Node ships a built-in `navigator` whose own property has a **getter and no setter**. Spec files are ES modules, so strict mode applies and that assignment throws. Measured:

| context | result |
| --- | --- |
| plain script | passes silently |
| **ES module** | **throws** |
| ES module, after `delete globalThis.navigator` | passes |

So why was `main` ever green? Because the teardown used `delete`, which removes the built-in **for the rest of the process**. Whichever file ran first paid the error; every file after it found a plain, writable property. `jsSdk:unit` sets `fileParallelism: false`, so its files run serially in one process — and "which file runs first" silently decided whether the suite passed.

The default order happened to be lucky. **Adding an unrelated spec file elsewhere in the suite changes the order** — which is exactly what #511 does, and why it saw the failure once and never again: subsequent runs used its new, also-lucky order.

There is a second victim. `pull-debug-info-redaction.unit.spec.ts` documents its premise as *"`navigator.onLine` … is harmlessly `undefined` on Node's built-in navigator (a getter-only global we leave alone)"*. That premise was already false whenever the lifecycle spec had run first and deleted it.

`fileParallelism: false` was added for #222 to stop these same globals racing. It removed the concurrency but not the order dependency.

## The fix

`Object.defineProperty` installs over a getter-only property, and the teardown restores the **saved descriptor** instead of deleting — so a file leaves the process as it found it.

The helpers live in `test/0_setup/browser-globals.ts` rather than inside the spec, because the regression test has to exercise the real ones. An earlier draft asserted against a local copy and **survived** a mutation that made the teardown `delete` again — a test comparing two expressions it computes itself cannot fail. Three mutations kill it now:

| mutation | caught |
| --- | --- |
| revert `defineGlobal` to plain assignment | ✅ 2 tests |
| restore by `delete` instead of the saved descriptor | ✅ |
| `defineGlobal` forgets to save the descriptor | ✅ |

## Why the regression test looks like that

It cannot be "run the suite in the wrong order" — the harness picks the order. So it pins the properties that make order stop mattering: that Node's descriptor really is getter-only, that assignment really does throw against it, that `defineGlobal` works anyway, and that `restoreGlobal` leaves the built-in in place. Plus one text check that the lifecycle spec has not gone back to assignment — the single failure mode that would pass every behavioural test in that file, in the lucky order.

The first assertion is a premise check: if Node ever stops shipping `navigator` as a getter, the test says the fix is now unnecessary rather than quietly passing for a new reason.

## Checks

- `jsSdk:unit` shuffled — **5 runs, 793 passed, 0 failed** (`main`: 5 of 5 failed)
- `jsSdk:unit` pull specs — 34 passed
- `pnpm run test:typecheck` clean · `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_