### PR TITLE
deps: raise the audit floor that a new smol-toml advisory moved past

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ overrides:
   qs: '>=6.16.0 <7'
   devalue: '>=5.8.1 <6'
   svgo: '>=4.1.0 <5'
+  smol-toml: '>=1.7.1 <2'
   esbuild: '>=0.28.1 <0.29'
   form-data: '>=4.0.6 <5'
   '@tiptap/core': '>=3.30.4 <4'
@@ -6673,8 +6674,8 @@ packages:
     resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
     engines: {node: '>=20.0.0'}
 
-  smol-toml@1.7.0:
-    resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   socket.io-client@4.8.3:
@@ -13498,7 +13499,7 @@ snapshots:
       markdownlint: 0.41.1(supports-color@10.2.2)
       markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.23.2(supports-color@10.2.2))
       micromatch: 4.0.8
-      smol-toml: 1.7.0
+      smol-toml: 1.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16059,7 +16060,7 @@ snapshots:
 
   smob@1.6.2: {}
 
-  smol-toml@1.7.0: {}
+  smol-toml@1.8.0: {}
 
   socket.io-client@4.8.3(supports-color@10.2.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -102,6 +102,12 @@ overrides:
   # during the build — a dev dependency that executes in CI, so it is in scope.
   # The tree carries only the 4.x line.
   svgo: '>=4.1.0 <5'
+  # GHSA-7w5x-hrqm-74c2 — denial of service via a malformed TOML document.
+  # Reaches us only through `markdownlint-cli2`, a dev dependency the `lint:md`
+  # gate runs in CI, and only on input the repository controls; the floor is
+  # raised because the audit step is tree-wide and does not care about that
+  # distinction. The tree carries only the 1.x line.
+  smol-toml: '>=1.7.1 <2'
   # esbuild is 0.x — every minor is a breaking release, so the ceiling is the minor
   esbuild: '>=0.28.1 <0.29'
   form-data: '>=4.0.6 <5'


### PR DESCRIPTION
`pnpm audit --audit-level=moderate` fails on **`main`**, and therefore on every
branch opened from it — including #522 and #525, where it is the only red leg.

Same shape as #453 and #510: no code caused it. The audit queries the advisory
database live rather than reading a lockfile snapshot, so a newly published
advisory reddens everything at once, and `main`'s last green run merely predates
it. Reproduced on a clean `origin/main` before touching anything.

## The advisory

**smol-toml** — [GHSA-7w5x-hrqm-74c2](https://github.com/advisories/GHSA-7w5x-hrqm-74c2)
(**high**): denial of service via a malformed TOML document, `<=1.7.0`.

One path into the tree: `.>markdownlint-cli2>smol-toml`. That is a dev dependency
the `lint:md` gate runs in CI, on input this repository controls — so the
practical exposure is nil. The floor is raised anyway, because the audit step is
tree-wide and does not make that distinction, and a red `test` leg on every PR is
worse than an override line with a comment saying why it is there.

`smol-toml: '>=1.7.1 <2'` — the tree carries only the 1.x line; the lockfile
resolves **1.8.0**.

`pnpm lint:md` re-run after the bump (28 files, 0 issues), since
`markdownlint-cli2` is the only consumer.

## What is deliberately left

Two `low` advisories remain, both on `joi` through `docs>@bitrix24/b24ui-nuxt`:
prototype pollution via a `__proto__` language key, and `object().rename()` with a
template target. They sit below `--audit-level=moderate`, gated nothing before
this change and gate nothing after it. Folding them in would mean raising a floor
no check asks for — that belongs to whoever moves the threshold.

## Checks

```text
before  →  3 vulnerabilities found · Severity: 2 low | 1 high   exit 1
after   →  2 vulnerabilities found · Severity: 2 low            exit 0
```

- `pnpm install` — clean
- `pnpm lint:md` — 28 files, 0 issues

Sent on its own rather than folded into a feature branch: it unblocks the whole
queue, and a dependency floor has no business riding along with unrelated work.
