### PR TITLE
deps: raise the js-yaml floor to the version the manifest already asks for

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ overrides:
   tar: '>=7.5.16 <8'
   launch-editor: '>=2.14.1 <3'
   markdown-it: '>=14.1.2 <15'
-  js-yaml: '>=5.3.0 <6'
+  js-yaml: '>=5.4.1 <6'
   sharp: '>=0.35.4 <0.36'
   h3: 1.15.11
   '@nuxtjs/mdc': '>=0.23.0 <1'
@@ -77,8 +77,8 @@ importers:
         specifier: ^10.9.1
         version: 10.9.1(jiti@2.7.0)(supports-color@10.2.2)
       js-yaml:
-        specifier: '>=5.3.0 <6'
-        version: 5.3.0
+        specifier: '>=5.4.1 <6'
+        version: 5.4.1
       markdownlint-cli2:
         specifier: ^0.23.2
         version: 0.23.2(supports-color@10.2.2)
@@ -4824,8 +4824,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@5.3.0:
-    resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
+  js-yaml@5.4.1:
+    resolution: {integrity: sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@7.3.0:
@@ -7791,7 +7791,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 5.3.0
+      js-yaml: 5.4.1
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -11751,7 +11751,7 @@ snapshots:
     dependencies:
       entities: 8.0.0
       htmlparser2: 12.0.0
-      js-yaml: 5.3.0
+      js-yaml: 5.4.1
       markdown-exit: 1.1.0-beta.2
     optionalDependencies:
       shiki: 4.4.3
@@ -13165,7 +13165,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@5.3.0:
+  js-yaml@5.4.1:
     dependencies:
       argparse: 2.0.1
 
@@ -13492,7 +13492,7 @@ snapshots:
   markdownlint-cli2@0.23.2(supports-color@10.2.2):
     dependencies:
       globby: 16.2.2
-      js-yaml: 5.3.0
+      js-yaml: 5.4.1
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.3.0
@@ -13892,7 +13892,7 @@ snapshots:
   minimark@1.0.0:
     dependencies:
       entities: 7.0.1
-      js-yaml: 5.3.0
+      js-yaml: 5.4.1
 
   minimatch@10.2.6:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -158,7 +158,7 @@ overrides:
   # GHSA-5p4m-2wfm-xmqj — quadratic CPU consumption in `!!omap` resolution
   # (CVE-2026-59870 fix not backported below 4.3.1; the 5.x line carries both
   # fixes, and 5 is what the root manifest now declares)
-  js-yaml: '>=5.3.0 <6'
+  js-yaml: '>=5.4.1 <6'
   # GHSA-f88m-g3jw-g9cj — sharp; reached via docs>@nuxt/image>ipx and
   # docs>nuxt-og-image. sharp is 0.x, so the ceiling is the minor.
   # Floor raised for GHSA-rgj7-g3m4-5g8c: the bundled libheif carries


### PR DESCRIPTION
Found while assessing #503. It is a live defect on `main`, not something that PR introduces.

## What is wrong

`package.json` has declared `js-yaml: ^5.4.1` since #470. The tree resolves **5.3.0**:

```text
package.json          js-yaml: ^5.4.1
pnpm-workspace.yaml   js-yaml: '>=5.3.0 <6'      ← from #344, never moved
node_modules          5.3.0
```

#470's bump never took effect, and nothing said so.

This is the **LOWER BOUND** failure mode written up in `pnpm-workspace.yaml` itself: an override replaces the range every dependent declares *and* is what pnpm records as the lockfile specifier, so a floor that lags a manifest holds an older version that `pnpm install --frozen-lockfile` accepts without complaint. There is no gate that catches it. The same note records `nuxt` having done exactly this before — which is how the note came to be written.

## Why it matters for #503

#503 proposes `js-yaml 5.3.0 → 5.4.1`. Dependabot reads the *resolved* version, so it is offering to redo a bump that already happened in the manifest. Merged against the current floor it would resolve 5.3.0 again — a no-op that reads as a success.

With this in, that row of #503 is simply already satisfied.

## Scope

Swept every floor in the overrides block against every manifest range in the workspace. **`js-yaml` is the only one lagging** — so this is one line, not a sweep.

The check is a few lines of comparison and would have caught this at #470. Worth automating; noted as a follow-up rather than smuggled in here.

## Checks

```text
before  →  node_modules/js-yaml  5.3.0
after   →  node_modules/js-yaml  5.4.1
```

- full `pnpm typecheck` — 11 passes green
- `pnpm vitest run --project jsSdk:unit` — 868 passed
- `pnpm lint` — clean; `pnpm docs:lint` — 0 errors, 0 warnings
- `node --test "scripts/__tests__/**/*.test.mjs"` — 170 passed
- `pnpm audit --audit-level=moderate` — clean at the gate's threshold

5.3 → 5.4 is a minor on a line the repo already migrated to at #344, and `scripts/_docs-utils.mjs` — the named-import consumer that migration was for — is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr


---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_