### PR TITLE
fix(http)!: state the JSON content type, and ask for the fetch adapter in a browser

### DIFF
--- a/docs/content/docs/1.getting-started/3.migration/2.v3.md
+++ b/docs/content/docs/1.getting-started/3.migration/2.v3.md
@@ -332,6 +332,71 @@ v3 envelope — and every code pinned in the built-in hard list, including
 `…INSUFFICIENTSCOPEEXCEPTION` at 403. Full detail in
 [Error Codes](/docs/working-with-the-rest-api/error-codes/#classification-by-category-restapiv3).
 
+## Behaviour: a browser now uses the `fetch` adapter
+
+Another change that alters what working code does **without producing a compile
+error**.
+
+Axios picks its adapter by walking `['xhr', 'http', 'fetch']` and taking the
+first supported entry, so anywhere `XMLHttpRequest` exists — a window, a worker —
+it picked **XHR**, by list order rather than by merit. In `3.0.0` the SDK asks for
+`fetch` in a browser-like runtime. Node is untouched: XHR does not exist there,
+the `http` adapter is already what gets chosen, and it stays chosen.
+
+Three things follow, and only in a browser.
+
+**1. A blocked redirect now errors.** `maxRedirects: 0` is read by `fetch` (as
+`redirect: 'manual'`) and was ignored outright by XHR. The SDK sets it on one
+request — a `restApi:v3` batch on a non-hook transport, which carries an access
+token that a redirect to a subdomain would take along — so on that one path a
+redirecting deployment now fails with `JSSDK_HTTP_REDIRECT_BLOCKED` where it used
+to complete the hop silently. Ordinary calls are unaffected.
+
+**2. A test double that stubs `XMLHttpRequest` stops intercepting.** `jsdom`
+counts as a browser here, so a suite mocking XHR no longer sees SDK traffic.
+
+**3. `onUploadProgress` on your own requests through `ajaxClient`** degrades
+outside Chromium: axios gates it on request streaming, which Firefox and Safari
+do not offer, where XHR always delivered progress events.
+
+### The opt-out
+
+Every entry point takes `httpOptions` at construction, merged over the SDK's own
+axios defaults, so naming an adapter wins:
+
+```ts
+import { B24Hook } from '@bitrix24/b24jssdk'
+
+const $b24 = B24Hook.fromWebhookUrl(
+  'https://your-portal.bitrix24.com/rest/1/SECRET',
+  { httpOptions: { adapter: 'xhr' } }
+)
+```
+
+`B24Frame`, `B24Hook` and `B24OAuth` take the same option — and `B24Frame`, the browser entry point, is the one this change is about. It is a
+narrow slice of `AxiosRequestConfig`{lang="ts-type"} — `TypeHttpOptions`{lang="ts-type"} — deliberately: the keys
+the SDK needs in order to reach the portal are not offered there, and stay
+reachable through
+[`ajaxClient.defaults`](/docs/working-with-the-rest-api/core-http/#configuring-the-axios-instance).
+
+## Behaviour: the JSON content type is stated, not inherited
+
+The SDK has always sent JSON bodies, but never asked for the content type — axios
+supplies `application/json` on its own for a plain-object body. As of `3.0.0` the
+SDK sets the header itself, per request.
+
+This matters because the axios instance is public. A `Content-Type` on
+`ajaxClient.defaults` used to change the encoding of every SDK request, and the
+portal reads a `filter` boolean **only** from a JSON body: under
+`application/x-www-form-urlencoded` a `false`{lang="ts-type"} arrives as the
+string `"false"`, the condition is dropped, and the call answers with rows it
+should have excluded — with no error on either side. See
+[Filtering](/docs/working-with-the-rest-api/filtering/).
+
+Nothing to change on your side unless you were relying on that default to
+re-encode SDK traffic. `ajaxClient.defaults.headers` no longer reaches it; your
+own requests through the same instance are unaffected, `FormData` included.
+
 ## Typing: `placement.options` is no longer `any`
 
 `B24Frame`'s `placement.options` used to be typed `any`{lang="ts-type"} on a value

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
@@ -166,6 +166,49 @@ await $b24.actions.v3.call.make({
 })
 ```
 
+#### Which HTTP adapter runs
+
+In a **browser** the SDK asks axios for the `fetch` adapter. Left to itself axios
+walks `['xhr', 'http', 'fetch']` and takes the first *supported* entry, so
+anywhere `XMLHttpRequest` exists — a window, a dedicated worker, a shared
+worker — it picks **XHR** and never reaches `fetch`. That is selection by list
+order rather than by merit.
+
+Outside a browser nothing is asked for and axios decides: in Node there is no
+`XMLHttpRequest`, so `http` is already what gets picked, and it is the right one
+there.
+
+Name one yourself at construction if you would rather:
+
+```ts
+import { B24Hook } from '@bitrix24/b24jssdk'
+
+const b24 = B24Hook.fromWebhookUrl('https://your-portal.bitrix24.com/rest/1/SECRET')
+```
+
+```ts
+import { B24Hook } from '@bitrix24/b24jssdk'
+
+const b24 = new B24Hook(
+  { b24Url: 'https://your-portal.bitrix24.com', userId: 1, secret: 'SECRET' },
+  { httpOptions: { adapter: 'xhr' } }
+)
+```
+
+`httpOptions` is merged over the SDK's own axios defaults, so any key you name
+wins — `adapter` is simply the one this exists for.
+
+::warning
+**One behaviour moves with the adapter.** `maxRedirects` is read by `fetch` (as
+`redirect: 'manual'`) and ignored outright by XHR. The SDK sets it on the branch
+that carries an OAuth access token in the query string, to stop that token
+following a redirect. On `fetch` that guard now bites where it used to be inert:
+a redirecting deployment answers with an opaque `status: 0` instead of silently
+following the hop with the credential attached. That is the guard working, but it
+is a change of behaviour, not a no-op.
+::
+
+
 See [Limiters → Long-Running Requests & Non-idempotent Calls](/docs/working-with-the-rest-api/limiters/#long-running-requests--non-idempotent-calls)
 for the full explanation and alternative configurations.
 

--- a/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
+++ b/docs/content/docs/2.working-with-the-rest-api/1.call-rest-api-ver3.md
@@ -2,7 +2,7 @@
 title: CallV3.make
 description: 'Method for making Bitrix24 REST API version 3 calls.'
 category: 'actions'
-audited: 2026-09-09
+audited: 2026-09-12
 restApiVersion: 'rest-api-ver3'
 navigation.title: Call
 links:
@@ -165,49 +165,6 @@ await $b24.actions.v3.call.make({
   params: {/*…*/}
 })
 ```
-
-#### Which HTTP adapter runs
-
-In a **browser** the SDK asks axios for the `fetch` adapter. Left to itself axios
-walks `['xhr', 'http', 'fetch']` and takes the first *supported* entry, so
-anywhere `XMLHttpRequest` exists — a window, a dedicated worker, a shared
-worker — it picks **XHR** and never reaches `fetch`. That is selection by list
-order rather than by merit.
-
-Outside a browser nothing is asked for and axios decides: in Node there is no
-`XMLHttpRequest`, so `http` is already what gets picked, and it is the right one
-there.
-
-Name one yourself at construction if you would rather:
-
-```ts
-import { B24Hook } from '@bitrix24/b24jssdk'
-
-const b24 = B24Hook.fromWebhookUrl('https://your-portal.bitrix24.com/rest/1/SECRET')
-```
-
-```ts
-import { B24Hook } from '@bitrix24/b24jssdk'
-
-const b24 = new B24Hook(
-  { b24Url: 'https://your-portal.bitrix24.com', userId: 1, secret: 'SECRET' },
-  { httpOptions: { adapter: 'xhr' } }
-)
-```
-
-`httpOptions` is merged over the SDK's own axios defaults, so any key you name
-wins — `adapter` is simply the one this exists for.
-
-::warning
-**One behaviour moves with the adapter.** `maxRedirects` is read by `fetch` (as
-`redirect: 'manual'`) and ignored outright by XHR. The SDK sets it on the branch
-that carries an OAuth access token in the query string, to stop that token
-following a redirect. On `fetch` that guard now bites where it used to be inert:
-a redirecting deployment answers with an opaque `status: 0` instead of silently
-following the hop with the credential attached. That is the guard working, but it
-is a change of behaviour, not a no-op.
-::
-
 
 See [Limiters → Long-Running Requests & Non-idempotent Calls](/docs/working-with-the-rest-api/limiters/#long-running-requests--non-idempotent-calls)
 for the full explanation and alternative configurations.
@@ -400,6 +357,56 @@ does not offer it rather than guess.
 The mechanism is the portal's, not the SDK's: see
 [Bitrix24 REST v3 → «Повторный вызов без дублей»](https://apidocs.bitrix24.ru/api-reference/rest-v3.html)
 for the reference description.
+
+## Which HTTP adapter runs
+
+In a **browser** the SDK asks axios for the `fetch` adapter. Left to itself axios
+walks `['xhr', 'http', 'fetch']` and takes the first *supported* entry, so
+anywhere `XMLHttpRequest` exists — a window, a dedicated worker, a shared
+worker — it picks **XHR** and never reaches `fetch`. That is selection by list
+order rather than by merit.
+
+Outside a browser nothing is asked for and axios decides: in Node there is no
+`XMLHttpRequest`, so `http` is already what gets picked, and it is the right one
+there.
+
+Name one yourself at construction if you would rather:
+
+```ts
+import { B24Hook } from '@bitrix24/b24jssdk'
+
+const b24 = B24Hook.fromWebhookUrl('https://your-portal.bitrix24.com/rest/1/SECRET')
+```
+
+```ts
+import { B24Hook } from '@bitrix24/b24jssdk'
+
+const b24 = new B24Hook(
+  { b24Url: 'https://your-portal.bitrix24.com', userId: 1, secret: 'SECRET' },
+  { httpOptions: { adapter: 'xhr' } }
+)
+```
+
+`httpOptions` is merged over the SDK's own axios defaults, so any key you name
+wins — `adapter` is simply the one this exists for. It offers a narrow slice of
+`AxiosRequestConfig`{lang="ts-type"} (`TypeHttpOptions`{lang="ts-type"}); the keys the SDK needs to reach the portal —
+`baseURL`, `transformRequest`, `paramsSerializer`, `validateStatus`, `headers` —
+are not among them, and stay reachable through
+[`ajaxClient.defaults`](/docs/working-with-the-rest-api/core-http/#configuring-the-axios-instance).
+
+::warning
+**One behaviour moves with the adapter, on one narrow path.** `maxRedirects` is
+read by `fetch` (as `redirect: 'manual'`) and ignored outright by XHR. The SDK
+sets it where an OAuth access token rides in the query string, to stop that token
+following a redirect — which in a browser is **only a `restApi:v3` batch on a
+non-hook transport**, not an ordinary call. On `fetch` that guard bites where it
+used to be inert: a redirecting deployment gets an opaque response — status 0,
+empty body — instead of silently completing the hop with the credential attached.
+Axios resolves a response like that rather than rejecting it, so the SDK raises
+`JSSDK_HTTP_REDIRECT_BLOCKED` itself; without that the refused request would read
+as an empty success. That is the guard working, but it is a change of behaviour,
+not a no-op.
+::
 
 ## Alternatives and Recommendations
 

--- a/docs/content/docs/2.working-with-the-rest-api/5.choosing-the-right-method.md
+++ b/docs/content/docs/2.working-with-the-rest-api/5.choosing-the-right-method.md
@@ -1,7 +1,7 @@
 ---
 title: Choosing the right method
 description: 'Decision guide for picking between Call, CallList, FetchList, Batch and BatchByChunk in REST API v2 and v3.'
-audited: 2026-09-10
+audited: 2026-09-12
 navigation:
   title: Choosing the method
 links:

--- a/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
+++ b/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
@@ -106,25 +106,34 @@ validates operators and `in` / `between` shapes client-side. See the
 
 ## A boolean condition needs a JSON body
 
-The portal reads a `filter` value as a boolean **only when the request body is
-JSON**. Sent as `application/x-www-form-urlencoded`, `false`{lang="ts-type"}
-arrives as the string `"false"`, which is not a boolean to the portal — the
-condition is dropped and the call answers with rows it should have excluded.
-Nothing reports an error.
+A boolean in a `filter` survives only if the request body is **JSON**. Sent as
+`application/x-www-form-urlencoded` it arrives as a string — `"false"` rather
+than `false`{lang="ts-type"} — and the condition is dropped: the call answers
+with rows it should have excluded, and nothing reports an error.
 
-Measured on `user.get`, one portal, same minute:
+Measured on one field of one method (`user.get`, `ACTIVE`), one portal, same
+minute — so read it as what to expect rather than as a contract:
 
 | body | `filter: { ACTIVE: true }` | `filter: { ACTIVE: false }` |
 |----|----|----|
 | JSON | 1 row | **0 rows** |
 | `application/x-www-form-urlencoded` | 1 row | **1 row** — condition ignored |
 
+Only the `false`{lang="ts-type"} column carries the finding. Form-encoded
+`true`{lang="ts-type"} is equally the string `"true"`, so its 1 row is exactly
+what an ignored condition would also produce — it is there as the control, not as
+evidence. Whether the same happens to numbers or `null`{lang="ts-type"} was not
+measured.
+
 **The SDK sends JSON and now says so**, on every request, rather than relying on
 axios to pick `application/json`{lang="ts-type"} for a plain-object body. That
 matters because the axios instance is public: the SDK sets the content type per
 request, so raising `ajaxClient.defaults.timeout` — which
 [the v3 call page](/docs/working-with-the-rest-api/call-rest-api-ver3/) suggests
-for long writes — cannot change the body encoding by accident.
+for long writes — cannot change the body encoding by accident. One channel still
+reaches it: a **request interceptor** on that instance runs after the SDK's
+config is assembled, so an interceptor that sets `Content-Type` changes the
+encoding of SDK traffic too, and reopens exactly this.
 
 ::warning
 If you build the same call **by hand** — `curl`, a webhook tester, your own HTTP

--- a/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
+++ b/docs/content/docs/2.working-with-the-rest-api/5.filtering.md
@@ -1,7 +1,7 @@
 ---
 title: Filtering
 description: 'Reference for building filter parameters in Bitrix24 REST API v2 (prefix operators) and v3 (array-of-triples), including date formatting and the order-stripping rule.'
-audited: 2026-09-10
+audited: 2026-09-12
 navigation:
   title: Filtering
 links:
@@ -103,6 +103,35 @@ Two-arg forms are sugar:
 For anything beyond a flat list, prefer the typed `FilterV3` builder — it
 validates operators and `in` / `between` shapes client-side. See the
 [b24jssdk-filtering skill](https://github.com/bitrix24/b24jssdk/blob/main/skills/b24jssdk-filtering/SKILL.md).
+
+## A boolean condition needs a JSON body
+
+The portal reads a `filter` value as a boolean **only when the request body is
+JSON**. Sent as `application/x-www-form-urlencoded`, `false`{lang="ts-type"}
+arrives as the string `"false"`, which is not a boolean to the portal — the
+condition is dropped and the call answers with rows it should have excluded.
+Nothing reports an error.
+
+Measured on `user.get`, one portal, same minute:
+
+| body | `filter: { ACTIVE: true }` | `filter: { ACTIVE: false }` |
+|----|----|----|
+| JSON | 1 row | **0 rows** |
+| `application/x-www-form-urlencoded` | 1 row | **1 row** — condition ignored |
+
+**The SDK sends JSON and now says so**, on every request, rather than relying on
+axios to pick `application/json`{lang="ts-type"} for a plain-object body. That
+matters because the axios instance is public: the SDK sets the content type per
+request, so raising `ajaxClient.defaults.timeout` — which
+[the v3 call page](/docs/working-with-the-rest-api/call-rest-api-ver3/) suggests
+for long writes — cannot change the body encoding by accident.
+
+::warning
+If you build the same call **by hand** — `curl`, a webhook tester, your own HTTP
+client — send it as JSON. A form-encoded body is where this bites, and it bites
+silently: the rows look plausible, there is no error, and the filter that was
+ignored is the one you were relying on.
+::
 
 ## Dates
 

--- a/docs/content/docs/2.working-with-the-rest-api/70.core-http.md
+++ b/docs/content/docs/2.working-with-the-rest-api/70.core-http.md
@@ -81,9 +81,21 @@ For most use cases call [`actions.v2.batch.make`](/docs/working-with-the-rest-ap
 
 ## Configuring the axios instance
 
-`ajaxClient` is the live axios instance the transport uses. There is no
-constructor option for axios settings today, so this is where you change them —
-after the client exists, through `defaults`:
+`ajaxClient` is the live axios instance the transport uses. There are two ways
+in. `httpOptions` at construction is merged over the SDK's own defaults, which is
+where `adapter` belongs; anything else you can change after the client exists,
+through `defaults`:
+
+```ts
+import { B24Hook } from '@bitrix24/b24jssdk'
+
+const b24 = B24Hook.fromWebhookUrl(
+  'https://your-portal.bitrix24.com/rest/1/SECRET',
+  { httpOptions: { adapter: 'xhr' } }
+)
+```
+
+`httpOptions` is a deliberately narrow slice of `AxiosRequestConfig`{lang="ts-type"} — `TypeHttpOptions`{lang="ts-type"}: `adapter`, `timeout`, `timeoutErrorMessage`, `proxy`, `httpAgent`, `httpsAgent`, `maxRedirects`, `maxContentLength`, `maxBodyLength`, `decompress`, `withCredentials`. `baseURL`, `transformRequest`, `paramsSerializer`, `validateStatus` and `headers` are how the SDK talks to the portal, and overriding them breaks it quietly — a `transformRequest`{lang="ts-type"} here replaces the request body wholesale, with no error on either side and a portal-side failure only — so they are not offered here. They remain reachable through `defaults` below, where it reads as the deliberate act it is.
 
 ```ts
 import { ApiVersion } from '@bitrix24/b24jssdk'
@@ -94,11 +106,37 @@ http.ajaxClient.defaults.timeout = 120_000
 http.ajaxClient.defaults.proxy = { host: '10.0.0.1', port: 3128 }
 ```
 
-Two things the SDK sets and you should know before overriding them:
+Four things the SDK sets and you should know before overriding them:
 
 - **`timeout: 30_000`** and a matching `timeoutErrorMessage`. Raise it for a
-  long-running report method rather than raising the retry count.
+  long-running report method rather than raising the retry count. The message is
+  read by the XHR and Node adapters only; on `fetch` axios composes its own
+  (`timeout of 30000ms exceeded`, code `ETIMEDOUT` rather than `ECONNABORTED`).
+  The SDK classifies both as a timeout either way.
 - **`User-Agent`**, on server-side runtimes only — browsers forbid the header.
+- **`Content-Type: application/json`**, per request rather than on the instance.
+  The portal reads a `filter` boolean only from a JSON body, and axios was
+  supplying that content type by default rather than by intent — see
+  [Filtering](/docs/working-with-the-rest-api/filtering/). Because it is set per
+  request, `ajaxClient.defaults.headers` no longer reaches SDK traffic; your own
+  requests through this instance are unaffected, including a `FormData` body,
+  whose multipart boundary axios still computes. A **request interceptor** you
+  install on this instance still outranks it — that runs after the config is
+  assembled — so an interceptor that sets `Content-Type` changes the encoding of
+  SDK traffic too, and with it the boolean-filter behaviour above.
+- **`adapter: 'fetch'`, in a browser or a worker only.** Left alone, axios walks
+  `['xhr', 'http', 'fetch']` and takes the first supported entry, which is XHR
+  wherever `XMLHttpRequest` exists. Outside a browser nothing is asked for.
+
+::note
+**Two things follow from the adapter, if you touch this instance yourself.**
+A test suite running under `jsdom` counts as a browser here, so a double that
+stubs `XMLHttpRequest` stops intercepting SDK traffic — pass
+`httpOptions: { adapter: 'xhr' }` in that suite. And axios gates
+`onUploadProgress` on request streaming, which only Chromium over HTTP/2
+supports: your own uploads through `ajaxClient` get no progress events in
+Firefox or Safari, where XHR always delivered them. Same opt-out.
+::
 
 ::warning
 **`maxRedirects` is forced to `0` on one request, and only one.** A
@@ -113,6 +151,18 @@ The constraint is per-request, not on the instance: nothing else the SDK sends
 is affected, and a redirect elsewhere in your traffic still works. A portal that
 does redirect this one request gets a legible 301 instead of a silent hop with a
 bearer token attached.
+
+**In a browser the sibling branch behaves differently**, and since the `fetch`
+adapter arrived it is no longer inert. There the token rides in the query string
+rather than a header, `maxRedirects: 0` is set for the same reason, and `fetch`
+reads it as `redirect: 'manual'` where XHR ignored it outright. What comes back
+is an **opaque** response — `status: 0`{lang="ts-type"}, empty body, no headers —
+and axios *resolves* that: `settle` returns early on any falsy status, before
+`validateStatus` is consulted, and the fetch adapter has no status-0 guard of its
+own (XHR did). Left at that, the refused request would answer as a silently empty
+success, so the SDK raises `JSSDK_HTTP_REDIRECT_BLOCKED` itself — only on the
+request that asked for `maxRedirects: 0`, so an ordinary status-0 network failure
+is unaffected. Same narrow scope: a `restApi:v3` batch on a non-hook transport.
 
 If you know your redirect target and want the hop anyway, a transport subclass
 can return `maxRedirects` from `_prepareRequestConfig` and it wins — the value

--- a/docs/content/docs/2.working-with-the-rest-api/78.logging.md
+++ b/docs/content/docs/2.working-with-the-rest-api/78.logging.md
@@ -2,7 +2,7 @@
 title: Logging & Credential Redaction
 description: 'What the SDK redacts automatically before any request information enters the logger or an AjaxError, what it does not redact, and how to wire a custom logger via setLogger(...) without re-introducing credential leaks.'
 category: 'logging'
-audited: 2026-09-08
+audited: 2026-09-12
 navigation.title: Logging & Redaction
 links:
   - label: redact.ts (canonical key list)

--- a/docs/content/docs/99.examples/1.dashboard-deals-csv.md
+++ b/docs/content/docs/99.examples/1.dashboard-deals-csv.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Export deals to CSV'
 description: 'Stream every CRM deal that matches a date filter into a CSV file using a webhook and FetchListV2.'
-audited: 2026-09-10
+audited: 2026-09-12
 category: 'examples'
 featured: true
 cookbookOrder: 2

--- a/docs/content/docs/99.examples/2.frame-app-skeleton.md
+++ b/docs/content/docs/99.examples/2.frame-app-skeleton.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Frame app skeleton'
 description: 'Minimum viable Bitrix24 iframe app: init handshake, set title, persist app state, open a slider, close cleanly.'
-audited: 2026-08-24
+audited: 2026-09-12
 category: 'examples'
 featured: true
 cookbookOrder: 4

--- a/docs/content/docs/99.examples/3.webhook-cli-node.md
+++ b/docs/content/docs/99.examples/3.webhook-cli-node.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Webhook CLI smoke test'
 description: 'A 30-line Node script that authenticates against a Bitrix24 portal via inbound webhook and prints the calling user — useful as the first thing you run after creating a webhook.'
-audited: 2026-09-01
+audited: 2026-09-12
 category: 'examples'
 featured: true
 cookbookOrder: 1

--- a/docs/content/docs/99.examples/4.bulk-update-deals.md
+++ b/docs/content/docs/99.examples/4.bulk-update-deals.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recipe: Bulk update deals'
 description: 'Migrate thousands of CRM deals to a new stage using BatchByChunkV2 — automatic chunking, partial-error handling, and a single progress line.'
-audited: 2026-09-09
+audited: 2026-09-12
 category: 'examples'
 featured: true
 cookbookOrder: 3

--- a/packages/jssdk/src/core/abstract-b24.ts
+++ b/packages/jssdk/src/core/abstract-b24.ts
@@ -176,8 +176,21 @@ export abstract class AbstractB24 implements TypeB24 {
    * Returns settings for http connection
    * @protected
    */
+  /**
+   * Axios config handed to both transports at construction.
+   *
+   * `null` by default: the transports already choose sensible defaults, and an
+   * entry point that takes no such option from its caller has nothing to add.
+   * The entry points that do accept one assign this before building the clients.
+   *
+   * Whatever lands here is spread **after** the transport's own defaults, so a
+   * caller wins on any key they name — including `adapter`, which is the reason
+   * this channel is open to callers at all.
+   */
+  protected _httpOptions: null | object = null
+
   protected _getHttpOptions(): null | object {
-    return null
+    return this._httpOptions
   }
 
   /**

--- a/packages/jssdk/src/core/abstract-b24.ts
+++ b/packages/jssdk/src/core/abstract-b24.ts
@@ -1,6 +1,6 @@
 import type { LoggerInterface } from '../logger'
 import type { TypeB24 } from '../types/b24'
-import type { TypeHttp } from '../types/http'
+import type { TypeHttp, TypeHttpOptions } from '../types/http'
 import type { AuthActions } from '../types/auth'
 import type { RestrictionParams } from '../types/limiters'
 import { SdkError } from './sdk-error'
@@ -173,10 +173,6 @@ export abstract class AbstractB24 implements TypeB24 {
   }
 
   /**
-   * Returns settings for http connection
-   * @protected
-   */
-  /**
    * Axios config handed to both transports at construction.
    *
    * `null` by default: the transports already choose sensible defaults, and an
@@ -187,9 +183,14 @@ export abstract class AbstractB24 implements TypeB24 {
    * caller wins on any key they name — including `adapter`, which is the reason
    * this channel is open to callers at all.
    */
-  protected _httpOptions: null | object = null
+  protected _httpOptions: null | TypeHttpOptions = null
 
-  protected _getHttpOptions(): null | object {
+  /**
+   * Settings for the http connection, read once per transport at construction.
+   *
+   * @protected
+   */
+  protected _getHttpOptions(): null | TypeHttpOptions {
     return this._httpOptions
   }
 

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -175,9 +175,15 @@ function isCorsEnforcedRuntime(): boolean {
  * `redirect: 'manual'`; the XHR adapter ignores it outright. The only branch that
  * sets it in a browser is the query-auth one below, which exists to stop an
  * access token following a redirect — so the change is that the guard now bites
- * where it used to be inert, and a redirecting deployment gets an opaque
- * `status: 0` instead of a silent hop carrying the credential. That is the
- * guard doing its job, but it is a change, not a no-op.
+ * where it used to be inert: a redirecting deployment gets an opaque response
+ * (status 0, empty body) instead of a silent hop carrying the credential.
+ *
+ * Opaque is not the same as rejected. `settle` resolves any response whose
+ * status is falsy *before* `validateStatus` is consulted, and unlike the XHR
+ * adapter — which rejects `status === 0` as `ECONNABORTED` on its own — the
+ * fetch adapter has no such guard, so that blocked redirect would otherwise
+ * reach the caller as an empty **success**. `_makeAxiosRequest` states it
+ * instead, on the branch that asked for `maxRedirects: 0` and nowhere else.
  *
  * Returned as a spread-able object rather than a value so "no opinion" and
  * "`undefined` on purpose" stay distinguishable, and placed **before** the
@@ -801,10 +807,12 @@ export abstract class AbstractHttp implements TypeHttp {
     // be load-bearing for someone. This branch is different: it is reached only
     // by a v3 batch on a non-hook transport, which fails on every portal today —
     // there is no working behaviour here to preserve. A deployment that does
-    // redirect gets a rejection through `validateStatus` instead of a silent hop
-    // with a credential attached — as a legible 301 on the Node adapter, and as
-    // an opaque `status: 0` on `fetch`, where `redirect: 'manual'` is what
-    // `maxRedirects: 0` becomes and the response carries no status of its own.
+    // redirect gets an error instead of a silent hop with a credential attached —
+    // a legible 301 through `validateStatus` on the Node adapter, and on `fetch`,
+    // where `redirect: 'manual'` is what `maxRedirects: 0` becomes and the
+    // response carries no status of its own, the explicit status-0 check after
+    // the `post` below (axios resolves an opaque response rather than rejecting
+    // it).
     //
     // Before the spread, not after, so it is a default rather than a lock: a
     // transport that overrides `_prepareRequestConfig` — `HttpV2` already does —
@@ -829,8 +837,12 @@ export abstract class AbstractHttp implements TypeHttp {
     // boundary axios computes for them. This states what the SDK's own traffic
     // depends on without deciding anything for traffic it does not own.
     //
-    // After the `requestConfig` spread so a transport can still override it;
-    // none does today.
+    // Spread first inside `headers`, so anything a transport puts in
+    // `requestConfig.headers` overrides it; none does today. What this does not
+    // reach is a request interceptor installed on the public `ajaxClient` — that
+    // runs after the config is assembled and can still replace the header (and
+    // with it the encoding). Documented rather than defended: the instance is
+    // public on purpose.
     const jsonBody = { 'Content-Type': 'application/json' }
 
     const effectiveConfig: AxiosRequestConfig | undefined = canSendAuthHeader
@@ -882,6 +894,26 @@ export abstract class AbstractHttp implements TypeHttp {
     }
 
     const response = await this._clientAxios.post<SuccessPayload<T>>(methodFormatted, paramsFormatted, effectiveConfig)
+
+    // A blocked redirect is not an error on every adapter, so say so here.
+    // `settle` resolves any response with a falsy status before `validateStatus`
+    // runs, and the fetch adapter — what a browser now gets — turns
+    // `redirect: 'manual'` into an opaque response: status 0, empty body, no
+    // headers. The XHR adapter rejected that shape itself (`ECONNABORTED`);
+    // fetch does not, so without this the caller gets a successful, silently
+    // empty answer to a request the SDK deliberately refused to follow.
+    //
+    // Scoped to the branch that set `maxRedirects: 0`, so an ordinary status-0
+    // network failure keeps its existing classification.
+    if (0 === effectiveConfig?.maxRedirects && 0 === response.status) {
+      throw new AjaxError({
+        code: 'JSSDK_HTTP_REDIRECT_BLOCKED',
+        description: 'The portal answered with a redirect, which this request does not follow: it carries an access token, '
+          + 'and a redirect to a subdomain would take the credential along. Point the SDK at the final URL instead.',
+        status: 0,
+        requestInfo: { method, params, requestId }
+      })
+    }
 
     // Redact the log-bound copy only; callers still receive the untouched
     // `response.data` below. First-party success bodies don't embed credentials

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -155,6 +155,43 @@ function isCorsEnforcedRuntime(): boolean {
 }
 
 /**
+ * Which axios adapter to ask for, when there is a reason to ask at all.
+ *
+ * Axios walks its default `['xhr', 'http', 'fetch']` and takes the first
+ * supported* entry, so anywhere `XMLHttpRequest` exists — a window, a dedicated
+ * worker, a shared worker — it picks **XHR** and never reaches `fetch`. That is a
+ * 1999 API chosen by ordering rather than by merit: no streaming, no
+ * `AbortSignal` beyond `abort()`, and headers that arrive as one folded string.
+ *
+ * So in a browser-like runtime this asks for `fetch` instead. Everywhere else —
+ * Node, most obviously — nothing is returned and axios decides for itself: there
+ * XHR does not exist, the `http` adapter is already what gets picked, and it is
+ * the better one for that runtime.
+ *
+ * Guarded on `fetch` actually being there rather than on a version check, since
+ * the point is to reach it, not to assert an era.
+ *
+ * **One behaviour moves with it.** The fetch adapter reads `maxRedirects`, as
+ * `redirect: 'manual'`; the XHR adapter ignores it outright. The only branch that
+ * sets it in a browser is the query-auth one below, which exists to stop an
+ * access token following a redirect — so the change is that the guard now bites
+ * where it used to be inert, and a redirecting deployment gets an opaque
+ * `status: 0` instead of a silent hop carrying the credential. That is the
+ * guard doing its job, but it is a change, not a no-op.
+ *
+ * Returned as a spread-able object rather than a value so "no opinion" and
+ * "`undefined` on purpose" stay distinguishable, and placed **before** the
+ * caller's `options` so an explicit `adapter` always wins.
+ */
+function preferredAdapter(): { adapter?: 'fetch' } {
+  if (!isCorsEnforcedRuntime()) {
+    return {}
+  }
+
+  return 'function' === typeof globalThis.fetch ? { adapter: 'fetch' } : {}
+}
+
+/**
  * Abstract base class for all Bitrix24 REST API HTTP transports.
  *
  * Provides shared infrastructure used by {@link HttpV2} and {@link HttpV3}: Axios instance
@@ -215,6 +252,7 @@ export abstract class AbstractHttp implements TypeHttp {
     this._clientAxios = axios.create({
       timeout: 30_000,
       timeoutErrorMessage: 'Request timeout exceeded',
+      ...preferredAdapter(),
       ...(options ?? {}),
       // headers last so the merged default + caller headers aren't wiped by an
       // `options.headers` (or the previous `headers: undefined`) spread (#144).

--- a/packages/jssdk/src/core/http/abstract-http.ts
+++ b/packages/jssdk/src/core/http/abstract-http.ts
@@ -773,18 +773,48 @@ export abstract class AbstractHttp implements TypeHttp {
     // can hand back a `maxRedirects` and win. `TypeCallOptions` carries no such
     // field today, so there is no way for an ordinary caller to reopen it, which
     // is the right way round for a credential.
+    // The portal reads a `filter` value as a boolean only when the body is JSON.
+    // Under `application/x-www-form-urlencoded`, `ACTIVE: false` arrives as the
+    // string `"false"`, the condition is dropped, and the call answers with rows
+    // it should have excluded — no error on either side. Measured on
+    // `user.get` (`filter: { ACTIVE: false }` → 0 rows as JSON, 1 as form data,
+    // against the same portal in the same minute).
+    //
+    // The SDK has always sent JSON, but never asked for it: axios picks
+    // `application/json` on its own for a plain-object body. That default is
+    // reachable — `ajaxClient` is public and the docs encourage touching it to
+    // raise `defaults.timeout` — so one header on the instance silently breaks
+    // every boolean filter portal-wide.
+    //
+    // Per request rather than on the instance, deliberately: a caller who posts
+    // `FormData` through `ajaxClient` themselves still gets the multipart
+    // boundary axios computes for them. This states what the SDK's own traffic
+    // depends on without deciding anything for traffic it does not own.
+    //
+    // After the `requestConfig` spread so a transport can still override it;
+    // none does today.
+    const jsonBody = { 'Content-Type': 'application/json' }
+
     const effectiveConfig: AxiosRequestConfig | undefined = canSendAuthHeader
       ? {
           maxRedirects: 0,
           ...requestConfig,
           headers: {
+            ...jsonBody,
             ...requestConfig?.headers,
             Authorization: `Bearer ${authData.access_token}`
           }
         }
       : useQueryAuth
-        ? { maxRedirects: 0, ...requestConfig }
-        : requestConfig
+        ? {
+            maxRedirects: 0,
+            ...requestConfig,
+            headers: { ...jsonBody, ...requestConfig?.headers }
+          }
+        : {
+            ...requestConfig,
+            headers: { ...jsonBody, ...requestConfig?.headers }
+          }
 
     // `paramsFormatted` carries the OAuth `auth` (access_token) for non-hook flows;
     // log a redacted copy so the secret never enters logger context, while axios

--- a/packages/jssdk/src/frame/b24.ts
+++ b/packages/jssdk/src/frame/b24.ts
@@ -1,3 +1,4 @@
+import type { TypeHttpOptions } from '../types/http'
 import { SdkError } from '../core/sdk-error'
 import type { LoggerInterface } from '../logger'
 import type { B24LangList } from '../core/language/list'
@@ -53,11 +54,17 @@ export class B24Frame extends AbstractB24 implements TypeB24 {
     queryParams: B24FrameQueryParams,
     options?: {
       restrictionParams?: Partial<RestrictionParams>
+      /**
+       * Axios settings for both transports, merged over the SDK's own defaults.
+       * See {@link TypeHttpOptions} — the key it exists for is `adapter`.
+       */
+      httpOptions?: TypeHttpOptions
     }
   ) {
     super()
 
     this.#restrictionParams = options?.restrictionParams
+    this._httpOptions = options?.httpOptions ?? null
 
     this.#appFrame = new AppFrame(queryParams)
 

--- a/packages/jssdk/src/hook/b24.ts
+++ b/packages/jssdk/src/hook/b24.ts
@@ -1,4 +1,4 @@
-import type { AxiosRequestConfig } from 'axios'
+import type { TypeHttpOptions } from '../types/http'
 import { SdkError } from '../core/sdk-error'
 import type { AuthActions, B24HookParams } from '../types/auth'
 import type { RestrictionParams } from '../types/limiters'
@@ -36,14 +36,10 @@ export class B24Hook extends AbstractB24 implements TypeB24 {
     options?: {
       restrictionParams?: Partial<RestrictionParams>
       /**
-       * Axios config for both transports, merged over the SDK's own defaults.
-       *
-       * The key this exists for is `adapter`. In a browser the SDK asks for
-       * `fetch`, because axios would otherwise pick XHR by list order; pass
-       * `{ adapter: 'xhr' }` to go back, or name any adapter axios accepts.
-       * Everywhere else nothing is asked for and axios decides.
+       * Axios settings for both transports, merged over the SDK's own defaults.
+       * See {@link TypeHttpOptions} — the key it exists for is `adapter`.
        */
-      httpOptions?: AxiosRequestConfig
+      httpOptions?: TypeHttpOptions
     }
   ) {
     super()
@@ -113,7 +109,10 @@ export class B24Hook extends AbstractB24 implements TypeB24 {
    * without echoing the URL (which contains the secret).
    *
    * @param url - Full webhook URL as shown in the Bitrix24 admin panel.
-   * @param options - Optional restriction parameters (rate limits, etc.).
+   * @param options - Optional restriction parameters (rate limits, etc.) and
+   *     `httpOptions`, forwarded to the constructor unchanged — this is the
+   *     factory the documentation recommends, so the escape hatch has to be
+   *     reachable from it.
    * @returns A ready-to-use `B24Hook` instance.
    * @throws {SdkError} If the URL is empty (`JSSDK_HOOK_URL_EMPTY`), unparseable
    *     (`JSSDK_HOOK_URL_INVALID`), not HTTPS (`JSSDK_HOOK_URL_NOT_HTTPS`),
@@ -122,7 +121,10 @@ export class B24Hook extends AbstractB24 implements TypeB24 {
    */
   public static fromWebhookUrl(
     url: string,
-    options?: { restrictionParams?: Partial<RestrictionParams> }
+    options?: {
+      restrictionParams?: Partial<RestrictionParams>
+      httpOptions?: TypeHttpOptions
+    }
   ): B24Hook {
     if (!url.trim()) {
       throw new SdkError({ code: 'JSSDK_HOOK_URL_EMPTY', description: 'Webhook URL cannot be empty', status: 0 })

--- a/packages/jssdk/src/hook/b24.ts
+++ b/packages/jssdk/src/hook/b24.ts
@@ -1,3 +1,4 @@
+import type { AxiosRequestConfig } from 'axios'
 import { SdkError } from '../core/sdk-error'
 import type { AuthActions, B24HookParams } from '../types/auth'
 import type { RestrictionParams } from '../types/limiters'
@@ -34,6 +35,15 @@ export class B24Hook extends AbstractB24 implements TypeB24 {
     b24HookParams: B24HookParams,
     options?: {
       restrictionParams?: Partial<RestrictionParams>
+      /**
+       * Axios config for both transports, merged over the SDK's own defaults.
+       *
+       * The key this exists for is `adapter`. In a browser the SDK asks for
+       * `fetch`, because axios would otherwise pick XHR by list order; pass
+       * `{ adapter: 'xhr' }` to go back, or name any adapter axios accepts.
+       * Everywhere else nothing is asked for and axios decides.
+       */
+      httpOptions?: AxiosRequestConfig
     }
   ) {
     super()
@@ -43,6 +53,8 @@ export class B24Hook extends AbstractB24 implements TypeB24 {
     )
 
     const warningText = 'The B24Hook object is intended exclusively for use on the server.\nA webhook contains a secret access key, which MUST NOT be used in client-side code (browser, mobile app).'
+
+    this._httpOptions = options?.httpOptions ?? null
 
     this._httpV2 = new HttpV2(this.#authHookManager, this._getHttpOptions(), options?.restrictionParams)
     this._httpV2.setClientSideWarning(true, warningText)

--- a/packages/jssdk/src/oauth/b24.ts
+++ b/packages/jssdk/src/oauth/b24.ts
@@ -1,4 +1,4 @@
-import type { AxiosRequestConfig } from 'axios'
+import type { TypeHttpOptions } from '../types/http'
 import type { AuthActions, B24OAuthParams, B24OAuthSecret, CallbackRefreshAuth, CustomRefreshAuth } from '../types/auth'
 import type { RestrictionParams } from '../types/limiters'
 import type { TypeB24, ApiVersion } from '../types/b24'
@@ -40,14 +40,10 @@ export class B24OAuth extends AbstractB24 implements TypeB24 {
     options?: {
       restrictionParams?: Partial<RestrictionParams>
       /**
-       * Axios config for both transports, merged over the SDK's own defaults.
-       *
-       * The key this exists for is `adapter`. In a browser the SDK asks for
-       * `fetch`, because axios would otherwise pick XHR by list order; pass
-       * `{ adapter: 'xhr' }` to go back, or name any adapter axios accepts.
-       * Everywhere else nothing is asked for and axios decides.
+       * Axios settings for both transports, merged over the SDK's own defaults.
+       * See {@link TypeHttpOptions} — the key it exists for is `adapter`.
        */
-      httpOptions?: AxiosRequestConfig
+      httpOptions?: TypeHttpOptions
     }
   ) {
     super()

--- a/packages/jssdk/src/oauth/b24.ts
+++ b/packages/jssdk/src/oauth/b24.ts
@@ -1,3 +1,4 @@
+import type { AxiosRequestConfig } from 'axios'
 import type { AuthActions, B24OAuthParams, B24OAuthSecret, CallbackRefreshAuth, CustomRefreshAuth } from '../types/auth'
 import type { RestrictionParams } from '../types/limiters'
 import type { TypeB24, ApiVersion } from '../types/b24'
@@ -38,6 +39,15 @@ export class B24OAuth extends AbstractB24 implements TypeB24 {
     oAuthSecret: B24OAuthSecret,
     options?: {
       restrictionParams?: Partial<RestrictionParams>
+      /**
+       * Axios config for both transports, merged over the SDK's own defaults.
+       *
+       * The key this exists for is `adapter`. In a browser the SDK asks for
+       * `fetch`, because axios would otherwise pick XHR by list order; pass
+       * `{ adapter: 'xhr' }` to go back, or name any adapter axios accepts.
+       * Everywhere else nothing is asked for and axios decides.
+       */
+      httpOptions?: AxiosRequestConfig
     }
   ) {
     super()
@@ -48,6 +58,8 @@ export class B24OAuth extends AbstractB24 implements TypeB24 {
     )
 
     const warningText = 'The B24OAuth object is intended exclusively for use on the server.\nA webhook contains a secret access key, which MUST NOT be used in client-side code (browser, mobile app).'
+
+    this._httpOptions = options?.httpOptions ?? null
 
     this._httpV2 = new HttpV2(this.#authOAuthManager, this._getHttpOptions(), options?.restrictionParams)
     this._httpV2.setClientSideWarning(true, warningText)

--- a/packages/jssdk/src/types/http.ts
+++ b/packages/jssdk/src/types/http.ts
@@ -5,7 +5,7 @@ import type { PayloadTime } from './payloads'
 import type { RestrictionParams, RestrictionManagerStats } from './limiters'
 import type { ApiVersion } from './b24'
 import type { FilterV3Group } from '../tools/filter-v3'
-import type { AxiosInstance } from 'axios'
+import type { AxiosInstance, AxiosRequestConfig } from 'axios'
 
 /**
  * Types for HTTP communication with the Bitrix24 REST API: call parameters (filtering, ordering,
@@ -196,6 +196,39 @@ export type AjaxIdempotency = {
   /** `true` only when the portal marked the body as a replayed response. */
   replayed: boolean
 }
+
+/**
+ * Axios settings a caller may hand the SDK at construction, merged over the
+ * SDK's own defaults for both transports.
+ *
+ * The key this exists for is `adapter`: in a browser the SDK asks for `fetch`,
+ * because axios would otherwise walk `['xhr', 'http', 'fetch']` and take XHR by
+ * list order. Pass `{ adapter: 'xhr' }` to go back, or name any adapter axios
+ * accepts.
+ *
+ * Deliberately a narrow slice of `AxiosRequestConfig` rather than the whole
+ * thing. `baseURL`, `transformRequest`, `paramsSerializer`, `validateStatus`
+ * and `headers` are how the SDK talks to the portal — a `transformRequest` here
+ * replaces the request body wholesale, with no error on either side and a
+ * portal-side failure only — so they are not offered. Anything outside this
+ * list is still reachable after construction through
+ * `getHttpClient(version).ajaxClient.defaults`, where it reads as the
+ * deliberate act it is.
+ */
+export type TypeHttpOptions = Pick<
+  AxiosRequestConfig,
+  | 'adapter'
+  | 'timeout'
+  | 'timeoutErrorMessage'
+  | 'proxy'
+  | 'httpAgent'
+  | 'httpsAgent'
+  | 'maxRedirects'
+  | 'maxContentLength'
+  | 'maxBodyLength'
+  | 'decompress'
+  | 'withCredentials'
+>
 
 /**
  * Per-request transport options — the things that belong to one call rather

--- a/skills/b24jssdk-core/SKILL.md
+++ b/skills/b24jssdk-core/SKILL.md
@@ -273,6 +273,36 @@ const clientAxios = $b24.getHttpClient(ApiVersion.v2).ajaxClient
 clientAxios.defaults.timeout = 120_000
 ```
 
+There is a second channel, and it is the one to reach for when the setting has to
+apply from the first request: `httpOptions` at construction, on `B24Frame`,
+`B24Hook`, `B24Hook.fromWebhookUrl` and `B24OAuth`, merged over the SDK's own
+axios defaults.
+
+```ts
+import { B24Hook } from '@bitrix24/b24jssdk'
+
+const b24 = B24Hook.fromWebhookUrl(
+  'https://your-portal.bitrix24.com/rest/1/SECRET',
+  { httpOptions: { adapter: 'xhr' } }
+)
+```
+
+`adapter` is what it exists for. In a browser the SDK asks axios for `fetch` —
+left alone, axios walks `['xhr', 'http', 'fetch']` and takes XHR by list order,
+not by merit; outside a browser it asks for nothing. Pass `{ adapter: 'xhr' }` to
+go back, which is also the answer for a `jsdom` suite whose test double stubs
+`XMLHttpRequest`.
+
+`httpOptions` is a narrow slice of `AxiosRequestConfig` (`TypeHttpOptions`):
+`adapter`, `timeout`, `timeoutErrorMessage`, `proxy`, `httpAgent`, `httpsAgent`,
+`maxRedirects`, `maxContentLength`, `maxBodyLength`, `decompress`,
+`withCredentials`. `baseURL`, `transformRequest`, `paramsSerializer`,
+`validateStatus` and `headers` are how the SDK reaches the portal and are not
+offered there — `defaults` above still reaches them, where it reads as the
+deliberate act it is. Note `defaults.headers['Content-Type']` no longer changes
+SDK traffic: the SDK states the JSON content type per request (see the
+`b24jssdk-filtering` skill for why that matters).
+
 ## Enterprise limits
 
 `LicenseManager` (from `useB24Helper`) automatically swaps in the enterprise restriction params if the portal is enterprise. To do it manually:

--- a/skills/b24jssdk-filtering/SKILL.md
+++ b/skills/b24jssdk-filtering/SKILL.md
@@ -140,6 +140,27 @@ If you need a specific sort order, drop down to `call.make` and page manually �
 - **v2**: object with values `'asc' | 'desc' | 'ASC' | 'DESC'` — `order: { id: 'asc', amount: 'desc' }`.
 - **v3**: object form **only** (`{ field: 'asc' | 'desc' }`). Arrays throw `InvalidOrderException`. The DTO field must carry the server-side `#[Sortable]` attribute, or the request is **refused**: HTTP 400 with `BITRIX_REST_V3_EXCEPTION_VALIDATION_REQUESTVALIDATIONEXCEPTION` and the field name in `validation[].field`. (The specific PHP class is `DtoFieldRequiredAttributeException`, but it inherits that code and gets none of its own, so match on the code and the field — never on the message, which is localised.) `<entity>.field.list` tells you which fields are `sortable` before you send anything.
 
+## A boolean condition needs a JSON body
+
+A boolean in a `filter` survives only if the request body is **JSON**. Sent as
+`application/x-www-form-urlencoded` it arrives as the string `"false"`, the
+condition is dropped, and the call answers with rows it should have excluded —
+no error on either side. Measured on `user.get` / `ACTIVE`: JSON
+`{ ACTIVE: false }` → 0 rows, form-encoded → 1 row.
+
+The SDK states `Content-Type: application/json` on every request, per request, so
+this is handled — with two ways to undo it:
+
+- a **request interceptor** on `getHttpClient(v).ajaxClient` that sets
+  `Content-Type` runs after the SDK's config and changes the encoding;
+- building the same call **by hand** (`curl`, a webhook tester, your own client)
+  and posting form data.
+
+```ts
+// ✅ through the SDK — JSON, so the condition holds
+await $b24.actions.v2.call.make({ method: 'user.get', params: { filter: { ACTIVE: false } } })
+```
+
 ## Dates
 
 Use the SDK helper `Text.toB24Format(date)` — it produces the Bitrix24 format `yyyy-MM-dd'T'HH:mm:ssZZ` and handles `Date | DateTime | string` inputs (see `Text.toB24Format` in `packages/jssdk/src/tools/text.ts`).

--- a/skills/b24jssdk-rest/SKILL.md
+++ b/skills/b24jssdk-rest/SKILL.md
@@ -352,6 +352,16 @@ await $b24.actions.v2.callList.make({ method: 'user.get', params: { filter: { US
 
 Measured on `user.get` with four users: `FILTER: { ID: 4 }` returns all four, `filter: { ID: 4 }` returns one. `SORT` is worse and louder — on `user.get` it makes the walker's own injected `order` fail the method's validation, so the request throws `ERROR_ARGUMENT` / *"Order must be a string"*. All of these are reported with a `warning` (#483), emitted through `LoggerFactory.forcedLog`, so it reaches `console.warn` even with the default logger. This is `restApi:v2` only; v3 has no uppercase contract — its parameters are camelCase and its `filter` is the array form.
 
+## A `filter` boolean needs a JSON body
+
+`false` in a filter is only a boolean while the body is JSON. Form-encoded it is
+the string `"false"` and the portal drops the condition — rows you meant to
+exclude come back, silently. The SDK sends JSON and states the header per
+request, so ordinary calls are fine; a request interceptor installed on
+`getHttpClient(version).ajaxClient` still outranks it, and a call you rebuild by
+hand outside the SDK has to set the content type itself. See the
+`b24jssdk-filtering` skill.
+
 ## `fetchList.make` — large lists, streaming
 
 Async iterator that yields chunks. Same shape as `callList.make` plus an optional `limit` for v3.

--- a/test/integration/core/blocked-redirect.unit.spec.ts
+++ b/test/integration/core/blocked-redirect.unit.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * A blocked redirect must reach the caller as an error, on every adapter.
+ *
+ * One request sets `maxRedirects: 0` — a `restApi:v3` batch on a non-hook
+ * transport, which carries an access token that a redirect to a subdomain would
+ * take along. On the Node adapter that produces a legible 301, which
+ * `validateStatus` rejects. On `fetch` — what a browser now gets — it produces
+ * an *opaque* response instead: status 0, empty body, no headers. Axios resolves
+ * that: `settle` returns early on any falsy status, before `validateStatus` is
+ * consulted, and unlike the XHR adapter (which rejects `status === 0` as
+ * `ECONNABORTED` itself) the fetch adapter has no guard of its own.
+ *
+ * So without an explicit check the refused request answered `isSuccess` with an
+ * empty body — a wrong answer rather than a visible refusal. The check is scoped
+ * to the branch that asked for `maxRedirects: 0`, so an ordinary status-0
+ * network failure keeps the classification it had.
+ *
+ * `*.unit.spec.ts` — no portal required.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { ApiVersion, B24Hook } from '../../../packages/jssdk/src/'
+import { B24OAuth } from '../../../packages/jssdk/src/oauth/b24'
+
+const OPAQUE_REDIRECT = {
+  status: 0,
+  statusText: '',
+  headers: {},
+  config: {} as never,
+  data: {}
+}
+
+function buildOAuth(): B24OAuth {
+  return new B24OAuth(
+    {
+      accessToken: 'ACCESS_TOKEN_PLACEHOLDER',
+      refreshToken: 'REFRESH_TOKEN_PLACEHOLDER',
+      expires: 2_000_000_000,
+      expiresIn: 3600,
+      domain: 'example.bitrix24.com',
+      memberId: 'member',
+      clientEndpoint: 'https://example.bitrix24.com/rest/',
+      serverEndpoint: 'https://oauth.bitrix.info/rest/',
+      status: 'L'
+    } as never,
+    { clientId: 'local.test', clientSecret: 'secret' } as never
+  )
+}
+
+describe('a redirect the SDK refuses to follow', () => {
+  let b24: B24Hook | B24OAuth | null = null
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    b24?.destroy()
+    b24 = null
+  })
+
+  it('@apiV3 fails the call instead of answering with an empty success', async () => {
+    b24 = buildOAuth()
+    const client = b24.getHttpClient(ApiVersion.v3)
+    vi.spyOn(client.ajaxClient, 'post').mockResolvedValue(OPAQUE_REDIRECT as never)
+
+    const error = await client.batch([['user.get', {}]]).catch((e: unknown) => e)
+
+    expect((error as { code?: string })?.code).toBe('JSSDK_HTTP_REDIRECT_BLOCKED')
+  })
+
+  // The narrow scope matters as much as the check: every other request the SDK
+  // makes leaves redirects alone, and a status 0 there means something else
+  // entirely — a dropped connection, a blocked request — which must keep
+  // arriving as what it is.
+  it('leaves an ordinary status-0 answer alone', async () => {
+    b24 = B24Hook.fromWebhookUrl('https://example.bitrix24.com/rest/1/secret/')
+    const client = b24.getHttpClient(ApiVersion.v2)
+    vi.spyOn(client.ajaxClient, 'post').mockResolvedValue({
+      ...OPAQUE_REDIRECT,
+      data: { result: [], time: {} }
+    } as never)
+
+    const result = await client.call('user.get', {}, 'req-redirect')
+
+    expect(result.isSuccess).toBe(true)
+  })
+})

--- a/test/integration/core/http-adapter-preference.unit.spec.ts
+++ b/test/integration/core/http-adapter-preference.unit.spec.ts
@@ -11,8 +11,10 @@
  * `*.unit.spec.ts` — no portal required.
  */
 import { describe, it, expect, afterEach } from 'vitest'
-import { ApiVersion, B24Hook } from '../../../packages/jssdk/src/'
+import { ApiVersion, B24Frame, B24Hook } from '../../../packages/jssdk/src/'
+import { B24OAuth } from '../../../packages/jssdk/src/oauth/b24'
 import type { TypeB24 } from '../../../packages/jssdk/src/'
+import { defineGlobal, restoreGlobal } from '../../0_setup/browser-globals'
 
 const AXIOS_DEFAULT_ORDER = ['xhr', 'http', 'fetch']
 
@@ -47,7 +49,7 @@ function asBrowserLikeRuntime(run: () => void): void {
 }
 
 describe('which axios adapter the SDK asks for', () => {
-  let b24: B24Hook | null = null
+  let b24: B24Hook | B24OAuth | null = null
 
   afterEach(() => {
     b24?.destroy()
@@ -78,6 +80,71 @@ describe('which axios adapter the SDK asks for', () => {
 
       expect(adapterOf(b24)).toBe('xhr')
     })
+  })
+
+  // `B24Frame` is the entry point that runs in a browser — the only one without
+  // the "server only" warning the other two carry — so it is the one the adapter
+  // preference applies to, and the one where `maxRedirects` stops being inert.
+  // An earlier revision gave the option to the two server-side classes and not
+  // to this one, which put the documented opt-out out of reach of the audience
+  // it was written for.
+  //
+  // Asserted on the plumbing rather than on a built client: the frame creates
+  // its transports inside `init()`, which needs a portal to answer the
+  // handshake. What has to hold here is that the constructor carries the option
+  // through to where `init()` will read it.
+  it('carries the option through on the browser entry point too', () => {
+    defineGlobal('window', { addEventListener() {}, removeEventListener() {} })
+
+    try {
+      class ProbeFrame extends B24Frame {
+        public optionsHandedToTransports(): null | object {
+          return this._getHttpOptions()
+        }
+      }
+
+      const frame = new ProbeFrame(
+        { DOMAIN: 'example.bitrix24.com', PROTOCOL: true, APP_SID: 'sid', LANG: 'en' },
+        { httpOptions: { adapter: 'xhr' } }
+      )
+
+      expect(frame.optionsHandedToTransports()).toEqual({ adapter: 'xhr' })
+    } finally {
+      restoreGlobal('window')
+    }
+  })
+
+  // Each entry point assigns `_httpOptions` for itself, so each one can drop it
+  // for itself — the hook path above cannot speak for this one.
+  it('carries the option through on the OAuth entry point too', () => {
+    b24 = new B24OAuth(
+      {
+        accessToken: 'ACCESS_TOKEN_PLACEHOLDER',
+        refreshToken: 'REFRESH_TOKEN_PLACEHOLDER',
+        expires: 2_000_000_000,
+        expiresIn: 3600,
+        domain: 'example.bitrix24.com',
+        memberId: 'member',
+        clientEndpoint: 'https://example.bitrix24.com/rest/',
+        serverEndpoint: 'https://oauth.bitrix.info/rest/',
+        status: 'L'
+      } as never,
+      { clientId: 'local.test', clientSecret: 'secret' } as never,
+      { httpOptions: { adapter: 'xhr' } }
+    )
+
+    expect(adapterOf(b24)).toBe('xhr')
+  })
+
+  // `fromWebhookUrl` is the factory the documentation recommends everywhere, so
+  // an escape hatch it cannot reach is not an escape hatch.
+  it('reaches the option through the recommended factory', () => {
+    b24 = B24Hook.fromWebhookUrl(
+      'https://example.bitrix24.com/rest/1/secret/',
+      { httpOptions: { adapter: 'xhr' } }
+    )
+
+    expect(adapterOf(b24)).toBe('xhr')
   })
 
   // Guarded on `fetch` being reachable rather than on a version check: the point

--- a/test/integration/core/http-adapter-preference.unit.spec.ts
+++ b/test/integration/core/http-adapter-preference.unit.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * In a browser the SDK asks axios for the `fetch` adapter.
+ *
+ * Axios walks its default `['xhr', 'http', 'fetch']` and takes the first
+ * supported* entry, so anywhere `XMLHttpRequest` exists — a window, a dedicated
+ * worker, a shared worker — it picks **XHR** and never reaches `fetch`. That is
+ * selection by list order, not by merit. Node is left alone: there XHR does not
+ * exist, `http` is already what gets picked, and it is the right one for that
+ * runtime.
+ *
+ * `*.unit.spec.ts` — no portal required.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { ApiVersion, B24Hook } from '../../../packages/jssdk/src/'
+import type { TypeB24 } from '../../../packages/jssdk/src/'
+
+const AXIOS_DEFAULT_ORDER = ['xhr', 'http', 'fetch']
+
+function adapterOf(b24: TypeB24, version: ApiVersion = ApiVersion.v2): unknown {
+  return b24.getHttpClient(version).ajaxClient.defaults.adapter
+}
+
+function buildHook(options?: { httpOptions?: { adapter?: string } }): B24Hook {
+  return new B24Hook(
+    { b24Url: 'https://example.bitrix24.com', userId: 1, secret: 'secret' },
+    options as never
+  )
+}
+
+/**
+ * `isCorsEnforcedRuntime()` reads `WorkerGlobalScope` as well as the browser
+ * environment, and a worker is the branch reachable from Node — no `window` or
+ * `document` has to be invented for it.
+ */
+function asBrowserLikeRuntime(run: () => void): void {
+  const saved = (globalThis as { WorkerGlobalScope?: unknown }).WorkerGlobalScope
+  ;(globalThis as { WorkerGlobalScope?: unknown }).WorkerGlobalScope = function () {}
+  try {
+    run()
+  } finally {
+    if (undefined === saved) {
+      delete (globalThis as { WorkerGlobalScope?: unknown }).WorkerGlobalScope
+    } else {
+      ;(globalThis as { WorkerGlobalScope?: unknown }).WorkerGlobalScope = saved
+    }
+  }
+}
+
+describe('which axios adapter the SDK asks for', () => {
+  let b24: B24Hook | null = null
+
+  afterEach(() => {
+    b24?.destroy()
+    b24 = null
+  })
+
+  it('asks for nothing outside a browser, so axios decides', () => {
+    b24 = buildHook()
+
+    expect(adapterOf(b24)).toEqual(AXIOS_DEFAULT_ORDER)
+    expect(adapterOf(b24, ApiVersion.v3)).toEqual(AXIOS_DEFAULT_ORDER)
+  })
+
+  it('asks for fetch in a browser-like runtime, on both transports', () => {
+    asBrowserLikeRuntime(() => {
+      b24 = buildHook()
+
+      expect(adapterOf(b24)).toBe('fetch')
+      expect(adapterOf(b24, ApiVersion.v3)).toBe('fetch')
+    })
+  })
+
+  // The default is placed before the caller's options are spread, so naming an
+  // adapter always wins — that is what makes this a default rather than a lock.
+  it('lets the caller name one instead', () => {
+    asBrowserLikeRuntime(() => {
+      b24 = buildHook({ httpOptions: { adapter: 'xhr' } })
+
+      expect(adapterOf(b24)).toBe('xhr')
+    })
+  })
+
+  // Guarded on `fetch` being reachable rather than on a version check: the point
+  // is to reach it, not to assert an era.
+  it('stands aside where fetch does not exist', () => {
+    const savedFetch = globalThis.fetch
+
+    asBrowserLikeRuntime(() => {
+      // @ts-expect-error — removing a global the type system says is always there
+      delete globalThis.fetch
+      b24 = buildHook()
+
+      expect(adapterOf(b24)).toEqual(AXIOS_DEFAULT_ORDER)
+    })
+
+    globalThis.fetch = savedFetch
+  })
+})

--- a/test/integration/core/idempotency-key-v3.unit.spec.ts
+++ b/test/integration/core/idempotency-key-v3.unit.spec.ts
@@ -111,9 +111,10 @@ describe('Idempotency-Key on restApi:v3 (issue #462)', () => {
       params: { fields: { name: 'audit-v3 idem' } }
     })
 
-    // Not merely "the value is undefined": the whole per-request config must
-    // stay absent, so an ordinary call is byte-for-byte what it was before.
-    expect(postSpy.mock.calls[0]?.[2]).toBeUndefined()
+    // The per-request config is no longer absent — every call now states
+    // `Content-Type: application/json` — so the pin is that it carries *only*
+    // that, and no idempotency header crept in beside it.
+    expect(postSpy.mock.calls[0]?.[2]?.headers).toEqual({ 'Content-Type': 'application/json' })
   })
 
   it('@apiV3 reports a replayed response through `isIdempotentReplay()`', async () => {
@@ -361,13 +362,16 @@ describe('Idempotency-Key on restApi:v3 (issue #462)', () => {
     expect(warning).toHaveBeenCalledTimes(1)
   })
 
-  it('@apiV2 stays on the two-argument post when no key is given', async () => {
+  it('@apiV2 sends nothing but the JSON content type when no key is given', async () => {
     b24 = buildHook()
     const httpClient = b24.getHttpClient(ApiVersion.v2)
     const postSpy = vi.spyOn(httpClient.ajaxClient, 'post').mockResolvedValue(writeResponse())
 
     await httpClient.call('crm.deal.add', {}, 'req-v2-plain')
 
-    expect(postSpy.mock.calls[0]?.[2]).toBeUndefined()
+    // This used to assert the third argument was absent altogether. It is not
+    // any more — the JSON content type is stated on every call rather than
+    // inherited from axios — so what is pinned is that nothing else joined it.
+    expect(postSpy.mock.calls[0]?.[2]?.headers).toEqual({ 'Content-Type': 'application/json' })
   })
 })

--- a/test/integration/core/json-body-content-type.unit.spec.ts
+++ b/test/integration/core/json-body-content-type.unit.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression for https://github.com/bitrix24/b24jssdk/issues/533
+ *
+ * The portal reads a `filter` value as a boolean only when the request body is
+ * JSON. Under `application/x-www-form-urlencoded`, `ACTIVE: false` arrives as
+ * the string `"false"`, the condition is dropped, and the call answers with rows
+ * it should have excluded — with no error on either side.
+ *
+ * Measured against one portal in one minute, `user.get` with
+ * `filter: { ACTIVE: … }`:
+ *
+ *   body JSON            true → 1 row   false → 0 rows
+ *   body form-urlencoded true → 1 row   false → 1 row
+ *
+ * The SDK had always sent JSON, but never asked for it — axios picks
+ * `application/json` on its own for a plain-object body. That default is
+ * reachable: `ajaxClient` is public and the documentation encourages touching it
+ * to raise `defaults.timeout`, so a single header on the instance silently broke
+ * every boolean filter portal-wide.
+ *
+ * `*.unit.spec.ts` — no portal required.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { ApiVersion, B24Hook } from '../../../packages/jssdk/src/'
+
+function buildHook(): B24Hook {
+  return B24Hook.fromWebhookUrl('https://example.bitrix24.com/rest/1/secret/')
+}
+
+const okResponse = {
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: {} as never,
+  data: { result: [], time: {} }
+}
+
+describe('the JSON content type is stated, not inherited (#533)', () => {
+  let b24: B24Hook | null = null
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    b24?.destroy()
+    b24 = null
+  })
+
+  it.each([ApiVersion.v2, ApiVersion.v3])('%s states it on every call', async (version) => {
+    b24 = buildHook()
+    const client = b24.getHttpClient(version)
+    const post = vi.spyOn(client.ajaxClient, 'post').mockResolvedValue(okResponse as never)
+
+    await client.call('user.get', { filter: { ACTIVE: false } }, 'req-533')
+
+    expect(post.mock.calls[0]?.[2]?.headers?.['Content-Type']).toBe('application/json')
+  })
+
+  // The reachable failure: one line on the public instance used to change the
+  // body encoding for every request the SDK made.
+  it('a form-urlencoded default on the instance no longer wins', async () => {
+    b24 = buildHook()
+    const client = b24.getHttpClient(ApiVersion.v2)
+    client.ajaxClient.defaults.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    const post = vi.spyOn(client.ajaxClient, 'post').mockResolvedValue(okResponse as never)
+
+    await client.call('user.get', { filter: { ACTIVE: false } }, 'req-533')
+
+    expect(post.mock.calls[0]?.[2]?.headers?.['Content-Type']).toBe('application/json')
+  })
+
+  // Per request rather than on the instance, deliberately. Measured: an
+  // instance-level `application/json` sticks to a `FormData` body and replaces
+  // the multipart boundary axios would have computed — so setting it there
+  // would break a caller who posts their own form data through `ajaxClient`.
+  it('leaves the instance default alone, so a caller\'s own FormData still works', async () => {
+    b24 = buildHook()
+    const client = b24.getHttpClient(ApiVersion.v2)
+
+    const instanceDefault = client.ajaxClient.defaults.headers['Content-Type']
+
+    expect(instanceDefault).toBeUndefined()
+  })
+})

--- a/test/integration/core/json-body-content-type.unit.spec.ts
+++ b/test/integration/core/json-body-content-type.unit.spec.ts
@@ -22,9 +22,31 @@
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { ApiVersion, B24Hook } from '../../../packages/jssdk/src/'
+import { B24OAuth } from '../../../packages/jssdk/src/oauth/b24'
 
 function buildHook(): B24Hook {
   return B24Hook.fromWebhookUrl('https://example.bitrix24.com/rest/1/secret/')
+}
+
+/**
+ * A non-hook transport, which takes the two other branches of the per-request
+ * config: `Authorization: Bearer` on a server, and `?auth=` in a browser.
+ */
+function buildOAuth(): B24OAuth {
+  return new B24OAuth(
+    {
+      accessToken: 'ACCESS_TOKEN_PLACEHOLDER',
+      refreshToken: 'REFRESH_TOKEN_PLACEHOLDER',
+      expires: 2_000_000_000,
+      expiresIn: 3600,
+      domain: 'example.bitrix24.com',
+      memberId: 'member',
+      clientEndpoint: 'https://example.bitrix24.com/rest/',
+      serverEndpoint: 'https://oauth.bitrix.info/rest/',
+      status: 'L'
+    } as never,
+    { clientId: 'local.test', clientSecret: 'secret' } as never
+  )
 }
 
 const okResponse = {
@@ -36,7 +58,7 @@ const okResponse = {
 }
 
 describe('the JSON content type is stated, not inherited (#533)', () => {
-  let b24: B24Hook | null = null
+  let b24: B24Hook | B24OAuth | null = null
 
   afterEach(() => {
     vi.restoreAllMocks()
@@ -65,6 +87,77 @@ describe('the JSON content type is stated, not inherited (#533)', () => {
     await client.call('user.get', { filter: { ACTIVE: false } }, 'req-533')
 
     expect(post.mock.calls[0]?.[2]?.headers?.['Content-Type']).toBe('application/json')
+  })
+
+  // The header is built in three branches — webhook, `Authorization: Bearer`,
+  // and the browser's query-auth — and only the first is exercised above. Each
+  // one composes the header object separately, so each one can lose it
+  // separately.
+  it('the Bearer branch states it too', async () => {
+    // That branch is narrower than it looks: a bare-array body on a non-hook
+    // transport outside a browser, i.e. a v3 batch. An ordinary OAuth call
+    // still carries its credential in the body.
+    b24 = buildOAuth()
+    const client = b24.getHttpClient(ApiVersion.v3)
+    const post = vi.spyOn(client.ajaxClient, 'post').mockResolvedValue({
+      ...okResponse,
+      data: { result: [{ items: [] }], time: {} }
+    } as never)
+
+    await client.batch([['user.get', {}]])
+
+    const headers = post.mock.calls[0]?.[2]?.headers as Record<string, string>
+    expect(headers['Content-Type']).toBe('application/json')
+    // And the credential still rides alongside it rather than replacing it.
+    expect(headers['Authorization']).toBe('Bearer ACCESS_TOKEN_PLACEHOLDER')
+  })
+
+  it('the browser query-auth branch states it too', async () => {
+    const originalWindow = (globalThis as { window?: unknown }).window
+    ;(globalThis as { window?: unknown }).window = { document: {} }
+
+    try {
+      b24 = buildOAuth()
+      const client = b24.getHttpClient(ApiVersion.v3)
+      const post = vi.spyOn(client.ajaxClient, 'post').mockResolvedValue({
+        ...okResponse,
+        data: { result: [{ items: [] }], time: {} }
+      } as never)
+
+      await client.batch([['user.get', {}]])
+
+      const headers = post.mock.calls[0]?.[2]?.headers as Record<string, string>
+      expect(headers['Content-Type']).toBe('application/json')
+      expect(headers['Authorization']).toBeUndefined()
+    } finally {
+      if (typeof originalWindow === 'undefined') {
+        delete (globalThis as { window?: unknown }).window
+      } else {
+        ;(globalThis as { window?: unknown }).window = originalWindow
+      }
+    }
+  })
+
+  // The header is a default, not a lock: it is spread before
+  // `requestConfig.headers`, so a transport that overrides
+  // `_prepareRequestConfig` can still name its own. Nothing in the SDK does
+  // today — this pins the ordering the source comment promises, which is what
+  // keeps the next edit from silently turning it into a lock.
+  it('a transport-supplied content type wins over it', async () => {
+    b24 = buildHook()
+    const client = b24.getHttpClient(ApiVersion.v2)
+
+    ;(client as unknown as {
+      _prepareRequestConfig: () => object
+    })._prepareRequestConfig = () => ({
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+
+    const post = vi.spyOn(client.ajaxClient, 'post').mockResolvedValue(okResponse as never)
+
+    await client.call('user.get', {}, 'req-533')
+
+    expect(post.mock.calls[0]?.[2]?.headers?.['Content-Type']).toBe('multipart/form-data')
   })
 
   // Per request rather than on the instance, deliberately. Measured: an

--- a/test/integration/core/v3-batch-body-shape.unit.spec.ts
+++ b/test/integration/core/v3-batch-body-shape.unit.spec.ts
@@ -97,7 +97,13 @@ describe('the body of a v3 batch', () => {
     expect(body).toHaveLength(2)
     expect(body).not.toHaveProperty('auth')
     // A webhook authenticates through the URL; nothing to put in a header.
-    expect(config).toBeUndefined()
+    // The per-request config is no longer absent: every call now states
+    // `Content-Type: application/json`, because the portal reads a `filter`
+    // boolean only from a JSON body and axios was supplying that by default
+    // rather than by intent. What this case guards is unchanged — no credential
+    // rides in the config.
+    expect(Object.keys(config ?? {})).toEqual(['headers'])
+    expect(config?.headers).toEqual({ 'Content-Type': 'application/json' })
   })
 
   it('@apiV3 keeps the OAuth token out of the array and sends it as a header', async () => {
@@ -155,7 +161,13 @@ describe('the body of a v3 batch', () => {
     // moving it too would be an untestable change to how every OAuth request
     // authenticates.
     expect((body as { auth?: string }).auth).toBe('ACCESS_TOKEN_PLACEHOLDER')
-    expect(config).toBeUndefined()
+    // The per-request config is no longer absent: every call now states
+    // `Content-Type: application/json`, because the portal reads a `filter`
+    // boolean only from a JSON body and axios was supplying that by default
+    // rather than by intent. What this case guards is unchanged — no credential
+    // rides in the config.
+    expect(Object.keys(config ?? {})).toEqual(['headers'])
+    expect(config?.headers).toEqual({ 'Content-Type': 'application/json' })
   })
 
   it('@apiV3 a browser sends the array and puts the token in the query string', async () => {
@@ -554,7 +566,13 @@ describe('the body of a v3 batch', () => {
 
       const [url, body, config] = post.mock.calls[0]!
       expect(Array.isArray(body)).toBe(true)
-      expect(config).toBeUndefined()
+      // The per-request config is no longer absent: every call now states
+      // `Content-Type: application/json`, because the portal reads a `filter`
+      // boolean only from a JSON body and axios was supplying that by default
+      // rather than by intent. What this case guards is unchanged — no credential
+      // rides in the config.
+      expect(Object.keys(config ?? {})).toEqual(['headers'])
+      expect(config?.headers).toEqual({ 'Content-Type': 'application/json' })
       // And no `?auth=`. A hook's credential is already in the URL **path**,
       // where the portal documents it; appending it again as a query parameter
       // would put a portal-wide, non-expiring secret in a second place for no
@@ -628,7 +646,13 @@ describe('the body of a v3 batch', () => {
     await b24.actions.v3.batch.make({ calls: COMMANDS })
 
     const [, body, config] = post.mock.calls[0]!
-    expect(config).toBeUndefined()
+    // The per-request config is no longer absent: every call now states
+    // `Content-Type: application/json`, because the portal reads a `filter`
+    // boolean only from a JSON body and axios was supplying that by default
+    // rather than by intent. What this case guards is unchanged — no credential
+    // rides in the config.
+    expect(Object.keys(config ?? {})).toEqual(['headers'])
+    expect(config?.headers).toEqual({ 'Content-Type': 'application/json' })
     expect(Array.isArray(body)).toBe(false)
     expect(JSON.stringify(config ?? {})).not.toContain('Bearer undefined')
   })


### PR DESCRIPTION
Closes #533. Answers the question behind #508.

Two changes to the same axios instance, measured against a live portal.

## 1. The JSON content type is stated, not inherited

The portal reads a `filter` value as a boolean **only when the body is JSON**.
Under `application/x-www-form-urlencoded`, `ACTIVE: false` arrives as the string
`"false"`, the condition is dropped, and the call answers with rows it should
have excluded. No error on either side.

Measured on `user.get` — one portal, same minute:

| body | `ACTIVE: true` | `ACTIVE: false` |
|---|---|---|
| JSON | 1 row | **0 rows** |
| `application/x-www-form-urlencoded` | 1 row | **1 row** — condition ignored |

The SDK has always sent JSON but never asked for it. Read at the request
interceptor, `Content-Type` is `undefined` on both v2 and v3; axios supplies
`application/json` on its own for a plain-object body.

**That default is reachable.** `ajaxClient` is public, and the v3 call page
actively advises raising `defaults.timeout` on it for long writes — so one header
on the instance silently broke every boolean filter portal-wide.

### Per request, not on the instance — and that is measured

An instance-level `application/json` **sticks to a `FormData` body** and replaces
the multipart boundary axios would otherwise compute:

```text
instance default application/json + FormData  ->  Content-Type: "application/json"
no instance default              + FormData  ->  Content-Type: undefined (axios fills it in)
```

So the shape #533 originally suggested would break a caller posting their own
form data through `ajaxClient`. Setting it per request states what the SDK's own
traffic depends on without deciding anything for traffic it does not own.

### One deliberate trade

Six tests failed, correctly. `idempotency-key-v3` carried *"the whole
per-request config must stay absent, so an ordinary call is byte-for-byte what it
was before"* — a deliberate decision, and this breaks it: every call now carries
one header. The pins are rewritten to guard what they were really protecting —
that nothing else joined it, and that no credential rides in the config.

## 2. A browser gets `fetch`; everywhere else axios decides

Axios walks `['xhr', 'http', 'fetch']` and takes the first *supported* entry.
`XMLHttpRequest` exists in a window, a dedicated worker and a shared worker, so in
all of them axios picks **XHR and never reaches `fetch`** — selection by list
order rather than by merit, on an API with no streaming, no `AbortSignal` beyond
`abort()`, and headers folded into one string.

Outside a browser nothing is asked for: in Node there is no `XMLHttpRequest`,
`http` is already what gets picked, and it is the right adapter there. Guarded on
`fetch` being reachable rather than on a version check.

### The option that was missing

The axios-config channel existed in `AbstractHttp` but was **closed**: the base
class's `_getHttpOptions()` returned a hard `null` and nothing overrode it. So the
only way to choose an adapter was to reach into `ajaxClient.defaults` after
construction. It now returns a field the entry points assign, and `B24Hook` /
`B24OAuth` take `httpOptions`:

```ts
new B24Hook(
  { b24Url: 'https://your-portal.bitrix24.com', userId: 1, secret: 'SECRET' },
  { httpOptions: { adapter: 'xhr' } }
)
```

Merged over the SDK's own defaults, and placed **before** them, so any key a
caller names wins.

Measured, all four outcomes:

```text
node, default                 -> ["xhr","http","fetch"]   axios decides
browser-like, fetch present   -> "fetch"
browser-like, caller says xhr -> "xhr"
browser-like, no fetch        -> ["xhr","http","fetch"]
```

### The behaviour that moves with it — not a no-op

`fetch` reads `maxRedirects` as `redirect: 'manual'`; XHR ignores it outright.
The only branch setting it in a browser is the query-auth one, which exists to
stop an OAuth access token following a redirect. **On `fetch` that guard now
bites where it used to be inert**: a redirecting deployment answers with an
opaque `status: 0` instead of silently completing the hop with the credential
attached.

That is the guard doing its job, but it is a change of behaviour. Stated in the
code, in the JSDoc, and as a warning on the v3 call page rather than left to be
discovered.

## Verified against a live portal

Both versions, both batch shapes, before and after:

```text
clean instance      v2 ACTIVE true/false 1/0 | v3 call ok | v2 batch ok | v3 batch ok
poisoned instance   v2 ACTIVE true/false 1/0 | v3 call ok | v2 batch ok | v3 batch ok
```

Before the change, the poisoned instance answered **1/1** — the bug. The v3
batch's bare-array body is unaffected.

## Tests

Two new specs. `json-body-content-type` pins the header on v2 and v3, that an
instance-level form-urlencoded default no longer wins, and that the instance
default stays empty so a caller's own `FormData` still works.
`http-adapter-preference` pins all four adapter outcomes above.

## Documentation

- **Filtering page** — the measured table, and the part that reaches past the
  SDK: anyone rebuilding the call by hand (curl, a webhook tester) must send JSON
  or lose the condition silently.
- **v3 call page** — "Which HTTP adapter runs", next to the existing
  `defaults.timeout` advice, since it is the same instance and the same reason a
  caller touches it; plus the `maxRedirects` warning.

## Checks

- `jsSdk:unit` — **900 passed**; `jsSdk:types` — 64, no type errors
- full `pnpm typecheck` — 11 passes green
- `pnpm lint`, `pnpm lint:md` — clean
- `pnpm docs:lint` — 0 errors, 0 warnings
- `docs:typecheck-blocks` (186), `skills:typecheck-blocks` (88),
  `jsdoc:typecheck-blocks` (45), `lint:v3-refs` — clean
- `node --test "scripts/__tests__/**/*.test.mjs"` — 170 passed

Typed `fix!`: the redirect guard changes what a browser sees on a redirecting
deployment, and an ordinary call is no longer byte-for-byte what it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr


---
_Generated by [Claude Code](https://claude.ai/code/session_01F22e2ft66y7nuBJjzdThBr)_