### PR TITLE
docs: refresh the audited stamps the #522 merge left behind

### DIFF
--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: CallListV2.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 2.'
 category: 'actions'
-audited: 2026-09-09
+audited: 2026-09-10
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: CallList

--- a/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.call-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallListV3.make
 description: 'Method for quickly retrieving all data from list methods of Bitrix24 REST API version 3.'
 category: 'actions'
-audited: 2026-09-09
+audited: 2026-09-10
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: CallList

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver2.md
@@ -2,7 +2,7 @@
 title: FetchListV2.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 2 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-09-09
+audited: 2026-09-10
 restApiVersion: 'rest-api-ver2'
 navigation:
   title: FetchList

--- a/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/2.fetch-list-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: FetchListV3.make
 description: 'Returns an AsyncGenerator that allows processing data from list methods of Bitrix24 REST API version 3 as it is received without loading the entire array into memory at once. This is especially useful when working with very large volumes of data.'
 category: 'actions'
-audited: 2026-09-09
+audited: 2026-09-10
 restApiVersion: 'rest-api-ver3'
 navigation:
   title: FetchList

--- a/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
+++ b/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
@@ -1,7 +1,7 @@
 ---
 title: Filtering
 description: 'Reference for building filter parameters in Bitrix24 REST API v2 (prefix operators) and v3 (array-of-triples), including date formatting and the order-stripping rule.'
-audited: 2026-09-09
+audited: 2026-09-10
 navigation:
   title: Filtering
 links:

--- a/docs/content/docs/99.examples/1.dashboard-deals-csv.md
+++ b/docs/content/docs/99.examples/1.dashboard-deals-csv.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Export deals to CSV'
 description: 'Stream every CRM deal that matches a date filter into a CSV file using a webhook and FetchListV2.'
-audited: 2026-09-09
+audited: 2026-09-10
 category: 'examples'
 featured: true
 cookbookOrder: 2
@@ -118,6 +118,7 @@ node scripts/deals-to-csv.mjs
 
 - `crm.item.list` returns up to 50 records per page; this is a server-side limit, not an SDK setting.
 - The generator does **not** support a custom `order` parameter — cursor pagination requires sorting by `cursorIdKey` (default `idKey`) ascending. Specifying `order` in `params` triggers a runtime warning and is stripped.
+- The walk stops after **10 000 pages** — 500 000 deals at 50 a page — and throws `JSSDK_ACTION_MAX_PAGES_EXCEEDED`{lang="ts-type"}. That is a backstop against a runaway, not a cap on this export; pass a higher `maxPages` if a portal genuinely holds more. Because `fetchList` streams, every page written to the CSV before that point is already on disk.
 - `idKey` defaults to `'ID'` (uppercase) for v2 endpoints. CRM item methods return `id` (lowercase), so override it explicitly as in the example. If a method sorts/filters by a different field name than it returns (e.g. `tasks.task.list` sorts by `ID` but returns `id`), also set `cursorIdKey` — `crm.item.list` accepts the lowercase name in both places, which is why this script needs only `idKey`. Get that pair wrong and the walk throws `JSSDK_ACTION_CURSOR_STALLED` rather than looping: see [Errors](/docs/working-with-the-rest-api/error-codes/).
 - One `B24Hook` instance corresponds to a single user account on the portal. If the deals you need are owned by another user, the webhook must be created by that user (or by an account with cross-user access).
 - For very large windows that exhaust the per-day method-call budget, split the date range into smaller chunks and run them sequentially.


### PR DESCRIPTION
`pnpm docs:lint` fails on **`main`**, and therefore on every branch opened from
it — including #525, where it is the only red leg.

```text
docs-lint: 0 error(s), 12 warning(s)
```

The `--strict` case in `scripts/__tests__/docs-lint.test.mjs` fails alongside it,
so the `docs-lint` CI job is red too.

## Nothing on those pages is wrong

#522 was written and stamped on **09-09** and squashed onto `main` on **09-10**.
`git log -1 -- <file>` therefore now reports the merge date for every source
those pages cite, which is later than the stamp. The content did not change; the
commit date did.

Same shape as #504, which cleaned up after the #494 merge.

**This will keep happening.** Stamping on the day a PR is opened and merging the
next is the ordinary case, and nothing warns at review time — the branch is green
because the source commits are still dated on the branch, and the staleness
appears only once the squash lands. The checker compares commit dates rather than
content, so it cannot tell a re-dated file from an edited one. Filed separately
(alongside #524, which is the other way this check misreports) rather than
papered over here.

## The six pages

Four are the list pages #522 itself rewrote — content audited against exactly
these sources yesterday, only the date moved.

The other two cite `call-list.ts` / `fetch-list.ts` without having been touched,
so they were **re-read** rather than restamped on faith:

- **`5.filtering.md`** — its `order`-stripping section is still accurate; #522 did
  not change that behaviour. No edit.
- **`99.examples/1.dashboard-deals-csv.md`** — re-reading found a real gap. The
  example walks *every* deal in a portal, and that walk now carries a 10 000-page
  ceiling it did not have when the page was written. Added under Limitations,
  with the part that matters for an export: `fetchList` streams, so every row
  already written to the CSV survives the error.

## Checks

```text
before  →  docs-lint: 0 error(s), 12 warning(s)   · script tests 169/170
after   →  docs-lint: 0 error(s),  0 warning(s)   · script tests 170/170
```

- `pnpm lint:md` — 28 files, 0 issues
- `pnpm docs:typecheck-blocks` — 181 blocks, clean

Sent on its own: it unblocks the queue, and a stamp refresh has no business
riding along with unrelated work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr


---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_